### PR TITLE
feat(Breeze.Server): support global keybindings

### DIFF
--- a/examples/animated_progress.exs
+++ b/examples/animated_progress.exs
@@ -86,12 +86,15 @@ defmodule AnimatedProgressExample do
     """
   end
 
-  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
   def handle_event(_, _, term), do: {:noreply, term}
   def handle_info(_, term), do: {:noreply, term}
 end
 
-Breeze.Server.start_link(view: AnimatedProgressExample, hide_cursor: true)
+Breeze.Server.start_link(
+  view: AnimatedProgressExample,
+  hide_cursor: true,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)
 
 receive do
 end

--- a/examples/counter.exs
+++ b/examples/counter.exs
@@ -15,11 +15,13 @@ defmodule Demo do
   def handle_event(_, %{"key" => "ArrowDown"}, term),
     do: {:noreply, assign(term, counter: term.assigns.counter - 1)}
 
-  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
   def handle_event(_, _, term), do: {:noreply, term}
 end
 
-Breeze.Server.start_link(view: Demo)
+Breeze.Server.start_link(
+  view: Demo,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)
 
 receive do
 end

--- a/examples/demo.exs
+++ b/examples/demo.exs
@@ -35,5 +35,9 @@ end
 
 # Breeze.Renderer.render(Demo, %{name: "hello"})
 
-Breeze.Server.start_link(view: Demo)
+Breeze.Server.start_link(
+  view: Demo,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)
+
 :timer.sleep(5000)

--- a/examples/docs.exs
+++ b/examples/docs.exs
@@ -104,7 +104,6 @@ defmodule Docs do
     {:noreply, term}
   end
 
-  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
   def handle_event(_, _, term), do: {:noreply, term}
 
   defp fetch_function_doc(module_str, function_str) do
@@ -146,7 +145,11 @@ defmodule Docs do
   end
 end
 
-Breeze.Server.start_link(view: Docs, hide_cursor: true)
+Breeze.Server.start_link(
+  view: Docs,
+  hide_cursor: true,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)
 
 receive do
 end

--- a/examples/focus.exs
+++ b/examples/focus.exs
@@ -104,5 +104,10 @@ defmodule Focus do
   end
 end
 
-Breeze.Server.start_link(view: Focus, hide_cursor: false)
+Breeze.Server.start_link(
+  view: Focus,
+  hide_cursor: false,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)
+
 :timer.sleep(100_000)

--- a/examples/grid.exs
+++ b/examples/grid.exs
@@ -16,11 +16,13 @@ defmodule Demo do
     """
   end
 
-  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
   def handle_event(_, _, term), do: {:noreply, term}
 end
 
-Breeze.Server.start_link(view: Demo)
+Breeze.Server.start_link(
+  view: Demo,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)
 
 receive do
 end

--- a/examples/list_view.exs
+++ b/examples/list_view.exs
@@ -26,13 +26,15 @@ defmodule ListViewDemo do
   end
 
   def handle_event("change", %{value: value}, term), do: {:noreply, assign(term, selected: value)}
-  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
   def handle_event(_, _, term), do: {:noreply, term}
 
   def handle_info(_, term), do: {:noreply, term}
 end
 
-Breeze.Server.start_link(view: ListViewDemo)
+Breeze.Server.start_link(
+  view: ListViewDemo,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)
 
 receive do
 end

--- a/examples/nested_views.exs
+++ b/examples/nested_views.exs
@@ -68,12 +68,15 @@ defmodule NestedViewsExample do
     {:noreply, assign(term, show_right: !term.assigns.show_right)}
   end
 
-  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
   def handle_event(_, _, term), do: {:noreply, term}
   def handle_info(_, term), do: {:noreply, term}
 end
 
-Breeze.Server.start_link(view: NestedViewsExample, hide_cursor: true)
+Breeze.Server.start_link(
+  view: NestedViewsExample,
+  hide_cursor: true,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)
 
 receive do
 end

--- a/examples/router.exs
+++ b/examples/router.exs
@@ -251,11 +251,11 @@ defmodule RouterExample do
     <box style="width-screen height-screen">
       <box style="bold">Router example</box>
       <box>Each route has its own ticking counter.</box>
-      <box>1 -> home, remounted when revisited</box>
-      <box>2 -> settings, persistence: true, includes a nested router</box>
-      <box>3 -> status, remounted when revisited</box>
-      <box>4 -> metrics, persistence: :preload, already ticking before first visit</box>
-      <box>5 -> logs, persistence: :preload, captures Logger output in the background</box>
+      <box>Global keys: 1 -> home, 2 -> settings, 3 -> status, 4 -> metrics, 5 -> logs</box>
+      <box>Settings uses persistence: true and includes a nested router</box>
+      <box>Status is remounted when revisited</box>
+      <box>Metrics uses persistence: :preload and is already ticking before first visit</box>
+      <box>Logs uses persistence: :preload and captures Logger output in the background</box>
       <box>Inside settings: a -> overview, b -> audit. Press q to quit.</box>
       <box style="height-1">
       </box>
@@ -279,7 +279,6 @@ defmodule RouterExample do
       {:noreply, Breeze.Router.navigate(term, :metrics, label: "Preloaded route", interval: 500)}
 
   def handle_event(_, %{"key" => "5"}, term), do: {:noreply, Breeze.Router.navigate(term, :logs)}
-  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
   def handle_event(_, _, term), do: {:noreply, term}
 
   def handle_info(:emit_log, term) do
@@ -303,7 +302,54 @@ defmodule RouterExample do
   end
 end
 
-Breeze.Server.start_link(view: RouterExample, hide_cursor: true)
+defmodule RouterExampleBindings do
+  import Breeze.View, only: [focus: 2]
+
+  def home(term) do
+    term
+    |> Breeze.Router.navigate(:home)
+    |> focus("main:home::home")
+  end
+
+  def settings(term) do
+    term
+    |> Breeze.Router.navigate(:settings, section: "team", interval: 350)
+    |> focus("main:persistent:settings::settings")
+  end
+
+  def status(term) do
+    term
+    |> Breeze.Router.navigate(:status, label: "Background jobs healthy", interval: 700)
+    |> focus("main:status::status")
+  end
+
+  def metrics(term) do
+    term
+    |> Breeze.Router.navigate(:metrics, label: "Preloaded route", interval: 500)
+    |> focus("main:persistent:metrics::metrics")
+  end
+
+  def logs(term) do
+    term
+    |> Breeze.Router.navigate(:logs)
+    |> focus("main:persistent:logs::logger")
+  end
+end
+
+global_keybindings = [
+  {"1", fn _event, term -> {:noreply, RouterExampleBindings.home(term)} end},
+  {"2", fn _event, term -> {:noreply, RouterExampleBindings.settings(term)} end},
+  {"3", fn _event, term -> {:noreply, RouterExampleBindings.status(term)} end},
+  {"4", fn _event, term -> {:noreply, RouterExampleBindings.metrics(term)} end},
+  {"5", fn _event, term -> {:noreply, RouterExampleBindings.logs(term)} end},
+  {"q", fn _event, term -> {:stop, term} end}
+]
+
+Breeze.Server.start_link(
+  view: RouterExample,
+  hide_cursor: true,
+  global_keybindings: global_keybindings
+)
 
 receive do
 end

--- a/examples/scroll.exs
+++ b/examples/scroll.exs
@@ -45,5 +45,9 @@ defmodule Scroll do
   def handle_event(_, _, term), do: {:noreply, term}
 end
 
-Breeze.Server.start_link(view: Scroll)
+Breeze.Server.start_link(
+  view: Scroll,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)
+
 :timer.sleep(100_000)

--- a/examples/snake.exs
+++ b/examples/snake.exs
@@ -119,7 +119,11 @@ defmodule Snake do
   end
 end
 
-Breeze.Server.start_link(view: Snake, hide_cursor: true)
+Breeze.Server.start_link(
+  view: Snake,
+  hide_cursor: true,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)
 
 receive do
 end

--- a/lib/breeze/render_state.ex
+++ b/lib/breeze/render_state.ex
@@ -148,7 +148,8 @@ defmodule Breeze.RenderState do
                 )
 
               {:noreply, val} ->
-                {:noreply, true, put_implicit_state(term, id, mod, val)}
+                term = put_implicit_state(term, id, mod, val)
+                {:noreply, val != implicit, term}
             end
 
           nil ->

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -6,6 +6,7 @@ defmodule Breeze.Term do
     :terminal,
     :reader,
     assigns: %{},
+    global_keybindings: [],
     focused: nil,
     focusables: [],
     elements: %{},
@@ -75,6 +76,7 @@ defmodule Breeze.Server do
 
     * `:view` - the view to run. This is required
     * `:hide_cursor` - hide the cursor on start. Defaults to `false`
+    * `:global_keybindings` - app-wide keybindings checked before focused event handling
 
   """
   def start_link(opts) do
@@ -85,7 +87,13 @@ defmodule Breeze.Server do
   def init(opts) do
     view = Keyword.fetch!(opts, :view)
     frame_delay_ms = Keyword.get(opts, :frame_delay_ms, 16)
-    {:ok, %Breeze.Term{view: view, frame_delay_ms: frame_delay_ms}, {:continue, {:start, opts}}}
+
+    {:ok,
+     %Breeze.Term{
+       view: view,
+       frame_delay_ms: frame_delay_ms,
+       global_keybindings: Keyword.get(opts, :global_keybindings, [])
+     }, {:continue, {:start, opts}}}
   end
 
   @doc false
@@ -227,31 +235,58 @@ defmodule Breeze.Server do
   end
 
   defp do_process_key(key, state) do
-    selected_implicit = Enum.find(state.implicit_state, fn {id, _el} -> id == state.focused end)
+    event = %{"key" => key}
 
-    {view_state, implicit_consumed, state} =
-      if selected_implicit do
-        {id, {_mod, _selected}} = selected_implicit
-
-        Breeze.RenderState.dispatch_implicit_event(
-          state,
-          id,
-          %{"key" => key},
-          fn state, id, change, event -> route_event(id, change, event, state) end
-        )
-      else
-        {:noreply, false, state}
-      end
-
-    cond do
-      view_state == :stop ->
+    case dispatch_global_keybindings(event, state) do
+      {:stop, state} ->
         {:stop, state}
 
-      implicit_consumed ->
+      {:noreply, state} ->
         {:noreply, state}
 
-      true ->
-        case route_event(state.focused, :ignore_me, %{"key" => key}, state) do
+      :continue ->
+        selected_implicit =
+          Enum.find(state.implicit_state, fn {id, _el} -> id == state.focused end)
+
+        {view_state, implicit_consumed, state} =
+          if selected_implicit do
+            {id, {_mod, _selected}} = selected_implicit
+
+            Breeze.RenderState.dispatch_implicit_event(
+              state,
+              id,
+              event,
+              fn state, id, change, event -> route_event(id, change, event, state) end
+            )
+          else
+            {:noreply, false, state}
+          end
+
+        cond do
+          view_state == :stop ->
+            {:stop, state}
+
+          implicit_consumed ->
+            {:noreply, state}
+
+          true ->
+            case route_event(state.focused, :ignore_me, event, state) do
+              {:stop, state} -> {:stop, state}
+              {:noreply, state} -> {:noreply, state}
+            end
+        end
+    end
+  end
+
+  @doc false
+  def dispatch_global_keybindings(event, state) do
+    case Enum.find(state.global_keybindings, fn {key, _fun} -> key == event["key"] end) do
+      nil ->
+        :continue
+
+      {_key, fun} when is_function(fun, 2) ->
+        case fun.(event, state) do
+          :continue -> :continue
           {:stop, state} -> {:stop, state}
           {:noreply, state} -> {:noreply, state}
         end
@@ -273,10 +308,13 @@ defmodule Breeze.Server do
   defp stop(state) do
     Enum.each(state.children, fn {_id, child} -> GenServer.stop(child.pid, :normal) end)
 
-    state.terminal
-    |> Termite.Screen.clear_screen()
-    |> Termite.Screen.show_cursor()
-    |> Termite.Screen.exit_alt_screen()
+    terminal =
+      state.terminal
+      |> Termite.Screen.clear_screen()
+      |> Termite.Screen.show_cursor()
+      |> Termite.Screen.exit_alt_screen()
+
+    Termite.Terminal.write(terminal, "\r")
 
     System.halt()
   end

--- a/test/breeze/live_view_test.exs
+++ b/test/breeze/live_view_test.exs
@@ -3,6 +3,7 @@ defmodule Breeze.LiveViewTest do
 
   alias Breeze.ChildServer
   alias Breeze.Renderer
+  alias Breeze.Server
   alias Breeze.Template
 
   defmodule CounterChild do
@@ -116,5 +117,20 @@ defmodule Breeze.LiveViewTest do
 
     {:ok, _acc, box} = ChildServer.render(pid, focused: nil, implicit_state: %{})
     assert box.content =~ "Frame: 1"
+  end
+
+  test "global keybindings are dispatched before focused event handling" do
+    event = %{"key" => "q"}
+
+    term = %Breeze.Term{
+      view: CounterChild,
+      global_keybindings: [
+        {"q", fn _event, term -> {:noreply, Breeze.View.assign(term, handled?: true)} end}
+      ],
+      assigns: %{}
+    }
+
+    assert {:noreply, %Breeze.Term{assigns: %{handled?: true}}} =
+             Server.dispatch_global_keybindings(event, term)
   end
 end

--- a/test/breeze/logger_test.exs
+++ b/test/breeze/logger_test.exs
@@ -83,6 +83,26 @@ defmodule Breeze.LoggerTest do
     assert logger_viewport(box).scroll == {elem(initial_scroll, 0) - 1, 0}
   end
 
+  test "focused logger still receives non-scroll keys" do
+    {:ok, pid} = ChildServer.start(view: Breeze.Logger, start_opts: [height: 6, max_lines: 20])
+    {:ok, _acc, _box} = ChildServer.render(pid, focused: "logger", implicit_state: %{})
+
+    Logger.info("clear-me-#{System.unique_integer([:positive])}")
+    Logger.flush()
+
+    wait_until(fn ->
+      {:ok, _acc, box} = ChildServer.render(pid, focused: "logger", implicit_state: %{})
+      box.content =~ "clear-me-"
+    end)
+
+    assert {:noreply, "logger"} = ChildServer.dispatch_event(pid, :ignore_me, %{"key" => "c"})
+
+    wait_until(fn ->
+      {:ok, _acc, box} = ChildServer.render(pid, focused: "logger", implicit_state: %{})
+      box.content =~ "Press c to clear." and not (box.content =~ "clear-me-")
+    end)
+  end
+
   test "logger autoscrolls while pinned to the bottom" do
     lines =
       for index <- 1..8 do


### PR DESCRIPTION
Global keybindings can be provided via the `global_keybindings` option. These keybindings are always applied regardless of the application state. This is useful for a quit button or a help dialogue.