### PR TITLE
default focused box

### DIFF
--- a/examples/focus.exs
+++ b/examples/focus.exs
@@ -42,6 +42,8 @@ defmodule Focus do
   use Breeze.View
 
   def mount(_opts, term) do
+    # set the default focus to element attribute id="l1"
+    term = %{term | focused: "l1"}
     {:ok, assign(term, last_value: "none")}
   end
 
@@ -63,7 +65,8 @@ defmodule Focus do
           <:item value="foo">Foo</:item>
         </.list>
       </box>
-      <box>{@last_value}</box>
+      <box>Press tab/shift-tab to change focus</box>
+      <box>last_value: {@last_value}</box>
     </box>
     """
   end


### PR DESCRIPTION
hi, thanks for the great work on this.

when running the focus examples, since there is no default focus, pressing up/down arrow keys doesn't really have any effects. at first it made me think maybe something was broken.

it took me a while to figure out how `focusable` works and how to toggle between them.

i think it would be a nice addition to have a default focus and a help message guiding the user to shift focus in this example