### PR TITLE
Support auto and screen dimensions

### DIFF
--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -254,7 +254,13 @@ defmodule Breeze.Renderer do
   defp apply_style("absolute", acc), do: Map.put(acc, :position, :absolute)
   defp apply_style("left-" <> num, acc), do: Map.put(acc, :left, String.to_integer(num))
   defp apply_style("top-" <> num, acc), do: Map.put(acc, :top, String.to_integer(num))
+
+  defp apply_style("width-auto", acc), do: Map.put(acc, :width, :auto)
+  defp apply_style("width-screen", acc), do: Map.put(acc, :width, :screen)
   defp apply_style("width-" <> num, acc), do: Map.put(acc, :width, String.to_integer(num))
+
+  defp apply_style("height-auto", acc), do: Map.put(acc, :height, :auto)
+  defp apply_style("height-screen", acc), do: Map.put(acc, :height, :screen)
   defp apply_style("height-" <> num, acc), do: Map.put(acc, :height, String.to_integer(num))
 
   defp apply_style("text-" <> num, acc),

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -29,10 +29,10 @@ defmodule Breeze.Renderer do
     |> repeat(
       choice([
         attribute,
-        boolean_attribute,
-        ignore(string(">"))
+        boolean_attribute
       ])
     )
+    |> ignore(string(">"))
 
   closing_tag = ignore(string("</")) |> concat(tag) |> ignore(string(">"))
 


### PR DESCRIPTION
I discovered the auto and screen modifiers in `back_breeze`, so I would like to use them in `breeze` :)
I guess the available modifiers could be exposed and accessed via some function in `back_breeze`, but for now this fix might be enough?
