### PR TITLE
feat(Breeze.Blocks): implement predefined components using implicits

### DIFF
--- a/examples/grid.exs
+++ b/examples/grid.exs
@@ -1,0 +1,26 @@
+defmodule Demo do
+  use Breeze.View
+
+  def mount(_opts, term), do: {:ok, term}
+
+  def render(assigns) do
+    ~H"""
+    <box style="grid grid-cols-2 grid-rows-3 width-screen height-screen">
+      <box style="border border-1">Top Left</box>
+      <box style="border border-2">Top Right</box>
+      <box style="border border-3">Middle Left</box>
+      <box style="border border-4">Middle Right</box>
+      <box style="border border-5">Bottom Left</box>
+      <box style="border border-6">Bottom Right</box>
+    </box>
+    """
+  end
+
+  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
+  def handle_event(_, _, term), do: {:noreply, term}
+end
+
+Breeze.Server.start_link(view: Demo)
+
+receive do
+end

--- a/examples/list_view.exs
+++ b/examples/list_view.exs
@@ -1,5 +1,6 @@
 defmodule ListViewDemo do
   use Breeze.View
+  import Breeze.Blocks
 
   def mount(_opts, term) do
     {:ok, term |> focus("languages") |> assign(selected: nil)}
@@ -8,7 +9,7 @@ defmodule ListViewDemo do
   def render(assigns) do
     ~H"""
     <box>
-      <.list id="languages" br-change="change">
+      <.list id="languages" br-change="change" style="focus:border-1">
         <:item value="elixir">Elixir</:item>
         <:item value="erlang">Erlang</:item>
         <:item value="rust">Rust</:item>
@@ -19,44 +20,19 @@ defmodule ListViewDemo do
         <:item value="gleam">Gleam</:item>
         <:item value="haskell">Haskell</:item>
       </.list>
-      <box :if={@selected} style="border width-24">Selected: <%= @selected %></box>
+      <box :if={@selected} style="border width-24">Selected: {@selected}</box>
     </box>
     """
   end
 
-  attr(:id, :string, required: true)
-  attr(:rest, :global)
-
-  slot :item do
-    attr(:value, :string, required: true)
-  end
-
-  def list(assigns) do
-    ~H"""
-    <box
-      id={@id}
-      implicit={Breeze.Implicit.List}
-      list-loop="true"
-      list-scroll-padding="1"
-      focusable
-      style="border width-24 height-8 overflow-scroll focus:border-3"
-      {@rest}
-    >
-      <box :for={item <- @item} value={item.value} style="selected:bg-4 selected:text-7 width-24">
-        <%= render_slot(item, %{}) %>
-      </box>
-    </box>
-    """
-  end
-
-  def handle_event("change", %{value: value}, term) do
-    {:noreply, assign(term, selected: value)}
-  end
-
+  def handle_event("change", %{value: value}, term), do: {:noreply, assign(term, selected: value)}
+  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
   def handle_event(_, _, term), do: {:noreply, term}
 
   def handle_info(_, term), do: {:noreply, term}
 end
 
 Breeze.Server.start_link(view: ListViewDemo)
-:timer.sleep(100_000)
+
+receive do
+end

--- a/lib/breeze/blocks.ex
+++ b/lib/breeze/blocks.ex
@@ -1,0 +1,107 @@
+defmodule Breeze.Blocks do
+  @moduledoc """
+  Reusable built-in components for Breeze views.
+
+  Import this module in your view to use the provided components:
+
+      defmodule MyView do
+        use Breeze.View
+        import Breeze.Blocks
+        ...
+      end
+
+  ## Style merging
+
+  All components expose a `style` attribute (and where applicable an
+  `item_style` attribute) that are merged with the component's defaults using
+  `merge_style/2`.  Style tokens are grouped by their *property key*, everything
+  before the last `-` segment, so an override of `"width-32"` replaces the
+  default `"width-24"` while leaving other properties intact (including `focus:`
+  prefixes).
+  """
+
+  use Breeze.View
+
+  attr :id, :string, required: true
+  attr :loop, :boolean, default: true
+  attr :style, :string, default: nil
+  attr :item_style, :string, default: nil
+  attr :rest, :global
+
+  slot :item do
+    attr :value, :string, required: true
+  end
+
+  def list(assigns) do
+    assigns =
+      assigns
+      |> assign(
+        style:
+          merge_style("border width-24 height-8 overflow-scroll focus:border-3", assigns[:style])
+      )
+      |> assign(
+        item_style: merge_style("selected:bg-4 selected:text-7 width-24", assigns[:item_style])
+      )
+
+    ~H"""
+    <box
+      id={@id}
+      implicit={Breeze.Implicit.List}
+      list-loop={@loop}
+      list-scroll-padding={1}
+      focusable
+      style={@style}
+      {@rest}
+    >
+      <box :for={item <- @item} value={item.value} style={@item_style}>
+        <%= render_slot(item, %{}) %>
+      </box>
+    </box>
+    """
+  end
+
+  @doc """
+  Merge two style strings, with `override` taking precedence over `default` for
+  matching style properties.
+
+  The *property key* for each style token is everything before its final `-`
+  segment, so tokens that share the same prefix override one another:
+
+      iex> Breeze.Blocks.merge_style("border width-24 height-8", "width-32")
+      "border width-32 height-8"
+
+      iex> Breeze.Blocks.merge_style("overflow-scroll", "overflow-hidden")
+      "overflow-hidden"
+
+  Tokens from `override` that do not match any default key are appended:
+
+      iex> Breeze.Blocks.merge_style("border width-24", "bg-4")
+      "border width-24 bg-4"
+
+  `nil` or an empty string override returns the default unchanged.
+  """
+  @spec merge_style(String.t(), String.t() | nil) :: String.t()
+  def merge_style(default, override) when override in [nil, ""], do: default
+
+  def merge_style(default, override) do
+    default_tokens = String.split(default, " ", trim: true)
+    override_tokens = String.split(override, " ", trim: true)
+
+    default_key_set = MapSet.new(default_tokens, &style_key/1)
+    override_map = Map.new(override_tokens, fn token -> {style_key(token), token} end)
+
+    merged =
+      Enum.map(default_tokens, fn token -> Map.get(override_map, style_key(token), token) end)
+
+    new_tokens = Enum.reject(override_tokens, &MapSet.member?(default_key_set, style_key(&1)))
+
+    Enum.join(merged ++ new_tokens, " ")
+  end
+
+  defp style_key(token) do
+    case String.split(token, "-") do
+      [_only] -> token
+      parts -> parts |> Enum.drop(-1) |> Enum.join("-")
+    end
+  end
+end

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -324,6 +324,9 @@ defmodule Breeze.Renderer do
   defp apply_style("bg-" <> num, {style, attrs}),
     do: {Style.background_color(style, String.to_integer(num)), attrs}
 
+  defp apply_style("border-rounded", {style, attrs}),
+    do: {Style.border(style, :rounded), attrs}
+
   defp apply_style("border-" <> num, {style, attrs}),
     do: {Style.border_color(style, String.to_integer(num)), attrs}
 

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -251,6 +251,36 @@ defmodule Breeze.Renderer do
   defp apply_style("reverse", {style, attrs}), do: {Style.reverse(style), attrs}
   defp apply_style("inline", {style, attrs}), do: {style, Map.put(attrs, :display, :inline)}
 
+  defp apply_style("grid", {style, attrs}) do
+    display =
+      case Map.get(attrs, :display) do
+        %BackBreeze.Grid{} = grid -> grid
+        _ -> %BackBreeze.Grid{columns: 1}
+      end
+
+    {style, Map.put(attrs, :display, display)}
+  end
+
+  defp apply_style("grid-cols-" <> num, {style, attrs}) do
+    display =
+      case Map.get(attrs, :display) do
+        %BackBreeze.Grid{} = grid -> grid
+        _ -> %BackBreeze.Grid{}
+      end
+
+    {style, Map.put(attrs, :display, %{display | columns: String.to_integer(num)})}
+  end
+
+  defp apply_style("grid-rows-" <> num, {style, attrs}) do
+    display =
+      case Map.get(attrs, :display) do
+        %BackBreeze.Grid{} = grid -> grid
+        _ -> %BackBreeze.Grid{}
+      end
+
+    {style, Map.put(attrs, :display, %{display | rows: String.to_integer(num)})}
+  end
+
   defp apply_style("overflow-scroll", {style, attrs}),
     do: {Style.overflow(style, :scroll), attrs}
 
@@ -276,6 +306,7 @@ defmodule Breeze.Renderer do
     do: {style, Map.put(attrs, :top, String.to_integer(num))}
 
   defp apply_style("width-auto", {style, attrs}), do: {Style.width(style, :auto), attrs}
+  defp apply_style("width-full", {style, attrs}), do: {Style.width(style, :full), attrs}
   defp apply_style("width-screen", {style, attrs}), do: {Style.width(style, :screen), attrs}
 
   defp apply_style("width-" <> num, {style, attrs}),

--- a/lib/breeze/template.ex
+++ b/lib/breeze/template.ex
@@ -28,6 +28,10 @@ defmodule Breeze.Template do
     %__MODULE__{nodes: nodes, env: Macro.Env.prune_compile_info(env)}
   end
 
+  def render_to_string({%__MODULE__{} = template, comp_assigns}, _assigns) do
+    render(template, comp_assigns)
+  end
+
   def render_to_string(%__MODULE__{} = template, assigns) do
     render(template, assigns)
   end
@@ -57,6 +61,10 @@ defmodule Breeze.Template do
   def render(%__MODULE__{nodes: nodes, env: env}, assigns) do
     ctx = %{assigns: normalize_assigns(assigns), vars: %{}, env: env}
     render_nodes(nodes, ctx)
+  end
+
+  def render_to_tree({%__MODULE__{} = template, comp_assigns}, _assigns) do
+    render_to_tree(template, comp_assigns)
   end
 
   def render_to_tree(%__MODULE__{nodes: nodes, env: env}, assigns) do
@@ -157,8 +165,10 @@ defmodule Breeze.Template do
       |> maybe_put_rest(rest)
       |> Map.merge(build_slots(children, ctx))
 
-    %__MODULE__{nodes: comp_nodes, env: comp_env} = invoke_component(module, fun, assigns)
-    comp_ctx = %{assigns: assigns, vars: %{}, env: comp_env}
+    {%__MODULE__{nodes: comp_nodes, env: comp_env}, comp_assigns} =
+      unwrap_component(invoke_component(module, fun, assigns), assigns)
+
+    comp_ctx = %{assigns: comp_assigns, vars: %{}, env: comp_env}
     nodes_to_tree(comp_nodes, comp_ctx)
   end
 
@@ -229,9 +239,10 @@ defmodule Breeze.Template do
       |> maybe_put_rest(rest)
       |> Map.merge(build_slots(children, ctx))
 
-    module
-    |> invoke_component(fun, assigns)
-    |> render_to_string(assigns)
+    {template, comp_assigns} =
+      unwrap_component(invoke_component(module, fun, assigns), assigns)
+
+    render_to_string(template, comp_assigns)
   end
 
   defp render_element(":" <> _slot_name, _attrs, _children, _ctx), do: ""
@@ -252,6 +263,14 @@ defmodule Breeze.Template do
     else
       apply(module, component, [assigns])
     end
+  end
+
+  defp unwrap_component({%__MODULE__{} = template, comp_assigns}, _caller_assigns) do
+    {template, comp_assigns}
+  end
+
+  defp unwrap_component(%__MODULE__{} = template, caller_assigns) do
+    {template, caller_assigns}
   end
 
   defp build_slots(children, ctx) do

--- a/lib/breeze/view.ex
+++ b/lib/breeze/view.ex
@@ -144,7 +144,7 @@ defmodule Breeze.View do
   attr :rest, :global
 
   slot :item do
-    attr(:value, :string, required: true)
+    attr :value, :string, required: true
   end
 
   def list(assigns) do
@@ -239,7 +239,7 @@ defmodule Breeze.View do
 
     quote do
       _ = var!(assigns)
-      unquote(Macro.escape(template))
+      {unquote(Macro.escape(template)), var!(assigns)}
     end
   end
 
@@ -311,11 +311,15 @@ defmodule Breeze.View do
   end
 
   @doc """
-  Merge values into `term.assigns`.
+  Merge values into `term.assigns`, or into a plain assigns map inside a component function.
   """
   @spec assign(map(), Enumerable.t()) :: map()
-  def assign(term, values) do
+  def assign(%{assigns: _} = term, values) do
     %{term | assigns: Map.merge(term.assigns, Map.new(values))}
+  end
+
+  def assign(assigns, values) when is_map(assigns) do
+    Map.merge(assigns, Map.new(values))
   end
 
   def focus(term, value) do

--- a/test/breeze/blocks_test.exs
+++ b/test/breeze/blocks_test.exs
@@ -1,0 +1,42 @@
+defmodule Breeze.BlocksTest do
+  use ExUnit.Case, async: true
+
+  alias Breeze.Blocks
+
+  describe "merge_style/2" do
+    test "nil override returns default unchanged" do
+      assert Blocks.merge_style("border width-24", nil) == "border width-24"
+    end
+
+    test "empty string override returns default unchanged" do
+      assert Blocks.merge_style("border width-24", "") == "border width-24"
+    end
+
+    test "override replaces a numeric-suffixed token" do
+      assert Blocks.merge_style("border width-24 height-8", "width-32") ==
+               "border width-32 height-8"
+    end
+
+    test "override replaces a non-numeric-suffixed token" do
+      assert Blocks.merge_style("border overflow-scroll", "overflow-hidden") ==
+               "border overflow-hidden"
+    end
+
+    test "new token from override is appended" do
+      assert Blocks.merge_style("border width-24", "bg-4") == "border width-24 bg-4"
+    end
+
+    test "state-prefixed tokens are matched by their full prefix" do
+      assert Blocks.merge_style("border focus:border-3", "focus:border-2") ==
+               "border focus:border-2"
+    end
+
+    test "multiple overrides are applied in one call" do
+      assert Blocks.merge_style(
+               "border width-24 height-8 overflow-scroll focus:border-3",
+               "width-32 focus:border-2"
+             ) ==
+               "border width-32 height-8 overflow-scroll focus:border-2"
+    end
+  end
+end


### PR DESCRIPTION
The implicit is quite complicated, and not something the end user necessarily wants to deal with all the time. This commit introduces wrappers around the built-in implicits, starting with a `list` component. This is a simple component for showing a list of elements.

The list has some default styles, but these can be overridden by passing in a `style`. The ListViewDemo has been updated to use `Breeze.Blocks.list/1`