### PR TITLE
feat(Breeze.Implicit.Modal): add a modal component

### DIFF
--- a/examples/modal.exs
+++ b/examples/modal.exs
@@ -1,0 +1,104 @@
+defmodule ModalExample do
+  use Breeze.View
+  import Breeze.Blocks
+
+  def mount(_opts, term) do
+    {:ok,
+     term
+     |> focus("open-modal")
+     |> assign(show_modal: false, selected_action: "none")}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <box style="width-screen height-screen">
+      <box style="bold">Modal example</box>
+      <box>Press Enter or m to open the modal.</box>
+      <box>Tab should stay inside the modal until it closes.</box>
+      <box>Escape closes the modal. q quits the example.</box>
+      <box>
+      </box>
+      <box id="open-modal" focusable style="border-rounded width-26 height-3 focus:border-4">
+        <box style="bold">Open modal</box>
+      </box>
+      <box>
+      </box>
+      <box id="other-panel" focusable style="border-rounded width-26 height-4 focus:border-4">
+        <box style="bold">Background panel</box>
+        <box>Last action: {@selected_action}</box>
+      </box>
+      <.modal :if={@show_modal} id="example-modal" width={46} height={10} br-change="close_modal">
+        <:title>Focused Widget Help</:title>
+        <box>Centered panel with trapped Tab focus.</box>
+        <box>Use it for help, palettes, and overlays.</box>
+        <box>
+        </box>
+        <box style="bold">Controls</box>
+        <box style="inline">
+          <box style="width-10">Tab</box>
+          <box>Move between actions</box>
+        </box>
+        <box style="inline">
+          <box style="width-10">Escape</box>
+          <box>Dismiss the modal</box>
+        </box>
+        <box style="inline">
+          <box style="width-10">Enter</box>
+          <box>Activate focused action</box>
+        </box>
+        <box style="inline">
+          <box
+            id="confirm"
+            focusable
+            default-focus
+            style="border-rounded width-14 height-1 focus:border-4"
+          >
+            <box style="bold">Confirm</box>
+          </box>
+          <box>
+          </box>
+          <box id="cancel" focusable style="border-rounded width-14 height-1 focus:border-4">
+            <box style="bold">Dismiss</box>
+          </box>
+        </box>
+      </.modal>
+    </box>
+    """
+  end
+
+  def handle_event("close_modal", _, term), do: {:noreply, assign(term, show_modal: false)}
+
+  def handle_event(_, %{"key" => key}, %{assigns: %{show_modal: false}} = term)
+      when key in ["Enter", "m"] and term.focused == "open-modal" do
+    {:noreply, assign(term, show_modal: true)}
+  end
+
+  def handle_event(_, %{"key" => "m"}, term), do: {:noreply, assign(term, show_modal: true)}
+
+  def handle_event(
+        _,
+        %{"key" => "Enter"},
+        %{assigns: %{show_modal: true}, focused: "confirm"} = term
+      ),
+      do: {:noreply, assign(term, show_modal: false, selected_action: "confirm")}
+
+  def handle_event(
+        _,
+        %{"key" => "Enter"},
+        %{assigns: %{show_modal: true}, focused: "cancel"} = term
+      ),
+      do: {:noreply, assign(term, show_modal: false, selected_action: "cancel")}
+
+  def handle_event(_, _, term), do: {:noreply, term}
+
+  def handle_info(_, term), do: {:noreply, term}
+end
+
+Breeze.Server.start_link(
+  view: ModalExample,
+  hide_cursor: true,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)
+
+receive do
+end

--- a/lib/breeze/blocks.ex
+++ b/lib/breeze/blocks.ex
@@ -62,6 +62,57 @@ defmodule Breeze.Blocks do
   end
 
   attr :id, :string, required: true
+  attr :selected, :string, default: nil
+  attr :style, :string, default: nil
+  attr :item_style, :string, default: nil
+  attr :rest, :global
+
+  slot :tab do
+    attr :value, :string, required: true
+    attr :label, :string, required: true
+  end
+
+  def tabs(assigns) do
+    active =
+      Enum.find(assigns.tab, List.first(assigns.tab), &(&1.value == assigns[:selected]))
+
+    assigns =
+      assigns
+      |> assign(active: active)
+      |> assign(style: merge_style("border overflow-hidden focus:border-3", assigns[:style]))
+      |> assign(
+        item_style:
+          merge_style(
+            "selected:bold selected:text-4 focus:selected:bg-4 focus:selected:text-7 overflow-scroll",
+            assigns[:item_style]
+          )
+      )
+
+    ~H"""
+    <box
+      id={@id}
+      implicit={Breeze.Implicit.Tabs}
+      focusable
+      tab-delegate={if @active do
+      "#{@id}-panel-#{@active.value}"
+    end}
+      tab-selected={@active.value}
+      style={@style}
+      {@rest}
+    >
+      <box style="inline" tab-bar="true">
+        <box :for={t <- @tab} value={t.value} tab-label={t.label} style={@item_style}>
+          {" #{t.label} "}
+        </box>
+      </box>
+      <box>
+      </box>
+      {render_slot(@active)}
+    </box>
+    """
+  end
+
+  attr :id, :string, required: true
   attr :content, :string, required: true
   attr :width, :integer, required: true
   attr :style, :string, default: nil
@@ -104,42 +155,67 @@ defmodule Breeze.Blocks do
     """
   end
 
-  def tabs(assigns) do
-    active =
-      Enum.find(assigns.tab, List.first(assigns.tab), &(&1.value == assigns[:selected]))
+  attr :width, :integer, required: true
+  attr :height, :integer, required: true
+  attr :style, :string, default: nil
+  attr :title_style, :string, default: nil
+  attr :rest, :global
 
+  slot :title
+  slot :inner_block
+
+  def panel(assigns) do
     assigns =
       assigns
-      |> assign(active: active)
-      |> assign(style: merge_style("border overflow-hidden focus:border-3", assigns[:style]))
       |> assign(
-        item_style:
-          merge_style(
-            "selected:bold selected:text-4 focus:selected:bg-4 focus:selected:text-7 overflow-scroll",
-            assigns[:item_style]
-          )
+        style: merge_style("border-rounded border-7 bg-0", assigns[:style]),
+        title_style: merge_style("bold bg-0", assigns[:title_style])
+      )
+
+    ~H"""
+    <box style={"#{@style} width-#{@width} height-#{@height}"} {@rest}>
+      {render_slot(@inner_block)}
+      <box :if={assigns[:title]} style={"absolute left-2 top-0 #{@title_style}"}>
+        {render_slot(@title)}
+      </box>
+    </box>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :width, :integer, required: true
+  attr :height, :integer, required: true
+  attr :style, :string, default: nil
+  attr :rest, :global
+
+  slot :title
+  slot :inner_block
+
+  def modal(assigns) do
+    assigns =
+      assigns
+      |> assign(
+        frame_width: assigns.width + 2,
+        frame_height: assigns.height + 2,
+        style: merge_style("bg-0", assigns[:style])
       )
 
     ~H"""
     <box
-      id={@id}
-      implicit={Breeze.Implicit.Tabs}
       focusable
-      tab-delegate={if @active do
-      "#{@id}-panel-#{@active.value}"
-    end}
-      tab-selected={@active.value}
-      style={@style}
+      default-focus
+      id={@id}
+      focus-scope="trap"
+      implicit={Breeze.Implicit.Modal}
+      width={@width}
+      height={@height}
+      style={"width-#{@frame_width} height-#{@frame_height}"}
       {@rest}
     >
-      <box style="inline" tab-bar="true">
-        <box :for={t <- @tab} value={t.value} tab-label={t.label} style={@item_style}>
-          {" #{t.label} "}
-        </box>
-      </box>
-      <box>
-      </box>
-      {render_slot(@active)}
+      <.panel width={@width} height={@height} style={@style}>
+        <:title :if={assigns[:title]}>{render_slot(@title)}</:title>
+        {render_slot(@inner_block)}
+      </.panel>
     </box>
     """
   end

--- a/lib/breeze/child_server.ex
+++ b/lib/breeze/child_server.ex
@@ -41,16 +41,55 @@ defmodule Breeze.ChildServer do
   end
 
   def handle_call({:render, opts}, _from, term) do
+    explicit_focus? = Keyword.has_key?(opts, :focused)
     term = maybe_put_terminal(term, Keyword.get(opts, :terminal))
     term = %{term | focused: Keyword.get(opts, :focused, term.focused)}
     implicit_state = Keyword.get(opts, :implicit_state, %{}) |> Map.merge(term.implicit_state)
     opts = Keyword.put(opts, :implicit_state, implicit_state)
 
-    {term, acc, box} =
+    {term, _acc, _box} =
       render_with_reconciled_implicits(term, opts, fn current_term, current_opts ->
         {acc, box} = Breeze.Renderer.render(current_term.view, current_term.assigns, current_opts)
-        {Breeze.RenderState.build(current_term, acc), acc, box}
+        current_term = Breeze.RenderState.build(current_term, acc)
+        focus_meta = Breeze.Focus.build_meta(acc.elements, current_term.implicit_state)
+
+        focus_memory =
+          Breeze.Focus.remember_focus(
+            current_term.focus_memory,
+            current_term.focused,
+            current_term.focus_meta
+          )
+
+        focused =
+          if explicit_focus? do
+            current_term.focused
+          else
+            Breeze.Focus.normalize_focus(
+              current_term.focused,
+              acc.focusables,
+              focus_meta,
+              focus_memory
+            )
+          end
+
+        current_term = %{
+          current_term
+          | focus_meta: focus_meta,
+            focus_memory: focus_memory,
+            focused: focused
+        }
+
+        {current_term, acc, box}
       end)
+
+    final_opts =
+      opts
+      |> Keyword.put(:focused, term.focused)
+      |> Keyword.put(:implicit_state, term.implicit_state)
+
+    {acc, box} = Breeze.Renderer.render(term.view, term.assigns, final_opts)
+    term = Breeze.RenderState.build(term, acc)
+    term = %{term | focus_meta: Breeze.Focus.build_meta(acc.elements, term.implicit_state)}
 
     {:reply, {:ok, acc, box}, term}
   end

--- a/lib/breeze/focus.ex
+++ b/lib/breeze/focus.ex
@@ -1,0 +1,181 @@
+defmodule Breeze.Focus do
+  @moduledoc false
+
+  @root_scope :__root__
+
+  def build_meta(elements, implicits) do
+    Enum.reduce(elements, %{}, fn {_idx, flags}, acc ->
+      case Keyword.get(flags, :id) do
+        nil ->
+          acc
+
+        id ->
+          meta =
+            flags
+            |> Map.new()
+            |> Map.merge(extract_implicit_focus_modifiers(flags, Map.get(implicits, id)))
+            |> normalize_meta()
+
+          Map.put(acc, id, meta)
+      end
+    end)
+  end
+
+  def remember_focus(focus_memory, nil, _focus_meta), do: focus_memory
+
+  def remember_focus(focus_memory, focused, focus_meta) do
+    case Map.get(focus_meta, focused) do
+      nil ->
+        focus_memory
+
+      meta ->
+        scopes = remembered_scopes(meta, focus_meta)
+        Enum.reduce(scopes, focus_memory, &Map.put(&2, &1, focused))
+    end
+  end
+
+  def active_focusables(focusables, focus_meta) do
+    case active_trapped_scope_id(focusables, focus_meta) do
+      nil -> focusables
+      scope_id -> Enum.filter(focusables, &in_scope?(focus_meta, &1, scope_id))
+    end
+  end
+
+  def normalize_focus(focused, focusables, focus_meta, focus_memory) do
+    focusables = active_focusables(focusables, focus_meta)
+
+    cond do
+      focusables == [] ->
+        nil
+
+      focused in focusables ->
+        focused
+
+      true ->
+        target_scope = active_trapped_scope_id(focusables, focus_meta)
+        pick_focus_target(focusables, target_scope, focus_meta, focus_memory)
+    end
+  end
+
+  def trapped_scope?(focusables, focus_meta) do
+    not is_nil(active_trapped_scope_id(focusables, focus_meta))
+  end
+
+  def in_scope?(_focus_meta, nil, _scope_id), do: false
+
+  def in_scope?(focus_meta, id, scope_id) do
+    case Map.get(focus_meta, id) do
+      %{id: ^scope_id} -> true
+      %{scope_path: scope_path} when is_list(scope_path) -> scope_id in scope_path
+      _ -> false
+    end
+  end
+
+  defp pick_focus_target(focusables, scope_id, focus_meta, focus_memory) do
+    remembered = Map.get(focus_memory, scope_id || @root_scope)
+    default = Enum.find(focusables, &default_focus_target?(focus_meta, &1, scope_id))
+    trapped_scope? = match?(%{focus_scope: :trap}, scope_id && Map.get(focus_meta, scope_id))
+
+    cond do
+      trapped_scope? and default ->
+        default
+
+      remembered in focusables ->
+        remembered
+
+      default ->
+        default
+
+      true ->
+        hd(focusables)
+    end
+  end
+
+  defp default_focus_target?(focus_meta, id, nil) do
+    match?(%{default_focus: true}, Map.get(focus_meta, id))
+  end
+
+  defp default_focus_target?(focus_meta, id, scope_id) do
+    match?(%{default_focus: true}, Map.get(focus_meta, id)) and
+      in_scope?(focus_meta, id, scope_id)
+  end
+
+  defp remembered_scopes(meta, focus_meta) do
+    scope_path = Map.get(meta, :scope_path, [])
+
+    cond do
+      meta.focus_scope == :trap ->
+        [meta.id]
+
+      trap_ancestor = List.last(Enum.filter(scope_path, &trapped_scope_id?(focus_meta, &1))) ->
+        [trap_ancestor | trailing_scopes_after(scope_path, trap_ancestor)]
+
+      true ->
+        [@root_scope | scope_path]
+    end
+  end
+
+  defp trailing_scopes_after(scope_path, trap_ancestor) do
+    scope_path
+    |> Enum.drop_while(&(&1 != trap_ancestor))
+    |> tl()
+  rescue
+    _ -> []
+  end
+
+  defp trapped_scope_id?(focus_meta, scope_id) do
+    match?(%{focus_scope: :trap}, Map.get(focus_meta, scope_id))
+  end
+
+  defp active_trapped_scope_id(focusables, focus_meta) do
+    focusables
+    |> Enum.flat_map(fn id ->
+      case Map.get(focus_meta, id) do
+        nil ->
+          []
+
+        meta ->
+          trapped_ancestors = Enum.filter(meta.scope_path, &trapped_scope_id?(focus_meta, &1))
+
+          if meta.focus_scope == :trap do
+            trapped_ancestors ++ [id]
+          else
+            trapped_ancestors
+          end
+      end
+    end)
+    |> List.last()
+  end
+
+  defp normalize_meta(meta) do
+    %{
+      id: Map.get(meta, :id),
+      implicit_owner: Map.get(meta, :implicit_owner),
+      default_focus:
+        truthy?(Map.get(meta, :"default-focus")) or truthy?(Map.get(meta, :default_focus)),
+      focus_scope:
+        normalize_focus_scope(Map.get(meta, :"focus-scope") || Map.get(meta, :focus_scope)),
+      scope_path: Map.get(meta, :"focus-scope-path", [])
+    }
+  end
+
+  defp extract_implicit_focus_modifiers(_flags, nil), do: %{}
+
+  defp extract_implicit_focus_modifiers(flags, {mod, implicit}) do
+    mod.handle_modifiers(:root, flags, implicit)
+    |> Enum.reduce(%{}, fn
+      {:default_focus, value}, acc -> Map.put(acc, :default_focus, value)
+      {:focus_scope, value}, acc -> Map.put(acc, :focus_scope, value)
+      _, acc -> acc
+    end)
+  end
+
+  defp normalize_focus_scope(true), do: :contain
+  defp normalize_focus_scope("trap"), do: :trap
+  defp normalize_focus_scope(:trap), do: :trap
+  defp normalize_focus_scope("contain"), do: :contain
+  defp normalize_focus_scope(:contain), do: :contain
+  defp normalize_focus_scope(_), do: nil
+
+  defp truthy?(value), do: value in [true, "true"]
+end

--- a/lib/breeze/implicit/modal.ex
+++ b/lib/breeze/implicit/modal.ex
@@ -1,0 +1,48 @@
+defmodule Breeze.Implicit.Modal do
+  @moduledoc false
+
+  def init(_items, last_state), do: last_state
+
+  def init(_items, root_attrs, last_state) do
+    width = dimension(root_attrs, :width, Map.get(last_state, :width, 0))
+    height = dimension(root_attrs, :height, Map.get(last_state, :height, 0))
+    screen_width = dimension(root_attrs, :"screen-width", Map.get(last_state, :screen_width, 0))
+
+    screen_height =
+      dimension(root_attrs, :"screen-height", Map.get(last_state, :screen_height, 0))
+
+    frame_width = width + 2
+    frame_height = height + 2
+
+    %{
+      width: width,
+      height: height,
+      frame_width: frame_width,
+      frame_height: frame_height,
+      screen_width: screen_width,
+      screen_height: screen_height,
+      left: div(max(screen_width - frame_width, 0), 2),
+      top: div(max(screen_height - frame_height, 0), 2)
+    }
+  end
+
+  def handle_event(_, %{"key" => "Escape"}, state) do
+    {{:change, %{action: :close}}, state}
+  end
+
+  def handle_event(_, _, state), do: {:noreply, state}
+
+  def handle_modifiers(:root, _flags, state) do
+    [style: "absolute left-#{state.left} top-#{state.top}"]
+  end
+
+  def handle_modifiers(:child, _flags, _state), do: []
+
+  defp dimension(attrs, key, fallback) do
+    case Map.get(attrs, key, fallback) do
+      value when is_integer(value) -> value
+      value when is_binary(value) -> String.to_integer(value)
+      _ -> fallback
+    end
+  end
+end

--- a/lib/breeze/render_state.ex
+++ b/lib/breeze/render_state.ex
@@ -159,6 +159,14 @@ defmodule Breeze.RenderState do
   end
 
   defp add_implicit_item(acc, term, id, mod, items, root_attrs) do
+    screen_width = if term.terminal, do: term.terminal.size.width, else: 0
+    screen_height = if term.terminal, do: term.terminal.size.height, else: 0
+
+    root_attrs =
+      root_attrs
+      |> Map.put(:"screen-width", screen_width)
+      |> Map.put(:"screen-height", screen_height)
+
     last_state =
       case term.implicit_state[id] do
         {_mod, last_state} -> last_state

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -79,17 +79,9 @@ defmodule Breeze.Renderer do
   end
 
   defp build_tree([{:attribute_bool, [attr]} | rest], box, children, style, flags, acc, opts) do
-    {flags, acc} =
-      case attr do
-        "focusable" ->
-          {Keyword.put(flags, :focusable, true),
-           %{acc | flags: Keyword.put(acc.flags, :focusable, true)}}
-
-        _ ->
-          {flags, acc}
-      end
-
-    build_tree(rest, box, children, style, flags, acc, opts)
+    attr = String.to_atom(attr)
+    acc = %{acc | flags: Keyword.put(acc.flags, attr, true)}
+    build_tree(rest, box, children, style, Keyword.put(flags, attr, true), acc, opts)
   end
 
   defp build_tree([content | rest], box, children, style, flags, acc, opts)
@@ -123,11 +115,9 @@ defmodule Breeze.Renderer do
 
   defp build_tree([{:box, _, nodes} | rest], box, children, style, flags, acc, opts) do
     child_flags =
-      cond do
-        Keyword.get(flags, :implicit) -> [implicit_owner: Keyword.fetch!(flags, :id)]
-        implicit_owner = Keyword.get(flags, :implicit_owner) -> [implicit_owner: implicit_owner]
-        true -> []
-      end
+      []
+      |> inherit_implicit_owner(flags)
+      |> inherit_focus_scope_path(flags)
 
     acc = %{
       acc
@@ -278,9 +268,40 @@ defmodule Breeze.Renderer do
             {idx,
              flags
              |> Keyword.update(:id, nil, &namespace_id(&1, prefix))
-             |> Keyword.update(:implicit_owner, nil, &namespace_id(&1, prefix))}
+             |> Keyword.update(:implicit_owner, nil, &namespace_id(&1, prefix))
+             |> Keyword.update(:"focus-scope-path", [], fn scope_path ->
+               Enum.map(scope_path, &namespace_id(&1, prefix))
+             end)}
           end)
     }
+  end
+
+  defp inherit_implicit_owner(child_flags, flags) do
+    cond do
+      Keyword.get(flags, :implicit) ->
+        Keyword.put(child_flags, :implicit_owner, Keyword.fetch!(flags, :id))
+
+      implicit_owner = Keyword.get(flags, :implicit_owner) ->
+        Keyword.put(child_flags, :implicit_owner, implicit_owner)
+
+      true ->
+        child_flags
+    end
+  end
+
+  defp inherit_focus_scope_path(child_flags, flags) do
+    scope_path = Keyword.get(flags, :"focus-scope-path", [])
+
+    scope_path =
+      if Keyword.get(flags, :"focus-scope") && Keyword.get(flags, :id) do
+        scope_path ++ [Keyword.fetch!(flags, :id)]
+      else
+        scope_path
+      end
+
+    if scope_path == [],
+      do: child_flags,
+      else: Keyword.put(child_flags, :"focus-scope-path", scope_path)
   end
 
   defp namespace_id(nil, _prefix), do: nil

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -8,7 +8,10 @@ defmodule Breeze.Term do
     assigns: %{},
     global_keybindings: [],
     focused: nil,
+    allow_unfocused?: false,
     focusables: [],
+    focus_meta: %{},
+    focus_memory: %{},
     elements: %{},
     events: %{},
     implicit_state: %{},
@@ -175,29 +178,37 @@ defmodule Breeze.Server do
   end
 
   defp process_data("\t", state) do
-    index = Enum.find_index(state.focusables, &(&1 == state.focused))
-
-    new_focused =
-      if index do
-        Enum.at(state.focusables, index + 1)
-      else
-        hd(state.focusables)
-      end
-
-    {:noreply, %{state | focused: new_focused}}
-  end
-
-  defp process_data("\e[Z", state) do
-    index = Enum.find_index(state.focusables, &(&1 == state.focused))
+    focusables = Breeze.Focus.active_focusables(state.focusables, state.focus_meta)
+    index = Enum.find_index(focusables, &(&1 == state.focused))
+    trapped_scope = Breeze.Focus.trapped_scope?(state.focusables, state.focus_meta)
 
     new_focused =
       cond do
-        index == 0 -> nil
-        index == nil -> hd(Enum.reverse(state.focusables))
-        true -> Enum.at(state.focusables, index - 1)
+        focusables == [] -> nil
+        trapped_scope && is_integer(index) -> Enum.at(focusables, index + 1) || hd(focusables)
+        is_integer(index) -> Enum.at(focusables, index + 1)
+        true -> hd(focusables)
       end
 
-    {:noreply, %{state | focused: new_focused}}
+    {:noreply, put_focus(state, new_focused)}
+  end
+
+  defp process_data("\e[Z", state) do
+    focusables = Breeze.Focus.active_focusables(state.focusables, state.focus_meta)
+    index = Enum.find_index(focusables, &(&1 == state.focused))
+    trapped_scope = Breeze.Focus.trapped_scope?(state.focusables, state.focus_meta)
+
+    new_focused =
+      cond do
+        focusables == [] -> nil
+        trapped_scope && index == 0 -> List.last(focusables)
+        trapped_scope && is_integer(index) -> Enum.at(focusables, index - 1)
+        index == 0 -> nil
+        index == nil -> List.last(focusables)
+        true -> Enum.at(focusables, index - 1)
+      end
+
+    {:noreply, put_focus(state, new_focused)}
   end
 
   defp process_data("\e", state) do
@@ -217,6 +228,8 @@ defmodule Breeze.Server do
       5 -> do_process_key("Escape", state)
     end
   end
+
+  defp process_data("\r", state), do: do_process_key("Enter", state)
 
   defp process_data(raw_key, state) do
     key =
@@ -246,7 +259,12 @@ defmodule Breeze.Server do
 
       :continue ->
         selected_implicit =
-          Enum.find(state.implicit_state, fn {id, _el} -> id == state.focused end)
+          state
+          |> implicit_event_target()
+          |> then(fn
+            nil -> nil
+            id -> Enum.find(state.implicit_state, fn {implicit_id, _el} -> implicit_id == id end)
+          end)
 
         {view_state, implicit_consumed, state} =
           if selected_implicit do
@@ -274,6 +292,30 @@ defmodule Breeze.Server do
               {:stop, state} -> {:stop, state}
               {:noreply, state} -> {:noreply, state}
             end
+        end
+    end
+  end
+
+  defp implicit_event_target(%{focused: nil}), do: nil
+
+  defp implicit_event_target(state) do
+    find_implicit_owner(state.focused, state.focus_meta, state.implicit_state)
+  end
+
+  defp find_implicit_owner(nil, _focus_meta, _implicit_state), do: nil
+
+  defp find_implicit_owner(id, focus_meta, implicit_state) do
+    cond do
+      Map.has_key?(implicit_state, id) ->
+        id
+
+      true ->
+        case Map.get(focus_meta, id) do
+          %{implicit_owner: owner} when is_binary(owner) ->
+            find_implicit_owner(owner, focus_meta, implicit_state)
+
+          _ ->
+            nil
         end
     end
   end
@@ -325,6 +367,10 @@ defmodule Breeze.Server do
     {state, _live_ids, _visible_live_ids, {acc, _box}} = render_view(state, state.implicit_state)
 
     implicits = Breeze.RenderState.build(state, acc).implicit_state
+    focus_meta = Breeze.Focus.build_meta(acc.elements, implicits)
+
+    focus_memory =
+      Breeze.Focus.remember_focus(state.focus_memory, state.focused, state.focus_meta)
 
     events =
       acc.elements
@@ -340,7 +386,12 @@ defmodule Breeze.Server do
         end
       end)
 
-    focused = state.focused
+    focused =
+      if state.allow_unfocused? and is_nil(state.focused) do
+        nil
+      else
+        Breeze.Focus.normalize_focus(state.focused, acc.focusables, focus_meta, focus_memory)
+      end
 
     {state, live_ids, _final_acc, output, dimensions, implicits} =
       render_final_view(%{state | focused: focused}, implicits)
@@ -359,7 +410,10 @@ defmodule Breeze.Server do
       | terminal: terminal,
         elements: dimensions,
         focusables: acc.focusables,
+        focus_meta: focus_meta,
+        focus_memory: focus_memory,
         focused: focused,
+        allow_unfocused?: is_nil(focused) and state.allow_unfocused?,
         implicit_state: implicits,
         events: events
     }
@@ -480,7 +534,6 @@ defmodule Breeze.Server do
       else
         child = start_child!(attrs, state.terminal)
         state = %{state | children: Map.put(state.children, id, child)}
-        state = maybe_take_child_focus(state, id, child.pid)
         {state, true}
       end
     end)
@@ -505,15 +558,6 @@ defmodule Breeze.Server do
     ref = Process.monitor(pid)
     %{pid: pid, ref: ref, view: view, persistent: persistent, visible: false}
   end
-
-  defp maybe_take_child_focus(%{focused: nil} = state, id, pid) do
-    case Breeze.ChildServer.metadata(pid) do
-      %{focused: nil} -> state
-      %{focused: focused} -> %{state | focused: namespace_live_id(id, focused)}
-    end
-  end
-
-  defp maybe_take_child_focus(state, _id, _pid), do: state
 
   defp prune_children(state, live_ids) do
     live_ids = MapSet.new(live_ids)
@@ -588,7 +632,7 @@ defmodule Breeze.Server do
   defp update_child_focus(state, _child_id, nil), do: state
 
   defp update_child_focus(state, child_id, focused),
-    do: %{state | focused: namespace_live_id(child_id, focused)}
+    do: put_focus(state, namespace_live_id(child_id, focused))
 
   defp clear_child_focus(%{focused: focused} = state, child_id) do
     if strip_live_prefix(focused, child_id) do
@@ -596,6 +640,10 @@ defmodule Breeze.Server do
     else
       state
     end
+  end
+
+  defp put_focus(state, focused) do
+    %{state | focused: focused, allow_unfocused?: is_nil(focused)}
   end
 
   defp child_implicit_state(implicit_state, live_id) do

--- a/lib/breeze/view.ex
+++ b/lib/breeze/view.ex
@@ -52,6 +52,8 @@ defmodule Breeze.View do
   * `focusable` - if the element should be added to the focus tree. These are added in
   the order they appear, and can be toggled using tab/shift-tab. The `focus` style
   state can be used to style these. E.g. style="border focus:border-3"
+  * `default-focus` - marks the preferred focus target when a view or focus scope becomes active
+  * `focus-scope` - defines a focus region. Set `focus-scope="trap"` to keep tab traversal inside it
   * `style` - the style for the box. This is covered in the [Style](`m:Breeze.View#module-style`) section.
   * `implicit` - this is a module that will be used for implicit state. This is covered
    in the [Implicits](`m:Breeze.View#module-implicits`) section.
@@ -201,6 +203,11 @@ defmodule Breeze.View do
 
   Return values can include style flags (for example `selected: true`) and structured
   scroll modifiers (`scroll_y`, `scroll_x`, or `scroll: {top, left}`).
+
+  Root implicit modifiers can also influence focus handling:
+
+  * `default_focus: true` - mark the root element as the preferred focus target
+  * `focus_scope: :trap` - constrain tab/shift-tab navigation to this implicit subtree
 
   ```
   def handle_modifiers(:child, attributes, state) do

--- a/test/breeze/focus_test.exs
+++ b/test/breeze/focus_test.exs
@@ -1,0 +1,64 @@
+defmodule Breeze.FocusTest do
+  use ExUnit.Case, async: true
+
+  alias Breeze.Focus
+
+  describe "normalize_focus/4" do
+    test "trapped scopes prefer default focus over remembered focus" do
+      focusables = ["confirm", "dismiss"]
+
+      focus_meta = %{
+        "modal" => %{
+          id: "modal",
+          implicit_owner: nil,
+          default_focus: false,
+          focus_scope: :trap,
+          scope_path: []
+        },
+        "confirm" => %{
+          id: "confirm",
+          implicit_owner: "modal",
+          default_focus: true,
+          focus_scope: nil,
+          scope_path: ["modal"]
+        },
+        "dismiss" => %{
+          id: "dismiss",
+          implicit_owner: "modal",
+          default_focus: false,
+          focus_scope: nil,
+          scope_path: ["modal"]
+        }
+      }
+
+      focus_memory = %{"modal" => "dismiss"}
+
+      assert Focus.normalize_focus(nil, focusables, focus_meta, focus_memory) == "confirm"
+    end
+
+    test "non-trapped scopes still restore remembered focus first" do
+      focusables = ["first", "second"]
+
+      focus_meta = %{
+        "first" => %{
+          id: "first",
+          implicit_owner: nil,
+          default_focus: true,
+          focus_scope: nil,
+          scope_path: []
+        },
+        "second" => %{
+          id: "second",
+          implicit_owner: nil,
+          default_focus: false,
+          focus_scope: nil,
+          scope_path: []
+        }
+      }
+
+      focus_memory = %{__root__: "second"}
+
+      assert Focus.normalize_focus(nil, focusables, focus_meta, focus_memory) == "second"
+    end
+  end
+end

--- a/test/breeze/implicit/modal_test.exs
+++ b/test/breeze/implicit/modal_test.exs
@@ -1,0 +1,37 @@
+defmodule Breeze.Implicit.ModalTest do
+  use ExUnit.Case, async: true
+
+  alias Breeze.Implicit.Modal
+
+  describe "init/3" do
+    test "centers the modal from root dimensions" do
+      state =
+        Modal.init(
+          [],
+          %{:width => 20, :height => 6, :"screen-width" => 80, :"screen-height" => 24},
+          %{}
+        )
+
+      assert state.frame_width == 22
+      assert state.frame_height == 8
+      assert state.left == 29
+      assert state.top == 8
+    end
+  end
+
+  describe "handle_event/3" do
+    test "escape emits a close change" do
+      state = %{left: 0, top: 0}
+
+      assert Modal.handle_event(nil, %{"key" => "Escape"}, state) ==
+               {{:change, %{action: :close}}, state}
+    end
+  end
+
+  describe "handle_modifiers/3" do
+    test "root modifiers position the modal absolutely" do
+      assert Modal.handle_modifiers(:root, [], %{left: 12, top: 4}) ==
+               [style: "absolute left-12 top-4"]
+    end
+  end
+end

--- a/test/breeze/live_view_test.exs
+++ b/test/breeze/live_view_test.exs
@@ -65,6 +65,21 @@ defmodule Breeze.LiveViewTest do
     def handle_info(_, term), do: {:noreply, term}
   end
 
+  defmodule FocusedChild do
+    use Breeze.View
+
+    def mount(_opts, term), do: {:ok, term}
+
+    def render(assigns) do
+      ~H"""
+      <box id="button" focusable style="focus:inverse">Focusable</box>
+      """
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
   test "render_to_tree preserves typed live attrs" do
     [{:box, _, [{:live, attrs}]}] =
       ParentLiveExample.render(%{start_opts: [seed: 1]})
@@ -101,6 +116,14 @@ defmodule Breeze.LiveViewTest do
     assert acc.ids == ["child::panel", "child::button"]
     assert acc.focusables == ["child::button"]
     assert box.content =~ "Count: 1"
+  end
+
+  test "unfocused live children do not render their own local focus ring" do
+    {:ok, pid} = ChildServer.start(view: FocusedChild, start_opts: [])
+
+    {:ok, _acc, box} = ChildServer.render(pid, focused: nil, implicit_state: %{})
+
+    refute box.content =~ "\e[7m"
   end
 
   test "child server emits invalidation on async state changes" do


### PR DESCRIPTION
The modal component has been added, along with a `panel` which allows absolutely rendering the title within the border.

There is now a different scope modal which allows a component to trap the scope. This ensures that when the modal is visible, tabbing won't leak out of the modal. When the model is dismissed, the previous focus state is restored.