### PR TITLE
feat(Breeze.Implicit.Dropdown): add dropdown menu implicit

### DIFF
--- a/lib/breeze/blocks.ex
+++ b/lib/breeze/blocks.ex
@@ -64,6 +64,117 @@ defmodule Breeze.Blocks do
   attr :id, :string, required: true
   attr :selected, :string, default: nil
   attr :style, :string, default: nil
+  attr :menu_style, :string, default: nil
+  attr :item_style, :string, default: nil
+  attr :width, :integer, default: nil
+  attr :menu_width, :integer, default: nil
+  attr :menu_top, :integer, default: 1
+  attr :menu_left, :integer, default: 0
+  attr :rest, :global
+
+  slot :item do
+    attr :value, :string, required: true
+  end
+
+  def dropdown(assigns) do
+    items_with_labels =
+      Enum.map(assigns.item, fn item ->
+        {item, render_slot(item, %{})}
+      end)
+
+    selected_label =
+      case Enum.find(items_with_labels, fn {item, _label} ->
+             Map.get(item, :value) == assigns[:selected]
+           end) do
+        {_item, label} -> label
+        nil -> to_string(assigns[:selected] || "")
+      end
+
+    width =
+      assigns[:width] ||
+        items_with_labels
+        |> Enum.map(fn {_item, label} -> String.length(label) + 4 end)
+        |> Kernel.++([String.length(selected_label) + 4, 8])
+        |> Enum.max()
+
+    menu_width = assigns[:menu_width] || width
+    menu_height = max(length(items_with_labels), 1)
+    trigger_content = build_dropdown_trigger(selected_label, width)
+
+    assigns =
+      assigns
+      |> assign(selected_label: selected_label)
+      |> assign(width: width)
+      |> assign(menu_width: menu_width)
+      |> assign(menu_height: menu_height)
+      |> assign(trigger_content: trigger_content)
+      |> assign(
+        trigger_style:
+          merge_style(
+            "bg-4 text-7 bold width-#{width} height-1 focus:inverse",
+            assigns[:style]
+          )
+      )
+      |> assign(menu_style: assigns[:menu_style])
+      |> assign(
+        item_style:
+          merge_style(
+            "width-#{menu_width} text-7 selected:bg-4 selected:text-7 focus:inverse",
+            assigns[:item_style]
+          )
+      )
+
+    assigns =
+      assign(assigns,
+        item_styles:
+          items_with_labels
+          |> Enum.with_index()
+          |> Enum.map(fn {{item, _label}, index} ->
+            {item, index, assigns.item_style}
+          end)
+      )
+
+    ~H"""
+    <box
+      id={@id}
+      implicit={Breeze.Implicit.Dropdown}
+      focusable
+      dropdown-selected={@selected}
+      dropdown-trigger-width={@width}
+      dropdown-menu-width={@menu_width}
+      dropdown-menu-height={@menu_height}
+      dropdown-menu-top={@menu_top}
+      dropdown-menu-left={@menu_left}
+      style={@trigger_style}
+      {@rest}
+    >
+      {@trigger_content}
+      <box dropdown-indicator-closed="true" style={@trigger_style}>▼</box>
+      <box dropdown-indicator-open="true" style={@trigger_style}>▲</box>
+      <box dropdown-frame="true" style={@menu_style}>
+      </box>
+      <box
+        :for={{item, index, item_style} <- @item_styles}
+        dropdown-item="true"
+        dropdown-item-index={index}
+        value={item.value}
+        style={item_style}
+      >
+        {render_slot(item, %{})}
+      </box>
+    </box>
+    """
+  end
+
+  defp build_dropdown_trigger(label, width) do
+    inner_width = max(width - 4, 0)
+    padded = String.pad_trailing(to_string(label), inner_width) |> String.slice(0, inner_width)
+    " " <> padded <> "   "
+  end
+
+  attr :id, :string, required: true
+  attr :selected, :string, default: nil
+  attr :style, :string, default: nil
   attr :item_style, :string, default: nil
   attr :rest, :global
 
@@ -79,7 +190,13 @@ defmodule Breeze.Blocks do
     assigns =
       assigns
       |> assign(active: active)
-      |> assign(style: merge_style("border overflow-hidden focus:border-3", assigns[:style]))
+      |> assign(
+        style:
+          merge_style(
+            "border overflow-hidden focus:border-3 grid grid-cols-1 grid-rows-2",
+            assigns[:style]
+          )
+      )
       |> assign(
         item_style:
           merge_style(
@@ -100,14 +217,12 @@ defmodule Breeze.Blocks do
       style={@style}
       {@rest}
     >
-      <box style="inline" tab-bar="true">
+      <box style="inline height-1" tab-bar="true">
         <box :for={t <- @tab} value={t.value} tab-label={t.label} style={@item_style}>
           {" #{t.label} "}
         </box>
       </box>
-      <box>
-      </box>
-      {render_slot(@active)}
+      <box style="height-full overflow-hidden">{render_slot(@active)}</box>
     </box>
     """
   end
@@ -197,20 +312,23 @@ defmodule Breeze.Blocks do
       |> assign(
         frame_width: assigns.width + 2,
         frame_height: assigns.height + 2,
-        style: merge_style("bg-0", assigns[:style])
+        style: merge_style("bg-0", assigns[:style]),
+        fill_content: blank_rect(assigns.width + 2, assigns.height + 2)
       )
 
     ~H"""
     <box
       id={@id}
+      focusable
       focus-scope="trap"
       implicit={Breeze.Implicit.Modal}
       width={@width}
       height={@height}
-      style={"width-#{@frame_width} height-#{@frame_height}"}
+      style={"width-#{@frame_width} height-#{@frame_height} bg-0 layer-50"}
       {@rest}
     >
-      <.panel width={@width} height={@height} style={@style}>
+      {@fill_content}
+      <.panel width={@width} height={@height} style={"absolute left-0 top-0 layer-51 #{@style}"}>
         <:title :if={assigns[:title]}>{render_slot(@title)}</:title>
         {render_slot(@inner_block)}
       </.panel>
@@ -261,5 +379,13 @@ defmodule Breeze.Blocks do
       [_only] -> token
       parts -> parts |> Enum.drop(-1) |> Enum.join("-")
     end
+  end
+
+  defp blank_rect(width, height) do
+    row = String.duplicate(" ", max(width, 0))
+
+    1..max(height, 0)
+    |> Enum.map(fn _ -> row end)
+    |> Enum.join("\n")
   end
 end

--- a/lib/breeze/implicit/dropdown.ex
+++ b/lib/breeze/implicit/dropdown.ex
@@ -1,0 +1,178 @@
+defmodule Breeze.Implicit.Dropdown do
+  @moduledoc false
+
+  def init(children, last_state), do: init(children, %{}, last_state)
+
+  def init(children, root_attrs, last_state) do
+    items = Enum.filter(children, &Map.get(&1, :"dropdown-item"))
+    values = Enum.map(items, &Map.get(&1, :value))
+
+    selected_index =
+      case Map.get(last_state, :selected) || Map.get(root_attrs, :"dropdown-selected") do
+        nil -> 0
+        selected -> Enum.find_index(values, &(&1 == selected)) || 0
+      end
+
+    selected_index = min(selected_index, max(length(values) - 1, 0))
+    selected = Enum.at(values, selected_index)
+    open? = Map.get(last_state, :open?, false)
+
+    %{
+      values: values,
+      selected: selected,
+      selected_index: selected_index,
+      highlighted_index:
+        normalize_index(Map.get(last_state, :highlighted_index, selected_index), values),
+      open?: open?,
+      trigger_width: int_option(root_attrs, :"dropdown-trigger-width", 10),
+      menu_width: int_option(root_attrs, :"dropdown-menu-width", 12),
+      menu_height: int_option(root_attrs, :"dropdown-menu-height", length(values) + 2),
+      menu_left: int_option(root_attrs, :"dropdown-menu-left", 0),
+      menu_top: int_option(root_attrs, :"dropdown-menu-top", 1)
+    }
+  end
+
+  def handle_event(_, %{"key" => key}, %{open?: false} = state)
+      when key in ["Enter", " ", "\x14", "ArrowDown", "ArrowUp", "j", "k"] do
+    {:noreply, open(state)}
+  end
+
+  def handle_event(_, %{"key" => "Escape"}, %{open?: true} = state) do
+    {:noreply, close(state)}
+  end
+
+  def handle_event(_, %{"key" => "\x14"}, %{open?: true} = state) do
+    {:noreply, close(state)}
+  end
+
+  def handle_event(_, %{"key" => key}, %{open?: true} = state)
+      when key in ["ArrowDown", "j"] do
+    {:noreply, %{state | highlighted_index: next_index(state, 1)}}
+  end
+
+  def handle_event(_, %{"key" => key}, %{open?: true} = state)
+      when key in ["ArrowUp", "k"] do
+    {:noreply, %{state | highlighted_index: next_index(state, -1)}}
+  end
+
+  def handle_event(_, %{"key" => key}, %{open?: true} = state) when key in ["Enter", " "] do
+    selected_index = state.highlighted_index || state.selected_index
+    selected = Enum.at(state.values, selected_index)
+
+    next_state = %{
+      close(state)
+      | selected: selected,
+        selected_index: selected_index,
+        highlighted_index: selected_index
+    }
+
+    {{:change, %{value: selected, index: selected_index}}, next_state}
+  end
+
+  def handle_event(_, _, state), do: {:noreply, state}
+
+  def handle_modifiers(:root, _flags, _state), do: []
+
+  def handle_modifiers(:child, flags, state) do
+    cond do
+      Keyword.get(flags, :"dropdown-indicator-open") && not state.open? ->
+        [style: indicator_style(state, hidden?: true)]
+
+      Keyword.get(flags, :"dropdown-indicator-open") ->
+        [style: indicator_style(state)]
+
+      Keyword.get(flags, :"dropdown-indicator-closed") && state.open? ->
+        [style: indicator_style(state, hidden?: true)]
+
+      Keyword.get(flags, :"dropdown-indicator-closed") ->
+        [style: indicator_style(state)]
+
+      Keyword.get(flags, :"dropdown-frame") && not state.open? ->
+        [style: "absolute left-0 top-0 width-0 height-0 overflow-hidden layer-20"]
+
+      Keyword.get(flags, :"dropdown-frame") ->
+        [style: frame_style(state)]
+
+      Keyword.get(flags, :"dropdown-item") && not state.open? ->
+        [style: "absolute left-0 top-0 width-0 height-0 overflow-hidden layer-21"]
+
+      Keyword.get(flags, :"dropdown-item") &&
+          Enum.at(state.values, state.highlighted_index) == Keyword.get(flags, :value) ->
+        [selected: true, style: item_style(state, flags)]
+
+      Keyword.get(flags, :"dropdown-item") ->
+        [style: item_style(state, flags)]
+
+      true ->
+        []
+    end
+  end
+
+  defp frame_style(state),
+    do:
+      "absolute left-#{state.menu_left} top-#{state.menu_top} width-#{state.menu_width} height-#{state.menu_height} bg-0 text-7 overflow-hidden layer-20"
+
+  defp item_style(state, flags) do
+    index = int_flag(flags, :"dropdown-item-index", 0)
+
+    "absolute left-#{state.menu_left} top-#{state.menu_top + index} bg-0 text-7 width-#{state.menu_width} layer-21"
+  end
+
+  defp indicator_style(state, opts \\ []) do
+    hidden? = Keyword.get(opts, :hidden?, false)
+    width = if hidden?, do: 0, else: 1
+    height = if hidden?, do: 0, else: 1
+    overflow = if hidden?, do: " overflow-hidden", else: ""
+
+    "absolute left-#{max(state.trigger_width - 2, 0)} top-0 width-#{width} height-#{height}#{overflow}"
+  end
+
+  defp int_flag(flags, key, default) do
+    case Keyword.get(flags, key) do
+      nil -> default
+      value when is_integer(value) -> value
+      value when is_binary(value) -> String.to_integer(value)
+      _ -> default
+    end
+  rescue
+    _ -> default
+  end
+
+  def open(state) do
+    %{state | open?: true, highlighted_index: state.selected_index}
+  end
+
+  def close(state) do
+    %{state | open?: false, highlighted_index: state.selected_index}
+  end
+
+  def blur(state), do: close(state)
+
+  defp next_index(%{values: []}, _delta), do: 0
+
+  defp next_index(%{values: values, highlighted_index: index}, delta) do
+    rem((index || 0) + delta + length(values), length(values))
+  end
+
+  defp normalize_index(index, []) when is_integer(index), do: index
+  defp normalize_index(_index, []), do: 0
+
+  defp normalize_index(index, values) when is_integer(index) do
+    index
+    |> max(0)
+    |> min(length(values) - 1)
+  end
+
+  defp normalize_index(_index, values), do: min(length(values) - 1, 0)
+
+  defp int_option(attrs, key, default) do
+    case Map.get(attrs, key) do
+      nil -> default
+      value when is_integer(value) -> value
+      value when is_binary(value) -> String.to_integer(value)
+      _ -> default
+    end
+  rescue
+    _ -> default
+  end
+end

--- a/lib/breeze/view.ex
+++ b/lib/breeze/view.ex
@@ -213,7 +213,9 @@ defmodule Breeze.View do
   There are two final handlers used during rendering.
 
   `animate/5` can transform the rendered `BackBreeze.Box` for lightweight
-  renderer-driven animation and other presentation changes.
+  renderer-driven animation and other presentation changes. It can return either
+  the updated box directly or `{:ok, box, overlays: overlays}` to request
+  terminal overlays during async animation passes.
 
   `handle_modifiers/3` receives `:root` or `:child` as the first argument and can be
   used to tell the renderer things about the state.
@@ -357,5 +359,18 @@ defmodule Breeze.View do
   @spec reset(map(), String.t()) :: map()
   def reset(term, id) do
     update_in(term.implicit_state, &Map.delete(&1, id))
+  end
+
+  @doc """
+  Update the implicit state for the given element ID in place.
+  """
+  @spec update_implicit(map(), String.t(), ({module(), map()} -> map())) :: map()
+  def update_implicit(term, id, fun) do
+    update_in(term.implicit_state, fn implicit_state ->
+      case Map.get(implicit_state, id) do
+        {mod, state} -> Map.put(implicit_state, id, {mod, fun.({mod, state})})
+        nil -> implicit_state
+      end
+    end)
   end
 end

--- a/test/__snapshots__/examples/modal/open.ansi
+++ b/test/__snapshots__/examples/modal/open.ansi
@@ -5,15 +5,15 @@ Escape closes the modal. q quits the example.
                                                                                 
 ╭──────────────────────────╮                                                    
 │[1mOpen modal[0m     [37m╭─[0m[1;48;5;0mFocused Widget Help[0m[37m──────────────────────────╮[0m                
-│               [37m│[0mCentered panel with trapped Tab focus.[48;5;0m        [0m[37m│[0m                
-│               [37m│[0mUse it for│help, palettes, and overlays.[48;5;0m      [0m[37m│[0m                
+│               [37m│[0mCentered[48;5;0m [0mpanel[48;5;0m [0mwith[48;5;0m [0mtrapped[48;5;0m [0mTab[48;5;0m [0mfocus.[48;5;0m        [0m[37m│[0m                
+│               [37m│[0mUse[48;5;0m [0mit[48;5;0m [0mfor[48;5;0m [0mhelp,[48;5;0m [0mpalettes,[48;5;0m [0mand[48;5;0m [0moverlays.[48;5;0m      [0m[37m│[0m                
 ╰───────────────[37m│[0m[48;5;0m                                              [0m[37m│[0m                
                 [37m│[0m[1mControls[0m[48;5;0m                                      [0m[37m│[0m                
-╭───────────────[37m│[0mTab───────Move between actions[48;5;0m                [0m[37m│[0m                
-│[1mBackground pane[0m[37m│[0mEscape    Dismiss the modal[48;5;0m                   [0m[37m│[0m                
-│Last action: no[37m│[0mEnter     Activate focused action[48;5;0m             [0m[37m│[0m                
-│               [37m│[0m[34m╭──────────────╮[0m╭──────────────╮              [37m│[0m                
-│               [37m│[0m[34m│[0m[1mConfirm[0m  │    [34m│[0m│[1mDismiss[0m       │              [37m│[0m                
+╭───────────────[37m│[0mTab[48;5;0m       [0mMove[48;5;0m [0mbetween[48;5;0m [0mactions[48;5;0m                [0m[37m│[0m                
+│[1mBackground pane[0m[37m│[0mEscape[48;5;0m    [0mDismiss[48;5;0m [0mthe[48;5;0m [0mmodal[48;5;0m                   [0m[37m│[0m                
+│Last action: no[37m│[0mEnter[48;5;0m     [0mActivate[48;5;0m [0mfocused[48;5;0m [0maction[48;5;0m             [0m[37m│[0m                
+│               [37m│[0m[34m╭──────────────╮[0m╭──────────────╮[48;5;0m              [0m[37m│[0m                
+│               [37m│[0m[34m│[0m[1mConfirm[0m[48;5;0m       [0m[34m│[0m│[1mDismiss[0m[48;5;0m       [0m│[48;5;0m              [0m[37m│[0m                
 ╰───────────────[37m│[0m[34m╰──────────────╯[0m╰──────────────╯[48;5;0m              [0m[37m│[0m                
                 [37m╰──────────────────────────────────────────────╯[0m                
                                                                                 

--- a/test/__snapshots__/examples/tabs/initial.ansi
+++ b/test/__snapshots__/examples/tabs/initial.ansi
@@ -3,12 +3,12 @@ Use left/right arrows while the ta
 The tab bar should scroll horizont
 [34m╭──────────────────────────────╮[0m  
 [34m│[0m[1;48;5;4;38;5;7m Overview [0m Requests  Responses[34m│[0m  
-[34m│[0m                              [34m│[0m  
 [34m│[0m[1mOverview[0m                     ▲[34m│[0m  
 [34m│[0mSelected tab value: overview █[34m│[0m  
 [34m│[0m                             │[34m│[0m  
 [34m│[0mOverview panel line 1        │[34m│[0m  
 [34m│[0mOverview panel line 2        │[34m│[0m  
-[34m│[0mOverview panel line 3        ▼[34m│[0m  
+[34m│[0mOverviewpanelline3▼           [34m│[0m  
+[34m│[0m                              [34m│[0m  
 [34m╰──────────────────────────────╯[0m  
                                   

--- a/test/__snapshots__/examples/tabs/next-tab.ansi
+++ b/test/__snapshots__/examples/tabs/next-tab.ansi
@@ -3,12 +3,12 @@ Use left/right arrows while the ta
 The tab bar should scroll horizont
 [34m╭──────────────────────────────╮[0m  
 [34m│[0m Overview [1;48;5;4;38;5;7m Requests [0m Responses[34m│[0m  
-[34m│[0m                              [34m│[0m  
 [34m│[0m[1mRequests[0m                     ▲[34m│[0m  
 [34m│[0mSelected tab value: requests █[34m│[0m  
 [34m│[0m                             │[34m│[0m  
 [34m│[0mRequests panel line 1        │[34m│[0m  
 [34m│[0mRequests panel line 2        │[34m│[0m  
-[34m│[0mRequests panel line 3        ▼[34m│[0m  
+[34m│[0mRequestspanelline3▼           [34m│[0m  
+[34m│[0m                              [34m│[0m  
 [34m╰──────────────────────────────╯[0m  
                                   

--- a/test/__snapshots__/examples/tabs/scrolled-tab.ansi
+++ b/test/__snapshots__/examples/tabs/scrolled-tab.ansi
@@ -3,12 +3,12 @@ Use left/right arrows while the ta
 The tab bar should scroll horizont
 [34m╭──────────────────────────────╮[0m  
 [34m│[0m  Responses  Headers [1;48;5;4;38;5;7m Cookies [0m[34m│[0m  
-[34m│[0m                              [34m│[0m  
 [34m│[0m[1mCookies[0m                      ▲[34m│[0m  
 [34m│[0mSelected tab value: cookies  █[34m│[0m  
 [34m│[0m                             │[34m│[0m  
 [34m│[0mCookies panel line 1         │[34m│[0m  
 [34m│[0mCookies panel line 2         │[34m│[0m  
-[34m│[0mCookies panel line 3         ▼[34m│[0m  
+[34m│[0mCookiespanelline3▼            [34m│[0m  
+[34m│[0m                              [34m│[0m  
 [34m╰──────────────────────────────╯[0m  
                                   

--- a/test/breeze/implicit/dropdown_test.exs
+++ b/test/breeze/implicit/dropdown_test.exs
@@ -1,0 +1,244 @@
+defmodule Breeze.Implicit.DropdownTest do
+  use ExUnit.Case, async: true
+
+  alias Breeze.Implicit.Dropdown
+
+  defmodule DropdownView do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def mount(_, term) do
+      {:ok, focus(term, "method") |> assign(method: "POST", methods: ["GET", "POST", "PUT"])}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <box style="width-screen height-screen">
+        <.dropdown
+          id="method"
+          selected={@method}
+          br-change="method_changed"
+          style="bg-4 text-7 bold focus:inverse width-10"
+          menu_width={12}
+        >
+          <:item :for={method <- @methods} value={method}>{" #{method}"}</:item>
+        </.dropdown>
+      </box>
+      """
+    end
+
+    def handle_event(_, %{"key" => "\x14"}, term) do
+      term =
+        update_implicit(term, "method", fn
+          {Breeze.Implicit.Dropdown, state} -> Breeze.Implicit.Dropdown.open(state)
+          {_mod, state} -> state
+        end)
+
+      {:noreply, term}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+  end
+
+  defmodule GridDropdownView do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def mount(_, term) do
+      {:ok, focus(term, "method") |> assign(method: "POST", methods: ["GET", "POST", "PUT"])}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <box style="width-screen height-screen">
+        <box style="grid grid-cols-3 height-1">
+          <.dropdown
+            id="method"
+            selected={@method}
+            br-change="method_changed"
+            style="bg-4 text-7 bold focus:inverse width-10"
+            menu_width={12}
+          >
+            <:item :for={method <- @methods} value={method}>{" #{method}"}</:item>
+          </.dropdown>
+          <box>{" filler "}</box>
+          <box>{" tail "}</box>
+        </box>
+      </box>
+      """
+    end
+
+    def handle_event(_, %{"key" => "\x14"}, term) do
+      term =
+        update_implicit(term, "method", fn
+          {Breeze.Implicit.Dropdown, state} -> Breeze.Implicit.Dropdown.open(state)
+          {_mod, state} -> state
+        end)
+
+      {:noreply, term}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+  end
+
+  test "opens on enter and selects the highlighted item" do
+    children = [
+      %{:"dropdown-item" => true, value: "GET"},
+      %{:"dropdown-item" => true, value: "POST"},
+      %{:"dropdown-item" => true, value: "PUT"}
+    ]
+
+    state = Dropdown.init(children, %{:"dropdown-selected" => "POST"}, %{})
+
+    assert {:noreply, open_state} = Dropdown.handle_event(nil, %{"key" => "Enter"}, state)
+    assert open_state.open? == true
+    assert open_state.highlighted_index == 1
+
+    assert {:noreply, moved_state} =
+             Dropdown.handle_event(nil, %{"key" => "ArrowDown"}, open_state)
+
+    assert moved_state.highlighted_index == 2
+
+    assert {{:change, %{value: "PUT", index: 2}}, selected_state} =
+             Dropdown.handle_event(nil, %{"key" => "Enter"}, moved_state)
+
+    assert selected_state.open? == false
+    assert selected_state.selected == "PUT"
+    assert selected_state.selected_index == 2
+  end
+
+  test "item modifiers collapse the items when closed" do
+    state = %{
+      values: ["GET"],
+      selected: "GET",
+      selected_index: 0,
+      highlighted_index: 0,
+      open?: false,
+      trigger_width: 10,
+      menu_width: 12,
+      menu_height: 3,
+      menu_left: 0,
+      menu_top: 1
+    }
+
+    assert [style: "absolute left-0 top-0 width-0 height-0 overflow-hidden layer-21"] =
+             Dropdown.handle_modifiers(:child, [{:"dropdown-item", true}, {:value, "GET"}], state)
+  end
+
+  test "highlighted item gets selected modifier when open" do
+    state = %{
+      values: ["GET", "POST"],
+      selected: "POST",
+      selected_index: 1,
+      highlighted_index: 1,
+      open?: true,
+      trigger_width: 10,
+      menu_width: 12,
+      menu_height: 4,
+      menu_left: 0,
+      menu_top: 1
+    }
+
+    assert [selected: true, style: "absolute left-0 top-1 bg-0 text-7 width-12 layer-21"] =
+             Dropdown.handle_modifiers(
+               :child,
+               [{:"dropdown-item", true}, {:"dropdown-item-index", 0}, {:value, "POST"}],
+               state
+             )
+  end
+
+  test "indicator modifiers swap visibility based on open state" do
+    closed_state = %{
+      values: ["GET", "POST"],
+      selected: "POST",
+      selected_index: 1,
+      highlighted_index: 1,
+      open?: false,
+      trigger_width: 10,
+      menu_width: 12,
+      menu_height: 4,
+      menu_left: 0,
+      menu_top: 1
+    }
+
+    open_state = %{closed_state | open?: true}
+
+    assert [style: "absolute left-8 top-0 width-1 height-1"] =
+             Dropdown.handle_modifiers(
+               :child,
+               [{:"dropdown-indicator-closed", true}],
+               closed_state
+             )
+
+    assert [style: "absolute left-8 top-0 width-0 height-0 overflow-hidden"] =
+             Dropdown.handle_modifiers(:child, [{:"dropdown-indicator-open", true}], closed_state)
+
+    assert [style: "absolute left-8 top-0 width-0 height-0 overflow-hidden"] =
+             Dropdown.handle_modifiers(:child, [{:"dropdown-indicator-closed", true}], open_state)
+
+    assert [style: "absolute left-8 top-0 width-1 height-1"] =
+             Dropdown.handle_modifiers(:child, [{:"dropdown-indicator-open", true}], open_state)
+  end
+
+  test "ctrl-t closes when already open" do
+    children = [
+      %{:"dropdown-item" => true, value: "GET"},
+      %{:"dropdown-item" => true, value: "POST"}
+    ]
+
+    state = Dropdown.init(children, %{:"dropdown-selected" => "POST"}, %{})
+    assert {:noreply, open_state} = Dropdown.handle_event(nil, %{"key" => "\x14"}, state)
+    assert open_state.open? == true
+
+    assert {:noreply, closed_state} =
+             Dropdown.handle_event(nil, %{"key" => "\x14"}, open_state)
+
+    assert closed_state.open? == false
+    assert closed_state.highlighted_index == closed_state.selected_index
+  end
+
+  test "opened dropdown renders its menu items" do
+    terminal = %Termite.Terminal{size: %{width: 40, height: 12}}
+    {:ok, pid} = Breeze.ChildServer.start(view: DropdownView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
+    assert {:noreply, "method", true} = Breeze.ChildServer.dispatch_input(pid, "\x14")
+
+    state = :sys.get_state(pid)
+
+    assert {:ok, _acc, box} =
+             Breeze.ChildServer.render(pid, focused: state.focused, terminal: terminal)
+
+    assert box.content =~ "GET"
+    assert box.content =~ "POST"
+    assert box.content =~ "PUT"
+    assert box.content =~ "▲"
+  end
+
+  test "closed dropdown renders the closed indicator without animate" do
+    terminal = %Termite.Terminal{size: %{width: 40, height: 12}}
+    {:ok, pid} = Breeze.ChildServer.start(view: DropdownView, terminal: terminal)
+
+    assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, terminal: terminal)
+
+    assert box.content =~ "▼"
+    refute box.content =~ "▲"
+  end
+
+  test "opened dropdown still renders inside a grid row" do
+    terminal = %Termite.Terminal{size: %{width: 40, height: 12}}
+    {:ok, pid} = Breeze.ChildServer.start(view: GridDropdownView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
+    assert {:noreply, "method", true} = Breeze.ChildServer.dispatch_input(pid, "\x14")
+
+    state = :sys.get_state(pid)
+
+    assert {:ok, _acc, box} =
+             Breeze.ChildServer.render(pid, focused: state.focused, terminal: terminal)
+
+    assert box.content =~ "GET"
+    assert box.content =~ "POST"
+    assert box.content =~ "PUT"
+  end
+end

--- a/test/breeze/view_test.exs
+++ b/test/breeze/view_test.exs
@@ -1,0 +1,28 @@
+defmodule Breeze.ViewTest do
+  use ExUnit.Case, async: true
+
+  import Breeze.View
+
+  test "update_implicit updates an existing implicit state" do
+    term = %{
+      implicit_state: %{
+        "dropdown" =>
+          {Breeze.Implicit.Dropdown, %{open?: false, selected_index: 1, highlighted_index: 0}}
+      }
+    }
+
+    updated =
+      update_implicit(term, "dropdown", fn
+        {Breeze.Implicit.Dropdown, state} -> Breeze.Implicit.Dropdown.open(state)
+      end)
+
+    assert {Breeze.Implicit.Dropdown, %{open?: true, highlighted_index: 1}} =
+             updated.implicit_state["dropdown"]
+  end
+
+  test "update_implicit ignores missing implicits" do
+    term = %{implicit_state: %{}}
+
+    assert update_implicit(term, "missing", fn {_mod, state} -> state end) == term
+  end
+end


### PR DESCRIPTION
The dropdown menu works by rendering the selected element. When expanded, it shows a list which supports arrow keys to navigate the menu. Selecting an item closes it again.