### PR TITLE
feat(Breeze.Implicit.Tab): add a tabs implicit

### DIFF
--- a/examples/tabs.exs
+++ b/examples/tabs.exs
@@ -1,0 +1,117 @@
+defmodule TabsExample do
+  use Breeze.View
+  import Breeze.Blocks
+
+  def mount(_opts, term) do
+    {screen_width, screen_height} = BackBreeze.screen_dimensions(term.terminal)
+
+    term =
+      term
+      |> assign_layout(screen_width, screen_height)
+      |> assign(selected_tab: "overview")
+      |> focus("tabs")
+
+    {:ok, term}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <box style="width-screen height-screen overflow-hidden">
+      <box style="bold">Tabs example</box>
+      <box>Use left/right arrows while the tabs are focused.</box>
+      <box>The tab bar should scroll horizontally to keep the selected tab visible.</box>
+      <.tabs
+        id="tabs"
+        selected={@selected_tab}
+        br-change="select_tab"
+        style={"width-#{@tabs_width} height-#{@tabs_height} border-rounded focus:border-4"}
+      >
+        <:tab value="overview" label="Overview">
+          <.panel label="Overview" value="overview" height={@panel_height}/>
+        </:tab>
+        <:tab value="requests" label="Requests">
+          <.panel label="Requests" value="requests" height={@panel_height}/>
+        </:tab>
+        <:tab value="responses" label="Responses">
+          <.panel label="Responses" value="responses" height={@panel_height}/>
+        </:tab>
+        <:tab value="headers" label="Headers">
+          <.panel label="Headers" value="headers" height={@panel_height}/>
+        </:tab>
+        <:tab value="cookies" label="Cookies">
+          <.panel label="Cookies" value="cookies" height={@panel_height}/>
+        </:tab>
+        <:tab value="timeline" label="Timeline">
+          <.panel label="Timeline" value="timeline" height={@panel_height}/>
+        </:tab>
+        <:tab value="inspector" label="Inspector">
+          <.panel label="Inspector" value="inspector" height={@panel_height}/>
+        </:tab>
+        <:tab value="settings" label="Settings">
+          <.panel label="Settings" value="settings" height={@panel_height}/>
+        </:tab>
+        <:tab value="shortcuts" label="Shortcuts">
+          <.panel label="Shortcuts" value="shortcuts" height={@panel_height}/>
+        </:tab>
+        <:tab value="advanced" label="Advanced">
+          <.panel label="Advanced" value="advanced" height={@panel_height}/>
+        </:tab>
+      </.tabs>
+    </box>
+    """
+  end
+
+  attr :height, :integer, required: true
+  attr :label, :string, required: true
+  attr :value, :string, required: true
+
+  def panel(assigns) do
+    assigns = assign(assigns, lines: panel_lines(assigns.label))
+
+    ~H"""
+    <.scroll id={"tabs-panel-#{@value}"} style={"width-full height-#{@height} overflow-scroll"}>
+      <box style="bold">{@label}</box>
+      <box>Selected tab value: {@value}</box>
+      <box>
+      </box>
+      <box :for={line <- @lines}>{line}</box>
+    </.scroll>
+    """
+  end
+
+  def handle_event("select_tab", %{value: tab}, term) do
+    {:noreply, term |> assign(selected_tab: tab)}
+  end
+
+  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
+  def handle_event(_, _, term), do: {:noreply, term}
+
+  def handle_info(:resize, term) do
+    {screen_width, screen_height} = BackBreeze.screen_dimensions(term.terminal)
+    {:noreply, assign_layout(term, screen_width, screen_height)}
+  end
+
+  def handle_info(_, term), do: {:noreply, term}
+
+  defp assign_layout(term, screen_width, screen_height) do
+    tabs_width = max(min(screen_width - 4, 36), 20)
+    panel_height = max(screen_height - 9, 6)
+
+    assign(term,
+      tabs_width: tabs_width,
+      tabs_height: panel_height + 2
+    )
+    |> assign(panel_height: panel_height)
+  end
+
+  defp panel_lines(label) do
+    for line <- 1..100 do
+      "#{label} panel line #{line}"
+    end
+  end
+end
+
+Breeze.Server.start_link(view: TabsExample, hide_cursor: true)
+
+receive do
+end

--- a/lib/breeze/blocks.ex
+++ b/lib/breeze/blocks.ex
@@ -56,9 +56,7 @@ defmodule Breeze.Blocks do
       style={@style}
       {@rest}
     >
-      <box :for={item <- @item} value={item.value} style={@item_style}>
-        <%= render_slot(item, %{}) %>
-      </box>
+      <box :for={item <- @item} value={item.value} style={@item_style}>{render_slot(item, %{})}</box>
     </box>
     """
   end
@@ -79,8 +77,69 @@ defmodule Breeze.Blocks do
       )
 
     ~H"""
-    <box focusable id={@id} implicit={Breeze.Implicit.Scroll} style={@style}>
-      {Breeze.Markdown.render(@content, @width)}
+    <.scroll id={@id} style={@style}>{Breeze.Markdown.render(@content, @width)}</.scroll>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :style, :string, default: nil
+  attr :rest, :global
+
+  slot :inner_block, required: true
+
+  def scroll(assigns) do
+    assigns =
+      assign(assigns,
+        style:
+          merge_style(
+            "height-full overflow-scroll scrollbar-arrows focus:scrollbar-3",
+            assigns[:style]
+          )
+      )
+
+    ~H"""
+    <box focusable id={@id} implicit={Breeze.Implicit.Scroll} style={@style} {@rest}>
+      {render_slot(@inner_block)}
+    </box>
+    """
+  end
+
+  def tabs(assigns) do
+    active =
+      Enum.find(assigns.tab, List.first(assigns.tab), &(&1.value == assigns[:selected]))
+
+    assigns =
+      assigns
+      |> assign(active: active)
+      |> assign(style: merge_style("border overflow-hidden focus:border-3", assigns[:style]))
+      |> assign(
+        item_style:
+          merge_style(
+            "selected:bold selected:text-4 focus:selected:bg-4 focus:selected:text-7 overflow-scroll",
+            assigns[:item_style]
+          )
+      )
+
+    ~H"""
+    <box
+      id={@id}
+      implicit={Breeze.Implicit.Tabs}
+      focusable
+      tab-delegate={if @active do
+      "#{@id}-panel-#{@active.value}"
+    end}
+      tab-selected={@active.value}
+      style={@style}
+      {@rest}
+    >
+      <box style="inline" tab-bar="true">
+        <box :for={t <- @tab} value={t.value} tab-label={t.label} style={@item_style}>
+          {" #{t.label} "}
+        </box>
+      </box>
+      <box>
+      </box>
+      {render_slot(@active)}
     </box>
     """
   end

--- a/lib/breeze/implicit/tabs.ex
+++ b/lib/breeze/implicit/tabs.ex
@@ -1,0 +1,117 @@
+defmodule Breeze.Implicit.Tabs do
+  @moduledoc false
+
+  def init(children, last_state), do: init(children, %{}, last_state)
+
+  def init(children, root_attrs, last_state) do
+    tab_items = Enum.filter(children, &Map.has_key?(&1, :value))
+    values = Enum.map(tab_items, & &1.value)
+
+    widths =
+      Enum.map(tab_items, fn item ->
+        label = Map.get(item, :"tab-label", "")
+        String.length(label) + 2
+      end)
+
+    selected_index =
+      case Map.get(last_state, :selected) do
+        nil ->
+          case Map.get(root_attrs, :"tab-selected") do
+            nil -> 0
+            initial -> Enum.find_index(values, &(&1 == initial)) || 0
+          end
+
+        selected ->
+          Enum.find_index(values, &(&1 == selected)) || 0
+      end
+
+    selected_index = min(selected_index, max(length(values) - 1, 0))
+    selected = Enum.at(values, selected_index)
+    offset_x = Map.get(last_state, :offset_x, 0)
+
+    viewport_width =
+      case Map.get(last_state, :__element__) do
+        nil -> Map.get(last_state, :viewport_width)
+        el -> el.viewport_width
+      end
+
+    %{
+      values: values,
+      widths: widths,
+      selected: selected,
+      selected_index: selected_index,
+      offset_x: offset_x,
+      viewport_width: viewport_width,
+      delegate_target: Map.get(root_attrs, :"tab-delegate")
+    }
+  end
+
+  def handle_event(_, %{"key" => key}, %{values: []} = state) when key in ["ArrowRight", "l"] do
+    {:noreply, state}
+  end
+
+  def handle_event(_, %{"key" => key}, state) when key in ["ArrowRight", "l"] do
+    count = length(state.values)
+    next = rem(state.selected_index + 1, count)
+    next_state = %{state | selected_index: next, selected: Enum.at(state.values, next)}
+    emit_change(%{next_state | offset_x: compute_offset_x(next_state)})
+  end
+
+  def handle_event(_, %{"key" => key}, %{values: []} = state) when key in ["ArrowLeft", "h"] do
+    {:noreply, state}
+  end
+
+  def handle_event(_, %{"key" => key}, state) when key in ["ArrowLeft", "h"] do
+    count = length(state.values)
+    prev = rem(state.selected_index - 1 + count, count)
+    prev_state = %{state | selected_index: prev, selected: Enum.at(state.values, prev)}
+    emit_change(%{prev_state | offset_x: compute_offset_x(prev_state)})
+  end
+
+  def handle_event(_, %{"key" => key}, %{delegate_target: target} = state)
+      when key in ["ArrowDown", "ArrowUp", "j", "k", "PageDown", "PageUp", "Home", "End"] and
+             is_binary(target) do
+    {{:delegate, target}, state}
+  end
+
+  def handle_event(_, _, state), do: {:noreply, state}
+
+  def handle_modifiers(:root, _flags, _state), do: []
+
+  def handle_modifiers(:child, flags, state) do
+    cond do
+      Keyword.has_key?(flags, :"tab-bar") -> [scroll_x: state.offset_x]
+      state.selected == Keyword.get(flags, :value) -> [selected: true]
+      true -> []
+    end
+  end
+
+  defp compute_offset_x(%{
+         widths: widths,
+         selected_index: selected_index,
+         offset_x: current_offset,
+         viewport_width: viewport_width
+       }) do
+    if is_nil(viewport_width) or viewport_width <= 0 do
+      current_offset
+    else
+      cumulative = widths |> Enum.take(selected_index) |> Enum.sum()
+      tab_width = Enum.at(widths, selected_index, 0)
+
+      cond do
+        cumulative < current_offset ->
+          cumulative
+
+        cumulative + tab_width > current_offset + viewport_width ->
+          cumulative + tab_width - viewport_width
+
+        true ->
+          current_offset
+      end
+    end
+  end
+
+  defp emit_change(state) do
+    {{:change, %{value: state.selected, index: state.selected_index}}, state}
+  end
+end

--- a/lib/breeze/logger_collector.ex
+++ b/lib/breeze/logger_collector.ex
@@ -16,18 +16,15 @@ defmodule Breeze.LoggerCollector do
   end
 
   def subscribe(pid \\ self()) do
-    {:ok, _collector} = ensure_started()
-    GenServer.call(@name, {:subscribe, pid})
+    call({:subscribe, pid})
   end
 
   def clear do
-    {:ok, _collector} = ensure_started()
-    GenServer.call(@name, :clear)
+    call(:clear)
   end
 
   def entries do
-    {:ok, _collector} = ensure_started()
-    GenServer.call(@name, :entries)
+    call(:entries)
   end
 
   @impl true
@@ -144,5 +141,14 @@ defmodule Breeze.LoggerCollector do
 
   defp restore_default_handler_level(level) do
     :logger.set_handler_config(@default_handler_id, :level, level)
+  end
+
+  defp call(message) do
+    {:ok, _collector} = ensure_started()
+    GenServer.call(@name, message)
+  catch
+    :exit, {:noproc, _} ->
+      {:ok, _collector} = ensure_started()
+      GenServer.call(@name, message)
   end
 end

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -123,10 +123,10 @@ defmodule Breeze.Renderer do
 
   defp build_tree([{:box, _, nodes} | rest], box, children, style, flags, acc, opts) do
     child_flags =
-      if Keyword.get(flags, :implicit) do
-        [implicit_id: Keyword.fetch!(flags, :id)]
-      else
-        []
+      cond do
+        Keyword.get(flags, :implicit) -> [implicit_owner: Keyword.fetch!(flags, :id)]
+        implicit_owner = Keyword.get(flags, :implicit_owner) -> [implicit_owner: implicit_owner]
+        true -> []
       end
 
     acc = %{
@@ -144,7 +144,8 @@ defmodule Breeze.Renderer do
     %{focusables: focusables} = acc
 
     focused =
-      (Keyword.get(flags, :id) || Keyword.get(flags, :implicit_id)) == Keyword.get(opts, :focused)
+      (Keyword.get(flags, :id) || Keyword.get(flags, :implicit_owner)) ==
+        Keyword.get(opts, :focused)
 
     flags = if focused, do: Keyword.put(flags, :focused, focused), else: flags
 
@@ -156,8 +157,15 @@ defmodule Breeze.Renderer do
       end
 
     implicit_state = Keyword.get(opts, :implicit_state, %{})
-    implicit_id = Keyword.get(flags, :implicit_id)
-    id = implicit_id || Keyword.get(flags, :id)
+    implicit_owner = Keyword.get(flags, :implicit_owner)
+    root_id = Keyword.get(flags, :id)
+
+    id =
+      cond do
+        Keyword.get(flags, :implicit) && root_id -> root_id
+        implicit_owner -> implicit_owner
+        true -> root_id
+      end
 
     {implicit_mod, implicit} =
       case id && get_in(implicit_state, [id]) do
@@ -165,7 +173,7 @@ defmodule Breeze.Renderer do
         {mod, state} -> {mod, state}
       end
 
-    type = if id == Keyword.get(flags, :id), do: :root, else: :child
+    type = if id == root_id, do: :root, else: :child
 
     {style_flags, style_modifiers, scroll_modifier} =
       if implicit do
@@ -379,7 +387,7 @@ defmodule Breeze.Renderer do
 
   defp apply_style("height-auto", {style, attrs}), do: {Style.height(style, :auto), attrs}
   defp apply_style("height-screen", {style, attrs}), do: {Style.height(style, :screen), attrs}
-  defp apply_style("height-full", {style, attrs}), do: {Style.height(style, :screen), attrs}
+  defp apply_style("height-full", {style, attrs}), do: {Style.height(style, :full), attrs}
 
   defp apply_style("height-" <> num, {style, attrs}),
     do: {Style.height(style, String.to_integer(num)), attrs}
@@ -389,6 +397,9 @@ defmodule Breeze.Renderer do
 
   defp apply_style("bg-" <> num, {style, attrs}),
     do: {Style.background_color(style, String.to_integer(num)), attrs}
+
+  defp apply_style("scrollbar-none", {style, attrs}),
+    do: {Style.scrollbar(style, false), attrs}
 
   defp apply_style("scrollbar-arrows", {style, attrs}),
     do: {Style.scrollbar(style, %{arrows: true}), attrs}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "back_breeze": {:git, "https://github.com/Gazler/back_breeze.git", "60f335e0a4201ce06bd0b9be7c042abf355c2860", []},
+  "back_breeze": {:git, "https://github.com/Gazler/back_breeze.git", "dceb1213cef1ae91a3f297dd91318a23dd337eb5", []},
   "earmark_parser": {:hex, :earmark_parser, "1.4.41", "ab34711c9dc6212dda44fcd20ecb87ac3f3fce6f0ca2f28d4a00e4154f8cd599", [:mix], [], "hexpm", "a81a04c7e34b6617c2792e291b5a2e57ab316365c2644ddc553bb9ed863ebefa"},
   "ex_doc": {:hex, :ex_doc, "0.34.2", "13eedf3844ccdce25cfd837b99bea9ad92c4e511233199440488d217c92571e8", [:mix], [{:earmark_parser, "~> 1.4.39", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_c, ">= 0.1.0", [hex: :makeup_c, repo: "hexpm", optional: true]}, {:makeup_elixir, "~> 0.14 or ~> 1.0", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1 or ~> 1.0", [hex: :makeup_erlang, repo: "hexpm", optional: false]}, {:makeup_html, ">= 0.1.0", [hex: :makeup_html, repo: "hexpm", optional: true]}], "hexpm", "5ce5f16b41208a50106afed3de6a2ed34f4acfd65715b82a0b84b49d995f95c1"},
   "makeup": {:hex, :makeup, "1.1.2", "9ba8837913bdf757787e71c1581c21f9d2455f4dd04cfca785c70bbfff1a76a3", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cce1566b81fbcbd21eca8ffe808f33b221f9eee2cbc7a1706fc3da9ff18e6cac"},

--- a/test/breeze/implicit/tabs_test.exs
+++ b/test/breeze/implicit/tabs_test.exs
@@ -1,0 +1,53 @@
+defmodule Breeze.Implicit.TabsTest do
+  use ExUnit.Case, async: true
+
+  alias Breeze.Implicit.Tabs
+
+  describe "init/3" do
+    test "uses the root selected tab when provided" do
+      children = [
+        %{:"tab-label" => "Overview", value: "overview"},
+        %{:"tab-label" => "Details", value: "details"}
+      ]
+
+      state = Tabs.init(children, %{:"tab-selected" => "details"}, %{})
+
+      assert state.selected == "details"
+      assert state.selected_index == 1
+    end
+  end
+
+  describe "handle_event/3" do
+    test "ignores horizontal navigation when there are no tabs" do
+      state = %{
+        values: [],
+        widths: [],
+        selected: nil,
+        selected_index: 0,
+        offset_x: 0,
+        viewport_width: 20
+      }
+
+      assert Tabs.handle_event(nil, %{"key" => "ArrowRight"}, state) == {:noreply, state}
+      assert Tabs.handle_event(nil, %{"key" => "ArrowLeft"}, state) == {:noreply, state}
+    end
+
+    test "delegates vertical navigation keys to the active panel target" do
+      state = %{
+        values: ["overview", "details"],
+        widths: [10, 9],
+        selected: "overview",
+        selected_index: 0,
+        offset_x: 0,
+        viewport_width: 20,
+        delegate_target: "panel-overview"
+      }
+
+      assert Tabs.handle_event(nil, %{"key" => "ArrowDown"}, state) ==
+               {{:delegate, "panel-overview"}, state}
+
+      assert Tabs.handle_event(nil, %{"key" => "PageDown"}, state) ==
+               {{:delegate, "panel-overview"}, state}
+    end
+  end
+end

--- a/test/breeze/renderer_test.exs
+++ b/test/breeze/renderer_test.exs
@@ -55,6 +55,47 @@ defmodule Breeze.RendererTest do
     end
   end
 
+  defmodule TabsWidthExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <.tabs id="tabs" selected="overview" style="width-6">
+        <:tab value="overview" label="Overview">
+          <box>body</box>
+        </:tab>
+        <:tab value="details" label="Details">
+          <box>more</box>
+        </:tab>
+      </.tabs>
+      """
+    end
+  end
+
+  defmodule ParentImplicit do
+    def init(_children, last_state), do: %{offset_x: last_state[:offset_x] || 0}
+    def handle_event(_, _, state), do: {:noreply, state}
+    def handle_modifiers(:root, _flags, state), do: [scroll_x: state.offset_x]
+    def handle_modifiers(:child, _flags, _state), do: []
+  end
+
+  defmodule NestedImplicitExample do
+    use Breeze.View
+
+    def render(assigns) do
+      ~H"""
+      <box id="parent" implicit={ParentImplicit}>
+        <box id="child" implicit={ScrollImplicit} style="border width-6 height-2 overflow-hidden">
+          <box>AAAAAA</box>
+          <box>BBBBBB</box>
+          <box>CCCCCC</box>
+        </box>
+      </box>
+      """
+    end
+  end
+
   describe "render_to_string/2" do
     test "converts the boxes to terminal output" do
       assert Renderer.render_to_string(Example, %{name: "world"}) ==
@@ -74,6 +115,31 @@ defmodule Breeze.RendererTest do
         )
 
       assert box.scroll == {1, 2}
+    end
+
+    test "preserves explicit tabs width when labels overflow" do
+      {state, _box} = Renderer.render(TabsWidthExample, %{})
+
+      assert hd(state.dimensions).width == 6
+      assert hd(state.dimensions).viewport_width == 6
+    end
+
+    test "applies nested implicit root modifiers using the nested implicit state" do
+      {_state, box} =
+        Renderer.render(NestedImplicitExample, %{},
+          implicit_state: %{
+            "parent" => {ParentImplicit, %{offset_x: 0}},
+            "child" => {ScrollImplicit, %{offset_y: 1}}
+          }
+        )
+
+      assert box.content ==
+               """
+               ┌──────┐
+               │BBBB  │
+               │CCCC  │
+               └──────┘\
+               """
     end
   end
 end


### PR DESCRIPTION
The tabs implicit renders a list of tabs that can be selected. This is similar to the list view but horizontally. Once change made to the core engine is the ability to delegate to a different implicit. This is used by tabs to allow the tab viewport to be scrolled without losing focus of the tabs bar.