### PR TITLE
feat(Breeze.Server): add set_default_focus

### DIFF
--- a/examples/focus.exs
+++ b/examples/focus.exs
@@ -42,15 +42,13 @@ defmodule Focus do
   use Breeze.View
 
   def mount(_opts, term) do
-    # set the default focus to element attribute id="l1"
-    term = %{term | focused: "l1"}
     {:ok, assign(term, last_value: "none")}
   end
 
   def render(assigns) do
     ~H"""
     <box id="lol">
-      <box style="inline border focus:border-3" focusable id="base">
+      <box style="inline border focus:border-3" id="base">
         <.list :for={id <- ["l1", "l2", "l3", "l4", "l5"]} br-change="change" id={id}>
           <:item value="hello">Hello</:item>
           <:item value="world">World</:item>


### PR DESCRIPTION
### what this feature does

automatically set the initial focus to the first focusable element when the TUI app starts, eliminating the extra Tab press.

### motivation of the feature request

right now `focused` defaults to `nil`, so users must press Tab after launch to focus the first element. i think removing this step would make the startup experience smoother, leading to a better ux. pls let me know your thought on the validity of the feature request.

### my implementation logic for this feature

1. collect the focusable elements in their intended order.
2. if no element is currently focused, set `focused` to the first focusable entry.

### open question

the implementation relies on `Breeze.Renderer.parse()` to build the ordered list of focusable elements. i’m not completely
certain that this is the intended use of the parser and would appreciate feedback.
