### PR TITLE
feat(Breeze.Implicit.Input): add input implicit and overlays

### DIFF
--- a/examples/forms.exs
+++ b/examples/forms.exs
@@ -1,0 +1,128 @@
+defmodule FormsDemo do
+  use Breeze.View
+
+  @fields [
+    {"name", "Name"},
+    {"email", "Email"},
+    {"website", "Website"},
+    {"path", "Path"}
+  ]
+
+  @website "https://jsonplaceholder.typicode.com/posts/123/comments?include=author,history"
+  @path "/Users/demo/projects/breeze_routing/lib/breeze/implicit/input.ex"
+
+  def mount(_opts, term) do
+    {screen_width, _screen_height} = BackBreeze.screen_dimensions(term.terminal)
+
+    {:ok,
+     term
+     |> focus("name")
+     |> assign(
+       screen_width: screen_width,
+       field_width: default_field_width(screen_width),
+       name: "",
+       name_cursor: 0,
+       email: "dev@example.com",
+       email_cursor: String.length("dev@example.com"),
+       website: @website,
+       website_cursor: String.length(@website),
+       path: @path,
+       path_cursor: String.length(@path)
+     )}
+  end
+
+  def render(assigns) do
+    assigns =
+      assign(assigns,
+        fields:
+          Enum.map(@fields, fn {id, label} ->
+            value = Map.fetch!(assigns, String.to_atom(id))
+            cursor = Map.fetch!(assigns, String.to_atom("#{id}_cursor"))
+            width = field_width(id, assigns.field_width)
+
+            %{
+              id: id,
+              label: label,
+              width: width,
+              value: value,
+              cursor: cursor,
+              row_style: row_style(id),
+              display: " " <> String.pad_trailing(value, max(width - 1, 0))
+            }
+          end)
+      )
+
+    ~H"""
+    <box style="width-screen height-screen">
+      <box style="bold">Forms Demo</box>
+      <box style="text-24">Focused example for horizontal input overflow.</box>
+      <box style="text-24">Tab between fields. The website field is fixed to 24 cells.</box>
+      <box style="height-1">
+      </box>
+      <box style="border-rounded width-72">
+        <box style="bold">Example Form</box>
+        <box style="height-1">
+        </box>
+        <box :for={field <- @fields} style={field.row_style}>
+          <box style="text-4 bold">{field.label}</box>
+          <box
+            id={field.id}
+            focusable
+            implicit={Breeze.Implicit.Input}
+            input-value={field.value}
+            input-cursor={field.cursor}
+            br-change={"#{field.id}_changed"}
+            style={"width-#{field.width} focus:inverse"}
+          >
+            {field.display}
+          </box>
+          <box style="text-24">width={field.width} cursor={field.cursor} value={field.value}</box>
+        </box>
+      </box>
+    </box>
+    """
+  end
+
+  def handle_event(event, %{value: value, cursor: cursor}, term) when is_binary(event) do
+    case String.replace_suffix(event, "_changed", "") do
+      ^event ->
+        {:noreply, term}
+
+      field ->
+        {:noreply,
+         assign(term, [
+           {String.to_atom(field), value},
+           {String.to_atom("#{field}_cursor"), cursor}
+         ])}
+    end
+  end
+
+  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
+  def handle_event(_, _, term), do: {:noreply, term}
+
+  def handle_info(:resize, term) do
+    {screen_width, _screen_height} = BackBreeze.screen_dimensions(term.terminal)
+
+    {:noreply,
+     assign(term, screen_width: screen_width, field_width: default_field_width(screen_width))}
+  end
+
+  def handle_info(_, term), do: {:noreply, term}
+
+  defp default_field_width(screen_width), do: min(max(screen_width - 8, 20), 60)
+
+  defp field_width("website", _default_width), do: 24
+  defp field_width(_id, default_width), do: default_width
+
+  defp row_style("path"), do: "height-4"
+  defp row_style(_id), do: "height-5"
+end
+
+Breeze.Example.run(
+  [
+    view: FormsDemo,
+    hide_cursor: true,
+    global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+  ],
+  keep_alive: :infinity
+)

--- a/lib/breeze/child_server.ex
+++ b/lib/breeze/child_server.ex
@@ -52,7 +52,12 @@ defmodule Breeze.ChildServer do
 
   @impl true
   def handle_call(:metadata, _from, term) do
-    {:reply, %{focused: term.focused, view: term.view}, term}
+    {:reply,
+     %{
+       focused: term.focused,
+       view: term.view,
+       focused_implicit_id: focused_implicit_id(term, term.focused)
+     }, term}
   end
 
   def handle_call({:render, opts}, _from, term) do
@@ -95,12 +100,14 @@ defmodule Breeze.ChildServer do
     end
   end
 
-  defp reply_from_result({:noreply, next_term}, _term) do
+  defp reply_from_result({:noreply, next_term}, term) do
+    next_term = apply_focus_transitions(term, next_term)
     notify_invalidate(next_term)
     {:reply, {:noreply, next_term.focused}, next_term}
   end
 
-  defp reply_from_result({:stop, next_term}, _term) do
+  defp reply_from_result({:stop, next_term}, term) do
+    next_term = apply_focus_transitions(term, next_term)
     notify_invalidate(next_term)
     {:stop, :normal, {:stop, next_term.focused}, next_term}
   end
@@ -272,18 +279,22 @@ defmodule Breeze.ChildServer do
       {id, {mod, implicit}}, acc ->
         every_ms = get_in(term.implicit_meta, [id, :rerender_every])
         box = Map.get(term.rendered_boxes, id)
+        layout = Map.get(term.elements, id)
 
         if is_integer(every_ms) and every_ms > 0 and match?(%BackBreeze.Box{}, box) and
              function_exported?(mod, :animate, 5) do
           [
             %{
               id: id,
+              owner_id: id,
               mod: mod,
               state: implicit,
               box: box,
+              layout: layout,
               flags: focus_flags(term, id),
               every_ms: every_ms,
-              active_when_pending: get_in(term.implicit_meta, [id, :active_when_pending]) == true
+              active_when_pending: get_in(term.implicit_meta, [id, :active_when_pending]) == true,
+              active_when_focused: get_in(term.implicit_meta, [id, :active_when_focused]) == true
             }
             | acc
           ]
@@ -308,13 +319,56 @@ defmodule Breeze.ChildServer do
   end
 
   defp reply_from_input_result({:noreply, next_term}, term) do
+    next_term = apply_focus_transitions(term, next_term)
     notify_invalidate(next_term)
     {:reply, {:noreply, next_term.focused, next_term != term}, next_term}
   end
 
-  defp reply_from_input_result({:stop, next_term}, _term) do
+  defp reply_from_input_result({:stop, next_term}, term) do
+    next_term = apply_focus_transitions(term, next_term)
     notify_invalidate(next_term)
     {:stop, :normal, {:stop, next_term.focused, true}, next_term}
+  end
+
+  defp apply_focus_transitions(prev_term, next_term) do
+    prev_implicit_id = focused_implicit_id(prev_term, prev_term.focused)
+    next_implicit_id = focused_implicit_id(next_term, next_term.focused)
+
+    next_term =
+      if prev_implicit_id && prev_implicit_id != next_implicit_id do
+        case Map.get(next_term.implicit_state, prev_implicit_id) do
+          {mod, state} ->
+            if function_exported?(mod, :blur, 1) do
+              Breeze.RenderState.put_implicit_state(
+                next_term,
+                prev_implicit_id,
+                mod,
+                mod.blur(state)
+              )
+            else
+              next_term
+            end
+
+          _ ->
+            next_term
+        end
+      else
+        next_term
+      end
+
+    next_term
+  end
+
+  defp focused_implicit_id(_term, nil), do: nil
+
+  defp focused_implicit_id(term, focused) do
+    cond do
+      Map.has_key?(term.implicit_state, focused) ->
+        focused
+
+      true ->
+        get_in(term.focus_meta, [focused, :implicit_owner])
+    end
   end
 
   defp notify_invalidate(term) do

--- a/lib/breeze/implicit/async_spinner.ex
+++ b/lib/breeze/implicit/async_spinner.ex
@@ -9,9 +9,16 @@ defmodule Breeze.Implicit.AsyncSpinner do
   def handle_modifiers(:root, _flags, _state), do: []
   def handle_modifiers(:child, _flags, _state), do: []
 
-  def animate(:root, box, _flags, _state, %{frame: frame, pending?: pending?}) do
+  def animate(:root, box, _flags, _state, %{frame: frame, pending?: pending?} = ctx) do
     content = if pending?, do: Enum.at(@frames, rem(frame, length(@frames))), else: "·"
-    %{box | content: content}
+
+    case Map.get(ctx, :layout) do
+      %Breeze.Viewport{left: left, top: top} when pending? ->
+        {:ok, %{box | content: "·"}, overlays: [%{x: left, y: top, content: content}]}
+
+      _ ->
+        %{box | content: content}
+    end
   end
 
   def animate(:child, box, _flags, _state, _ctx), do: box

--- a/lib/breeze/implicit/input.ex
+++ b/lib/breeze/implicit/input.ex
@@ -1,0 +1,244 @@
+defmodule Breeze.Implicit.Input do
+  @moduledoc false
+
+  @type state :: %{
+          optional(:viewport_width) => integer(),
+          value: String.t(),
+          cursor: non_neg_integer()
+        }
+
+  def init(items, last_state), do: init(items, %{}, last_state)
+
+  def init(_items, root_attrs, last_state) do
+    value = Map.get(root_attrs, :"input-value", "")
+    raw_cursor = Map.get(root_attrs, :"input-cursor", max_cursor(value))
+
+    attrs_state = %{
+      value: value,
+      cursor: if(is_binary(raw_cursor), do: String.to_integer(raw_cursor), else: raw_cursor)
+    }
+
+    state = Map.merge(last_state, attrs_state)
+    state = normalize_state(state)
+
+    {:ok, state, rerender_every: 500, active_when_focused: true}
+  end
+
+  @spec handle_event(term(), map(), state()) :: {:noreply, state()} | {{:change, map()}, state()}
+  def handle_event(_, %{"key" => "\x7f"}, %{cursor: 0} = state), do: {:noreply, state}
+
+  def handle_event(_, %{"key" => "\x7f"}, %{cursor: cursor} = state) when cursor > 0 do
+    {before, rest} = split_value(state.value, cursor)
+    value = drop_trailing_grapheme(before) <> rest
+    change(%{state | value: value, cursor: cursor - 1} |> normalize_state())
+  end
+
+  def handle_event(_, %{"key" => "Delete"}, state) do
+    {before, rest} = split_value(state.value, state.cursor)
+
+    if rest != "" do
+      change(%{state | value: before <> drop_leading_grapheme(rest)} |> normalize_state())
+    else
+      {:noreply, state}
+    end
+  end
+
+  def handle_event(_, %{"key" => "ArrowLeft"}, %{cursor: cursor} = state) when cursor > 0 do
+    change(%{state | cursor: cursor - 1} |> normalize_state())
+  end
+
+  def handle_event(_, %{"key" => "ArrowRight"}, state) do
+    if state.cursor < max_cursor(state.value) do
+      change(%{state | cursor: state.cursor + 1} |> normalize_state())
+    else
+      {:noreply, state}
+    end
+  end
+
+  def handle_event(_, %{"key" => "Home"}, %{cursor: 0} = state), do: {:noreply, state}
+
+  def handle_event(_, %{"key" => "Home"}, state),
+    do: change(%{state | cursor: 0} |> normalize_state())
+
+  def handle_event(_, %{"key" => "End"}, state) do
+    end_cursor = max_cursor(state.value)
+
+    if state.cursor == end_cursor,
+      do: {:noreply, state},
+      else: change(%{state | cursor: end_cursor} |> normalize_state())
+  end
+
+  def handle_event(_, %{"key" => key}, state) do
+    if insertable_key?(key) do
+      {before, rest} = split_value(state.value, state.cursor)
+      value = before <> key <> rest
+      change(%{state | value: value, cursor: state.cursor + 1} |> normalize_state())
+    else
+      {:noreply, state}
+    end
+  end
+
+  def handle_modifiers(:root, _flags, _state), do: []
+  def handle_modifiers(:child, _flags, _state), do: []
+
+  def animate(
+        :root,
+        box,
+        _flags,
+        state,
+        %{layout: layout, now: now, last_interaction_at: last_interaction_at}
+      )
+      when is_map(layout) do
+    source = source_content(box.content, state)
+    {content, display_cursor} = render_visible_content(source, state)
+
+    overlay = %{
+      x: layout.left + border_left_offset(box) + display_cursor,
+      y: layout.top + border_top_offset(box),
+      char: cursor_char(content, display_cursor),
+      visible?: Breeze.TerminalOverlay.visible?(now, last_interaction_at)
+    }
+
+    {:ok, %{box | content: content}, overlays: [overlay]}
+  end
+
+  def animate(:root, box, _flags, state, _ctx) do
+    source = source_content(box.content, state)
+    {content, _display_cursor} = render_visible_content(source, state)
+    %{box | content: content}
+  end
+
+  def animate(:child, box, _flags, _state, _ctx), do: box
+
+  def reconcile(%Breeze.Viewport{} = element, state) do
+    Map.put(state, :viewport_width, element.viewport_width || element.width || 0)
+  end
+
+  defp change(state) do
+    {{:change, %{value: state.value, cursor: state.cursor}}, state}
+  end
+
+  defp normalize_state(%{value: value, cursor: cursor} = state) do
+    %{state | cursor: clamp_cursor(cursor, value)}
+  end
+
+  defp clamp_cursor(cursor, value) when is_integer(cursor) do
+    cursor
+    |> max(0)
+    |> min(max_cursor(value))
+  end
+
+  defp clamp_cursor(_cursor, value), do: max_cursor(value)
+
+  defp max_cursor(value), do: max(String.length(value), 1)
+
+  defp split_value(value, cursor) do
+    String.split_at(value, clamp_cursor(cursor, value))
+  end
+
+  defp drop_trailing_grapheme(""), do: ""
+
+  defp drop_trailing_grapheme(value) do
+    graphemes = String.graphemes(value)
+    graphemes |> Enum.drop(-1) |> Enum.join()
+  end
+
+  defp drop_leading_grapheme(""), do: ""
+
+  defp drop_leading_grapheme(value) do
+    value
+    |> String.graphemes()
+    |> tl()
+    |> Enum.join()
+  end
+
+  defp display_cursor_index(content, %{value: value, cursor: cursor}) when is_binary(content) do
+    prefix_len(content, value) + cursor
+  end
+
+  defp cursor_char(content, display_cursor) when is_binary(content) do
+    String.at(content, display_cursor) || " "
+  end
+
+  defp source_content(content, %{value: value}) when is_binary(content) and is_binary(value) do
+    if value == "" or String.contains?(content, value) do
+      content
+    else
+      " " <> value
+    end
+  end
+
+  defp render_visible_content(content, %{viewport_width: width} = state)
+       when is_binary(content) and is_integer(width) and width > 0 do
+    display_cursor = display_cursor_index(content, state)
+    content_length = String.length(content)
+    scrolled? = display_cursor >= width and width > 1
+    visible_width = visible_width(scrolled?, width)
+    scroll_left = scroll_left(display_cursor, visible_width, content_length)
+    visible_cursor = visible_cursor_index(display_cursor, scroll_left, width, scrolled?)
+
+    {slice_graphemes(content, scroll_left, visible_width, width), visible_cursor}
+  end
+
+  defp render_visible_content(content, state) when is_binary(content) do
+    {content, display_cursor_index(content, state)}
+  end
+
+  defp visible_width(true, width) when width > 1 do
+    width - 1
+  end
+
+  defp visible_width(_scrolled?, width), do: width
+
+  defp scroll_left(display_cursor, width, content_length)
+       when display_cursor >= content_length and content_length >= width do
+    max(content_length - width, 0)
+  end
+
+  defp scroll_left(display_cursor, width, _content_length) when display_cursor >= width do
+    display_cursor - (width - 1)
+  end
+
+  defp scroll_left(_display_cursor, _width, _content_length), do: 0
+
+  defp visible_cursor_index(_display_cursor, _scroll_left, width, true) do
+    max(width - 1, 0)
+  end
+
+  defp visible_cursor_index(display_cursor, scroll_left, width, false) do
+    min(max(display_cursor - scroll_left, 0), max(width - 1, 0))
+  end
+
+  defp prefix_len(content, value) when is_binary(content) and is_binary(value) do
+    cond do
+      value == "" and String.starts_with?(content, " ") ->
+        1
+
+      value == "" ->
+        0
+
+      true ->
+        case String.split(content, value, parts: 2) do
+          [prefix, _suffix] -> String.length(prefix)
+          _ -> 0
+        end
+    end
+  end
+
+  defp slice_graphemes(content, start, visible_width, total_width) do
+    content
+    |> String.graphemes()
+    |> Enum.slice(start, visible_width)
+    |> Enum.join()
+    |> String.pad_trailing(total_width)
+  end
+
+  defp insertable_key?(key) when is_binary(key) do
+    String.length(key) == 1 and
+      String.printable?(key) and
+      key not in ["\n", "\r", "\t", "\v", "\f"]
+  end
+
+  defp border_left_offset(%{style: %{border: border}}), do: if(border.left, do: 1, else: 0)
+  defp border_top_offset(%{style: %{border: border}}), do: if(border.top, do: 1, else: 0)
+end

--- a/lib/breeze/implicit/modal.ex
+++ b/lib/breeze/implicit/modal.ex
@@ -36,7 +36,9 @@ defmodule Breeze.Implicit.Modal do
     [style: "absolute left-#{state.left} top-#{state.top}"]
   end
 
-  def handle_modifiers(:child, _flags, _state), do: []
+  def handle_modifiers(:child, _flags, _state) do
+    []
+  end
 
   defp dimension(attrs, key, fallback) do
     case Map.get(attrs, key, fallback) do

--- a/lib/breeze/key_decoder.ex
+++ b/lib/breeze/key_decoder.ex
@@ -1,0 +1,51 @@
+defmodule Breeze.KeyDecoder do
+  @moduledoc false
+
+  def decode("\e"), do: "Escape"
+  def decode("\r"), do: "Enter"
+
+  def decode(raw_key) do
+    cond do
+      String.starts_with?(raw_key, "\eO") ->
+        raw_key
+        |> String.trim_leading("\eO")
+        |> convert_ss3()
+
+      String.starts_with?(raw_key, Termite.Screen.escape_code()) ->
+        raw_key
+        |> String.trim_leading(Termite.Screen.escape_code())
+        |> convert_csi()
+
+      true ->
+        raw_key
+    end
+  end
+
+  defp convert_ss3("P"), do: "F1"
+  defp convert_ss3("Q"), do: "F2"
+  defp convert_ss3("R"), do: "F3"
+  defp convert_ss3("S"), do: "F4"
+  defp convert_ss3(key), do: key
+
+  defp convert_csi("[A"), do: "F1"
+  defp convert_csi("[B"), do: "F2"
+  defp convert_csi("[C"), do: "F3"
+  defp convert_csi("[D"), do: "F4"
+  defp convert_csi("11~"), do: "F1"
+  defp convert_csi("12~"), do: "F2"
+  defp convert_csi("13~"), do: "F3"
+  defp convert_csi("14~"), do: "F4"
+  defp convert_csi("A"), do: "ArrowUp"
+  defp convert_csi("B"), do: "ArrowDown"
+  defp convert_csi("C"), do: "ArrowRight"
+  defp convert_csi("D"), do: "ArrowLeft"
+  defp convert_csi("Z"), do: "ShiftTab"
+  defp convert_csi("H"), do: "Home"
+  defp convert_csi("F"), do: "End"
+  defp convert_csi("1~"), do: "Home"
+  defp convert_csi("3~"), do: "Delete"
+  defp convert_csi("4~"), do: "End"
+  defp convert_csi("5~"), do: "PageUp"
+  defp convert_csi("6~"), do: "PageDown"
+  defp convert_csi(key), do: key
+end

--- a/lib/breeze/render_state.ex
+++ b/lib/breeze/render_state.ex
@@ -227,6 +227,10 @@ defmodule Breeze.RenderState do
     {implicit_state, Map.new(implicit_meta)}
   end
 
+  defp normalize_init_result({:ok, implicit_state}) do
+    {implicit_state, %{}}
+  end
+
   defp normalize_init_result(implicit_state) do
     {implicit_state, %{}}
   end

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -167,7 +167,10 @@ defmodule Breeze.Renderer do
 
     box =
       if implicit && function_exported?(implicit_mod, :animate, 5) do
-        implicit_mod.animate(type, box, flags, implicit, animation_ctx(opts, id, focused))
+        implicit_mod
+        |> apply(:animate, [type, box, flags, implicit, animation_ctx(opts, id, focused)])
+        |> normalize_animation_result()
+        |> elem(0)
       else
         box
       end
@@ -272,6 +275,10 @@ defmodule Breeze.Renderer do
         focusables: Enum.reverse(child_acc.focusables) ++ acc.focusables
     }
   end
+
+  defp normalize_animation_result({:ok, %Box{} = box, _opts}), do: {box, %{}}
+  defp normalize_animation_result({:ok, %Box{} = box}), do: {box, %{}}
+  defp normalize_animation_result(%Box{} = box), do: {box, %{}}
 
   defp namespace_live_acc(acc, prefix) do
     acc
@@ -410,6 +417,10 @@ defmodule Breeze.Renderer do
       end
 
     {style, Map.put(attrs, :display, %{display | rows: String.to_integer(num)})}
+  end
+
+  defp apply_style("layer-" <> num, {style, attrs}) do
+    {style, Map.put(attrs, :layer, String.to_integer(num))}
   end
 
   defp apply_style("overflow-scroll", {style, attrs}),

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -47,6 +47,7 @@ defmodule Breeze.Server do
     children: %{},
     animation_timer: nil,
     next_tick_at: nil,
+    global_keybindings: [],
     hide_cursor?: true,
     busy_delay_ms: 120,
     frame_delay_ms: 80
@@ -124,6 +125,7 @@ defmodule Breeze.Server do
       reader: terminal.reader,
       view_pid: view_pid,
       focused: focused,
+      global_keybindings: Keyword.get(opts, :global_keybindings, []),
       hide_cursor?: hide_cursor?,
       busy_delay_ms: Keyword.get(opts, :busy_delay_ms, 120),
       frame_delay_ms: frame_delay_ms,
@@ -139,7 +141,20 @@ defmodule Breeze.Server do
   @impl true
   def handle_info({reader, {:data, data}}, %{reader: reader} = state) do
     {:key, key} = decode_input(data)
-    {:noreply, handle_key(key, state)}
+
+    cond do
+      stop_global_key?(key, state) ->
+        stop(state)
+
+      sync_input?(state, key) ->
+        case process_input_batch(reader, data, state) do
+          {:stop, state} -> stop(state)
+          {:noreply, state} -> {:noreply, maybe_render_base(state)}
+        end
+
+      true ->
+        {:noreply, start_async_input(key, state)}
+    end
   end
 
   def handle_info({reader, {:signal, :winch}}, %{reader: reader} = state) do
@@ -229,34 +244,100 @@ defmodule Breeze.Server do
     end
   end
 
-  defp handle_key("q", state), do: stop(state)
+  defp process_input_batch(reader, data, state) do
+    case handle_key(data, state) do
+      {:stop, state} ->
+        {:stop, state}
 
-  defp handle_key(_key, %{pending_ref: ref} = state) when not is_nil(ref), do: state
-
-  defp handle_key(key, state) when key in ["\t", "ShiftTab"] do
-    ref = make_ref()
-    session = self()
-
-    Task.start(fn ->
-      reply = Breeze.ChildServer.dispatch_input(state.view_pid, key)
-      send(session, {:event_reply, ref, reply})
-    end)
-
-    state
-    |> Map.put(:pending_ref, ref)
-    |> Map.put(:pending_started_at, System.monotonic_time(:millisecond))
-    |> Map.put(:last_interaction_at, System.monotonic_time(:millisecond))
-    |> render_frame()
-    |> schedule_animation()
+      {:noreply, state} ->
+        drain_input_batch(reader, state)
+    end
   end
 
-  defp handle_key(key, state) do
+  defp drain_input_batch(reader, state) do
+    receive do
+      {^reader, {:data, data}} ->
+        process_input_batch(reader, data, state)
+    after
+      0 -> {:noreply, state}
+    end
+  end
+
+  defp handle_key(raw_key, state) do
+    {:key, key} = decode_input(raw_key)
+
+    case key do
+      key when key in ["\t", "ShiftTab"] ->
+        state
+        |> touch_interaction()
+        |> apply_input_reply(Breeze.ChildServer.dispatch_input(state.view_pid, key))
+
+      key ->
+        state
+        |> touch_interaction()
+        |> apply_input_reply(dispatch_input_hierarchy(state, key))
+    end
+  end
+
+  defp apply_input_reply(state, reply) do
+    case reply do
+      {:stop, _focused} ->
+        {:stop, state}
+
+      {:stop, _focused, _consumed} ->
+        {:stop, state}
+
+      {:noreply, focused} ->
+        {:noreply, Map.put(state, :focused, focused)}
+
+      {:noreply, focused, _consumed} ->
+        {:noreply, Map.put(state, :focused, focused)}
+    end
+  end
+
+  defp touch_interaction(state) do
+    %{state | last_interaction_at: System.monotonic_time(:millisecond)}
+  end
+
+  defp sync_input?(state, key) do
+    key in ["\t", "ShiftTab"] or focused_implicit?(state)
+  end
+
+  defp stop_global_key?(key, state) do
+    event = %{"key" => key}
+
+    Enum.any?(state.global_keybindings, fn
+      {^key, fun} when is_function(fun, 2) ->
+        match?({:stop, _}, fun.(event, state))
+
+      _ ->
+        false
+    end)
+  end
+
+  defp focused_implicit?(%{focused: nil}), do: false
+
+  defp focused_implicit?(state) do
+    case focused_child_chain(state) do
+      [{_child_id, %{pid: pid}} | _] ->
+        match?(%{focused_implicit_id: id} when not is_nil(id), Breeze.ChildServer.metadata(pid))
+
+      [] ->
+        match?(
+          %{focused_implicit_id: id} when not is_nil(id),
+          Breeze.ChildServer.metadata(state.view_pid)
+        )
+    end
+  end
+
+  defp start_async_input(_key, %{pending_ref: ref} = state) when not is_nil(ref), do: state
+
+  defp start_async_input(key, state) do
     ref = make_ref()
     session = self()
 
     Task.start(fn ->
       reply = dispatch_input_hierarchy(state, key)
-
       send(session, {:event_reply, ref, reply})
     end)
 
@@ -299,10 +380,12 @@ defmodule Breeze.Server do
 
         true ->
           decorations = decorations ++ child_decorations
+          state = %{state | focused: focused}
+          {base_output, decorations} = prepare_decorations(box.content, decorations, state)
 
           state
-          |> Map.put(:base_output, box.content)
-          |> Map.put(:decorations, initialize_decorations(decorations))
+          |> Map.put(:base_output, base_output)
+          |> Map.put(:decorations, decorations)
           |> Map.put(:focused, focused)
           |> Map.put(:last_render_at, System.monotonic_time(:millisecond))
           |> render_frame()
@@ -355,13 +438,17 @@ defmodule Breeze.Server do
   end
 
   defp render_frame(state) do
-    output = apply_decorations(state.base_output, state.decorations, state)
+    {output, decorations} = apply_decorations(state.base_output, state.decorations, state)
+    output = strip_private_use_chars(output)
+    overlays = terminal_overlays(decorations, state)
+
     screen_height = state.terminal.size.height
     output_lines = length(String.split(output, "\n"))
     trailing = String.duplicate("\n\e[K", max(screen_height - output_lines, 0))
     output = "\e[K" <> String.replace(output, "\n", "\n\e[K") <> trailing
     terminal = Termite.Terminal.write(state.terminal, "\e[H" <> output)
-    %{state | terminal: terminal}
+    terminal = Breeze.TerminalOverlay.write_overlays(terminal, overlays)
+    %{state | terminal: terminal, decorations: decorations}
   end
 
   defp initialize_decorations(decorations) do
@@ -370,6 +457,26 @@ defmodule Breeze.Server do
       |> Map.put_new(:frame_index, 0)
       |> Map.put_new(:every_ms, 500)
     end)
+  end
+
+  defp prepare_decorations(output, decorations, state) do
+    decorations
+    |> initialize_decorations()
+    |> Enum.reduce({output, []}, fn decoration, {acc, updated} ->
+      {_animated_box, current_content, current_overlays} = render_decoration(decoration, state)
+
+      # TODO: Replace async decoration content by box coordinates instead of substring matching.
+      {
+        String.replace(acc, decoration.box.content, current_content, global: false),
+        [
+          decoration
+          |> Map.put(:current_content, current_content)
+          |> Map.put(:current_overlays, current_overlays)
+          | updated
+        ]
+      }
+    end)
+    |> then(fn {prepared_output, updated} -> {prepared_output, Enum.reverse(updated)} end)
   end
 
   defp advance_decorations(state) do
@@ -385,27 +492,63 @@ defmodule Breeze.Server do
   end
 
   defp apply_decorations(output, decorations, state) do
-    Enum.reduce(decorations, output, fn decoration, acc ->
+    Enum.reduce(decorations, {output, []}, fn decoration, {acc, updated} ->
       if decoration_active?(decoration, state) do
-        ctx = %{
-          phase: :async,
-          frame: decoration.frame_index,
-          now: System.monotonic_time(:millisecond),
-          pending?: pending_active?(state),
-          focused?: decoration.id == state.focused,
-          last_render_at: state.last_render_at,
-          last_interaction_at: state.last_interaction_at
-        }
-
-        animated_box =
-          decoration.mod.animate(:root, decoration.box, decoration.flags, decoration.state, ctx)
+        {_animated_box, current_content, current_overlays} = render_decoration(decoration, state)
 
         # TODO: Replace async decoration content by box coordinates instead of substring matching.
-        String.replace(acc, decoration.box.content, animated_box.content, global: false)
+        {
+          String.replace(acc, decoration.current_content, current_content, global: false),
+          [
+            decoration
+            |> Map.put(:current_content, current_content)
+            |> Map.put(:current_overlays, current_overlays)
+            | updated
+          ]
+        }
       else
-        acc
+        {acc, [decoration | updated]}
       end
     end)
+    |> then(fn {final_output, updated} -> {final_output, Enum.reverse(updated)} end)
+  end
+
+  defp render_decoration(decoration, state) do
+    now = System.monotonic_time(:millisecond)
+
+    ctx = decoration_ctx(decoration, state, now)
+
+    {animated_box, animate_opts} =
+      if function_exported?(decoration.mod, :animate, 5) do
+        decoration.mod
+        |> apply(:animate, [:root, decoration.box, decoration.flags, decoration.state, ctx])
+        |> normalize_animation_result()
+      else
+        {decoration.box, %{}}
+      end
+
+    {animated_box, animated_box.content, Map.get(animate_opts, :overlays, [])}
+  end
+
+  defp decoration_ctx(decoration, state, now) do
+    %{
+      phase: :async,
+      frame: decoration.frame_index,
+      now: now,
+      pending?: pending_active?(state),
+      focused?: (decoration[:owner_id] || decoration.id) == state.focused,
+      last_render_at: state.last_render_at,
+      last_interaction_at: state.last_interaction_at,
+      id: decoration.id,
+      layout: decoration[:layout]
+    }
+  end
+
+  defp strip_private_use_chars(output) do
+    output
+    |> String.to_charlist()
+    |> Enum.reject(&(&1 in 0xE000..0xF8FF))
+    |> List.to_string()
   end
 
   defp schedule_animation(%{decorations: []} = state), do: state
@@ -444,9 +587,14 @@ defmodule Breeze.Server do
 
   defp decoration_active?(decoration, state) do
     cond do
-      decoration[:active_when_pending] -> pending_active?(state)
-      decoration[:active_when_focused] -> decoration[:owner_id] == state.focused
-      true -> true
+      decoration[:active_when_pending] ->
+        pending_active?(state)
+
+      decoration[:active_when_focused] ->
+        (decoration[:owner_id] || decoration[:id]) == state.focused
+
+      true ->
+        true
     end
   end
 
@@ -485,6 +633,25 @@ defmodule Breeze.Server do
 
   defp remaining_busy_delay(_state), do: nil
 
+  defp terminal_overlays(decorations, state) do
+    decorations
+    |> Enum.filter(&decoration_active?(&1, state))
+    |> Enum.flat_map(&Map.get(&1, :current_overlays, []))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp normalize_animation_result({:ok, %BackBreeze.Box{} = box, opts}) when is_list(opts) do
+    {box, Map.new(opts)}
+  end
+
+  defp normalize_animation_result({:ok, %BackBreeze.Box{} = box}) do
+    {box, %{}}
+  end
+
+  defp normalize_animation_result(%BackBreeze.Box{} = box) do
+    {box, %{}}
+  end
+
   defp stop(state) do
     if Process.alive?(state.view_pid) do
       Process.exit(state.view_pid, :normal)
@@ -500,47 +667,7 @@ defmodule Breeze.Server do
     System.halt()
   end
 
-  defp decode_input("\e"), do: {:key, "Escape"}
-  defp decode_input("\r"), do: {:key, "Enter"}
-
-  defp decode_input(raw_key) do
-    key =
-      cond do
-        String.starts_with?(raw_key, "\eO") ->
-          convert_key_o(String.trim_leading(raw_key, "\eO"))
-
-        String.starts_with?(raw_key, Termite.Screen.escape_code()) ->
-          convert_key(String.trim_leading(raw_key, Termite.Screen.escape_code()))
-
-        true ->
-          raw_key
-      end
-
-    {:key, key}
-  end
-
-  defp convert_key_o("P"), do: "F1"
-  defp convert_key_o("Q"), do: "F2"
-  defp convert_key_o("R"), do: "F3"
-  defp convert_key_o("S"), do: "F4"
-  defp convert_key_o(key), do: key
-
-  defp convert_key("11~"), do: "F1"
-  defp convert_key("12~"), do: "F2"
-  defp convert_key("13~"), do: "F3"
-  defp convert_key("14~"), do: "F4"
-  defp convert_key("A"), do: "ArrowUp"
-  defp convert_key("B"), do: "ArrowDown"
-  defp convert_key("C"), do: "ArrowRight"
-  defp convert_key("D"), do: "ArrowLeft"
-  defp convert_key("Z"), do: "ShiftTab"
-  defp convert_key("H"), do: "Home"
-  defp convert_key("F"), do: "End"
-  defp convert_key("1~"), do: "Home"
-  defp convert_key("4~"), do: "End"
-  defp convert_key("5~"), do: "PageUp"
-  defp convert_key("6~"), do: "PageDown"
-  defp convert_key(key), do: key
+  defp decode_input(raw_key), do: {:key, Breeze.KeyDecoder.decode(raw_key)}
 
   defp ensure_children(state, missing) do
     Enum.reduce(missing, {state, false}, fn {id, attrs}, {state, started?} ->

--- a/lib/breeze/terminal_overlay.ex
+++ b/lib/breeze/terminal_overlay.ex
@@ -1,0 +1,58 @@
+defmodule Breeze.TerminalOverlay do
+  @moduledoc false
+  @blink_interval_ms 500
+  @recent_interaction_ms @blink_interval_ms * 2
+
+  def write_overlays(terminal, overlays) when is_list(overlays) do
+    Enum.reduce(overlays, terminal, &write_overlay(&2, &1))
+  end
+
+  def write_overlay(terminal, nil), do: terminal
+
+  def write_overlay(terminal, %{visible?: false}), do: terminal
+
+  def write_overlay(terminal, %{x: x, y: y, content: content}) when is_binary(content) do
+    terminal
+    |> Termite.Screen.cursor_position(x + 1, y + 1)
+    |> Termite.Terminal.write(content)
+    |> Termite.Screen.cursor_position(x + 1, y + 1)
+  end
+
+  def write_overlay(terminal, %{x: x, y: y, char: char}) do
+    content = cursor_open_code() <> char <> Termite.Style.reset_code()
+
+    terminal
+    |> Termite.Screen.cursor_position(x + 1, y + 1)
+    |> Termite.Terminal.write(content)
+    |> Termite.Screen.cursor_position(x + 1, y + 1)
+  end
+
+  def visible?(now_ms, last_interaction_at) when is_integer(now_ms) do
+    recent_interaction?(now_ms, last_interaction_at) or blink_visible?(now_ms)
+  end
+
+  def blink_visible?(now_ms) when is_integer(now_ms) do
+    rem(div(now_ms, @blink_interval_ms), 2) == 0
+  end
+
+  def next_blink_delay(now_ms) when is_integer(now_ms) do
+    case rem(now_ms, @blink_interval_ms) do
+      0 -> @blink_interval_ms
+      rem_ms -> @blink_interval_ms - rem_ms
+    end
+  end
+
+  defp recent_interaction?(now_ms, last_interaction_at)
+       when is_integer(now_ms) and is_integer(last_interaction_at) do
+    now_ms - last_interaction_at < @recent_interaction_ms
+  end
+
+  defp recent_interaction?(_now_ms, _last_interaction_at), do: false
+
+  defp cursor_open_code do
+    Termite.Style.ansi256()
+    |> Termite.Style.foreground(0)
+    |> Termite.Style.background(11)
+    |> Termite.Style.open_code()
+  end
+end

--- a/lib/breeze/viewport.ex
+++ b/lib/breeze/viewport.ex
@@ -7,6 +7,8 @@ defmodule Breeze.Viewport do
   """
 
   @type t :: %__MODULE__{
+          left: integer(),
+          top: integer(),
           width: non_neg_integer() | nil,
           height: non_neg_integer(),
           viewport_width: non_neg_integer() | nil,
@@ -15,7 +17,9 @@ defmodule Breeze.Viewport do
           content_height: non_neg_integer()
         }
 
-  defstruct width: nil,
+  defstruct left: 0,
+            top: 0,
+            width: nil,
             height: 0,
             viewport_width: nil,
             viewport_height: 0,
@@ -50,6 +54,8 @@ defmodule Breeze.Viewport do
       |> normalize_int(height)
 
     %__MODULE__{
+      left: normalize_signed_int(Map.get(dimensions, :left)),
+      top: normalize_signed_int(Map.get(dimensions, :top)),
       width: width,
       height: height,
       viewport_width: viewport_width,
@@ -130,6 +136,10 @@ defmodule Breeze.Viewport do
   defp normalize_optional_int(value, _fallback) when is_integer(value), do: max(value, 0)
   defp normalize_optional_int(nil, fallback), do: fallback
   defp normalize_optional_int(_value, fallback), do: fallback
+
+  defp normalize_signed_int(value, fallback \\ 0)
+  defp normalize_signed_int(value, _fallback) when is_integer(value), do: value
+  defp normalize_signed_int(_value, fallback), do: fallback
 
   defp clamp(value, min_value, max_value) do
     value

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
-  "back_breeze": {:git, "https://github.com/Gazler/back_breeze.git", "772ffecf0c2c5da78421669da925e5b8a28c0a93", []},
+  "back_breeze": {:git, "https://github.com/Gazler/back_breeze.git", "1ec69189451a3dde4c5e06bc4f4b64473853b30e", []},
   "earmark_parser": {:hex, :earmark_parser, "1.4.41", "ab34711c9dc6212dda44fcd20ecb87ac3f3fce6f0ca2f28d4a00e4154f8cd599", [:mix], [], "hexpm", "a81a04c7e34b6617c2792e291b5a2e57ab316365c2644ddc553bb9ed863ebefa"},
   "ex_doc": {:hex, :ex_doc, "0.34.2", "13eedf3844ccdce25cfd837b99bea9ad92c4e511233199440488d217c92571e8", [:mix], [{:earmark_parser, "~> 1.4.39", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_c, ">= 0.1.0", [hex: :makeup_c, repo: "hexpm", optional: true]}, {:makeup_elixir, "~> 0.14 or ~> 1.0", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1 or ~> 1.0", [hex: :makeup_erlang, repo: "hexpm", optional: false]}, {:makeup_html, ">= 0.1.0", [hex: :makeup_html, repo: "hexpm", optional: true]}], "hexpm", "5ce5f16b41208a50106afed3de6a2ed34f4acfd65715b82a0b84b49d995f95c1"},
   "makeup": {:hex, :makeup, "1.1.2", "9ba8837913bdf757787e71c1581c21f9d2455f4dd04cfca785c70bbfff1a76a3", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cce1566b81fbcbd21eca8ffe808f33b221f9eee2cbc7a1706fc3da9ff18e6cac"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.2", "627e84b8e8bf22e60a2579dad15067c755531fea049ae26ef1020cad58fe9578", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "41193978704763f6bbe6cc2758b84909e62984c7752b3784bd3c218bb341706b"},
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.1", "c7f58c120b2b5aa5fd80d540a89fdf866ed42f1f3994e4fe189abebeab610839", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "8a89a1eeccc2d798d6ea15496a6e4870b75e014d1af514b1b71fa33134f57814"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
-  "termite": {:git, "https://github.com/Gazler/termite.git", "6431dc54c8cdeb97b012a7b8e16b9d7116673d08", []},
+  "termite": {:git, "https://github.com/Gazler/termite.git", "0144fa75b1db476d395394129f1d9f98f6644684", []},
 }

--- a/test/breeze/child_server_event_test.exs
+++ b/test/breeze/child_server_event_test.exs
@@ -35,6 +35,33 @@ defmodule Breeze.ChildServerEventTest do
     def handle_info(_, term), do: {:noreply, term}
   end
 
+  defmodule RootOnlyModalView do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def mount(_opts, term) do
+      {:ok, assign(term, show_modal: true, closed?: false)}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <box style="width-screen height-screen">
+        <.modal :if={@show_modal} id="root-only-modal" width={30} height={6} br-change="close_modal">
+          <:title>Modal</:title>
+          <box>No focusable children</box>
+        </.modal>
+      </box>
+      """
+    end
+
+    def handle_event("close_modal", _event, term) do
+      {:noreply, assign(term, show_modal: false, closed?: true)}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
   test "escape on a focused modal child routes to the modal implicit" do
     terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
     {:ok, pid} = Breeze.ChildServer.start(view: ModalView, terminal: terminal)
@@ -47,6 +74,21 @@ defmodule Breeze.ChildServerEventTest do
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
     state = :sys.get_state(pid)
 
+    assert state.assigns.closed? == true
+    assert state.assigns.show_modal == false
+  end
+
+  test "escape closes a modal with no focusable children by focusing the modal root" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+    {:ok, pid} = Breeze.ChildServer.start(view: RootOnlyModalView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
+    assert %{focused: "root-only-modal"} = Breeze.ChildServer.metadata(pid)
+
+    assert {:noreply, "root-only-modal", true} =
+             Breeze.ChildServer.dispatch_input(pid, "Escape")
+
+    state = :sys.get_state(pid)
     assert state.assigns.closed? == true
     assert state.assigns.show_modal == false
   end

--- a/test/breeze/implicit/input_test.exs
+++ b/test/breeze/implicit/input_test.exs
@@ -1,0 +1,360 @@
+defmodule Breeze.Implicit.InputTest do
+  use ExUnit.Case, async: true
+
+  alias BackBreeze.Box
+  alias Breeze.ChildServer
+  alias Breeze.Implicit.Input
+
+  defmodule InputView do
+    use Breeze.View
+
+    def mount(_opts, term), do: {:ok, term}
+
+    def render(assigns) do
+      ~H"""
+      <box
+        id="url"
+        implicit={Breeze.Implicit.Input}
+        input-value="https://jsonplaceholder.typicode.com/posts"
+        input-cursor="42"
+      >
+        {@input_value}
+      </box>
+      """
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule NestedInputView do
+    use Breeze.View
+
+    def mount(_opts, term), do: {:ok, term |> Breeze.View.focus("url")}
+
+    def render(assigns) do
+      ~H"""
+      <box style="border">
+        <box style="border">
+          <box id="url" implicit={Breeze.Implicit.Input} input-value="hello" input-cursor="2" focusable>
+            hello
+          </box>
+        </box>
+      </box>
+      """
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule OverflowInputView do
+    use Breeze.View
+
+    @website "https://jsonplaceholder.typicode.com/posts/123/comments?include=author,history"
+
+    def mount(_opts, term) do
+      {:ok,
+       term
+       |> Breeze.View.focus("website")
+       |> Breeze.View.assign(
+         website: @website,
+         website_cursor: String.length(@website)
+       )}
+    end
+
+    def render(assigns) do
+      assigns =
+        Breeze.View.assign(assigns,
+          website_display: " " <> assigns.website,
+          website_cursor_text: Integer.to_string(assigns.website_cursor)
+        )
+
+      ~H"""
+      <box style="width-40">
+        <box style="inline height-1 width-full">
+          <box
+            id="website"
+            implicit={Breeze.Implicit.Input}
+            input-value={@website}
+            input-cursor={@website_cursor}
+            focusable
+            br-change="website_changed"
+            style="width-24 focus:inverse"
+          >
+            {@website_display}
+          </box>
+          <box style="width-4">{@website_cursor_text}</box>
+        </box>
+      </box>
+      """
+    end
+
+    def handle_event("website_changed", %{value: value, cursor: cursor}, term) do
+      {:noreply, Breeze.View.assign(term, website: value, website_cursor: cursor)}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
+  test "init returns normalized state and cursor animation metadata" do
+    assert {:ok, %{cursor: 1, value: ""}, rerender_every: 500, active_when_focused: true} =
+             Input.init([], %{id: "input"}, %{})
+  end
+
+  test "backspace clamps an out-of-range cursor" do
+    state = %{value: "", cursor: 1}
+
+    assert {{:change, %{value: "", cursor: 0}}, %{value: "", cursor: 0}} =
+             Input.handle_event(nil, %{"key" => "ArrowLeft"}, state)
+
+    assert {:noreply, %{value: "", cursor: 0}} =
+             Input.handle_event(nil, %{"key" => "\x7f"}, %{value: "", cursor: 0})
+
+    assert {:ok, %{value: "", cursor: 1}, rerender_every: 500, active_when_focused: true} =
+             Input.init([], %{:"input-value" => "", :"input-cursor" => 4}, %{})
+  end
+
+  test "init prefers input attrs over previous implicit state" do
+    assert {:ok, %{value: "", cursor: 0}, rerender_every: 500, active_when_focused: true} =
+             Input.init([], %{:"input-value" => "", :"input-cursor" => 0}, %{
+               value: "stale",
+               cursor: 5
+             })
+  end
+
+  test "animate leaves focused content untouched" do
+    assert %Box{content: "hello"} =
+             Input.animate(
+               :root,
+               %Box{content: "hello"},
+               [focused: true],
+               %{value: "hello", cursor: 2},
+               %{}
+             )
+  end
+
+  test "animate can return geometry-aware overlay data" do
+    box = %Box{style: %BackBreeze.Style{border: BackBreeze.Border.line()}}
+
+    assert {:ok, %Box{content: " hello"}, overlays: [%{x: 15, y: 5, char: " ", visible?: true}]} =
+             Input.animate(:root, box, [focused: true], %{value: "hello", cursor: 7}, %{
+               layout: %{left: 6, top: 4},
+               now: 0,
+               last_interaction_at: nil
+             })
+  end
+
+  test "animate keeps the overlay visible right after interaction" do
+    box = %Box{content: "hello", style: %BackBreeze.Style{border: BackBreeze.Border.line()}}
+
+    assert {:ok, %Box{}, overlays: [%{visible?: true}]} =
+             Input.animate(:root, box, [focused: true], %{value: "hello", cursor: 5}, %{
+               layout: %{left: 6, top: 4},
+               now: 500,
+               last_interaction_at: 1
+             })
+  end
+
+  test "animate scrolls overflowing content and pins the cursor to the edge" do
+    box = %Box{
+      content: " hello world",
+      style: %BackBreeze.Style{border: BackBreeze.Border.line()}
+    }
+
+    assert {:ok, %Box{content: "world "}, overlays: [%{x: 12, y: 5, char: " ", visible?: true}]} =
+             Input.animate(
+               :root,
+               box,
+               [focused: true],
+               %{value: "hello world", cursor: 11, viewport_width: 6},
+               %{
+                 layout: %{left: 6, top: 4},
+                 now: 0,
+                 last_interaction_at: nil
+               }
+             )
+  end
+
+  test "animate keeps overflow content stable during async overlay passes" do
+    box = %Box{
+      content: "istory                  ",
+      style: %BackBreeze.Style{border: BackBreeze.Border.line()}
+    }
+
+    assert {:ok, %Box{content: "?include=author,history "},
+            overlays: [%{x: 30, y: 5, char: " ", visible?: true}]} =
+             Input.animate(
+               :root,
+               box,
+               [focused: true],
+               %{
+                 value:
+                   "https://jsonplaceholder.typicode.com/posts/123/comments?include=author,history",
+                 cursor: 78,
+                 viewport_width: 24
+               },
+               %{
+                 layout: %{left: 6, top: 4},
+                 now: 0,
+                 last_interaction_at: nil
+               }
+             )
+  end
+
+  test "arrow right and end stop at the end of the input value" do
+    assert {:noreply, %{value: "hello", cursor: 5}} =
+             Input.handle_event(nil, %{"key" => "ArrowRight"}, %{value: "hello", cursor: 5})
+
+    assert {{:change, %{value: "hello", cursor: 5}}, %{value: "hello", cursor: 5}} =
+             Input.handle_event(nil, %{"key" => "End"}, %{value: "hello", cursor: 2})
+  end
+
+  test "control-newline keys are ignored" do
+    assert {:noreply, %{value: "hello", cursor: 2}} =
+             Input.handle_event(nil, %{"key" => "\n"}, %{value: "hello", cursor: 2})
+  end
+
+  test "delete removes the grapheme under the cursor" do
+    assert {{:change, %{value: "helo", cursor: 2}}, %{value: "helo", cursor: 2}} =
+             Input.handle_event(nil, %{"key" => "Delete"}, %{value: "hello", cursor: 2})
+  end
+
+  test "animate leaves unfocused content untouched" do
+    assert %Box{content: "hello"} =
+             Input.animate(:root, %Box{content: "hello"}, [], %{value: "hello", cursor: 2}, %{})
+  end
+
+  test "child server accepts implicits that return {:ok, state}" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+    {:ok, pid} = ChildServer.start(view: InputView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = ChildServer.render(pid, terminal: terminal)
+
+    assert %Breeze.Term{
+             implicit_state: %{
+               "url" => {Breeze.Implicit.Input, %{value: value, cursor: 42}}
+             }
+           } = :sys.get_state(pid)
+
+    assert value == "https://jsonplaceholder.typicode.com/posts"
+  end
+
+  test "nested input layout stores screen-relative coordinates" do
+    terminal = %Termite.Terminal{size: %{width: 40, height: 10}}
+    {:ok, pid} = ChildServer.start(view: NestedInputView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = ChildServer.render(pid, terminal: terminal)
+
+    assert %Breeze.Term{
+             elements: %{
+               "url" => %Breeze.Viewport{left: 2, top: 2}
+             }
+           } = :sys.get_state(pid)
+  end
+
+  test "child server renders a fixed-width input with a scrolled visible slice" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+    {:ok, pid} = ChildServer.start(view: OverflowInputView, terminal: terminal)
+
+    assert {:ok, _acc, box} = ChildServer.render(pid, terminal: terminal)
+
+    assert %Breeze.Term{
+             implicit_state: %{
+               "website" => {Breeze.Implicit.Input, %{viewport_width: 24}}
+             }
+           } = :sys.get_state(pid)
+
+    assert box.content =~ "?include=author,history "
+    refute box.content =~ "https://jsonplaceholder.typicode.com/posts"
+  end
+
+  test "child server keeps the cursor pinned when typing at the overflow edge" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+    {:ok, pid} = ChildServer.start(view: OverflowInputView, terminal: terminal)
+
+    assert {:ok, _acc, initial_box} = ChildServer.render(pid, terminal: terminal)
+    assert initial_box.content =~ "?include=author,history "
+
+    assert {:noreply, "website", true} = ChildServer.dispatch_input(pid, "!")
+
+    assert %Breeze.Term{
+             implicit_state: %{
+               "website" => {Breeze.Implicit.Input, %{value: value, cursor: 79}}
+             }
+           } = :sys.get_state(pid)
+
+    assert String.ends_with?(value, "history!")
+
+    assert {:ok, _acc, next_box} = ChildServer.render(pid, terminal: terminal)
+
+    assert next_box.content =~ "include=author,history! "
+    refute next_box.content =~ "comments?include=author,history"
+  end
+
+  test "child server scrolls back left after backspace from the overflow edge" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+    {:ok, pid} = ChildServer.start(view: OverflowInputView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = ChildServer.render(pid, terminal: terminal)
+    assert {:noreply, "website", true} = ChildServer.dispatch_input(pid, "!")
+
+    assert {:noreply, "website", true} = ChildServer.dispatch_input(pid, "\x7f")
+
+    assert %Breeze.Term{
+             implicit_state: %{
+               "website" => {Breeze.Implicit.Input, %{value: value, cursor: 78}}
+             }
+           } = :sys.get_state(pid)
+
+    assert String.ends_with?(value, "history")
+
+    assert {:ok, _acc, box} = ChildServer.render(pid, terminal: terminal)
+
+    assert box.content =~ "?include=author,history "
+    refute box.content =~ "include=author,history!"
+  end
+
+  test "child server reveals earlier content when moving left out of the overflow edge" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+    {:ok, pid} = ChildServer.start(view: OverflowInputView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = ChildServer.render(pid, terminal: terminal)
+
+    Enum.each(1..12, fn _ ->
+      assert {:noreply, "website", true} = ChildServer.dispatch_input(pid, "ArrowLeft")
+    end)
+
+    assert {:ok, _acc, box} = ChildServer.render(pid, terminal: terminal)
+
+    assert box.content =~ "23/comments?include=aut "
+    refute box.content =~ "?include=author,history "
+  end
+
+  test "child server delete updates a scrolled input through the normal key path" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+    {:ok, pid} = ChildServer.start(view: OverflowInputView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = ChildServer.render(pid, terminal: terminal)
+    assert {:noreply, "website", true} = ChildServer.dispatch_input(pid, "ArrowLeft")
+    assert {:noreply, "website", true} = ChildServer.dispatch_input(pid, "Delete")
+
+    assert %Breeze.Term{
+             implicit_state: %{
+               "website" => {Breeze.Implicit.Input, %{value: value, cursor: 77}}
+             }
+           } = :sys.get_state(pid)
+
+    refute String.contains?(value, "history")
+    assert String.ends_with?(value, "histor")
+  end
+
+  test "reconcile stores the rendered viewport width" do
+    assert %{viewport_width: 24} =
+             Input.reconcile(%Breeze.Viewport{width: 24, viewport_width: 24}, %{
+               value: "hello",
+               cursor: 5
+             })
+  end
+end

--- a/test/breeze/key_decoder_test.exs
+++ b/test/breeze/key_decoder_test.exs
@@ -1,0 +1,18 @@
+defmodule Breeze.KeyDecoderTest do
+  use ExUnit.Case, async: true
+
+  test "decodes common F1 variants" do
+    assert Breeze.KeyDecoder.decode("\eOP") == "F1"
+    assert Breeze.KeyDecoder.decode("\e[11~") == "F1"
+    assert Breeze.KeyDecoder.decode("\e[[A") == "F1"
+  end
+
+  test "decodes common navigation keys" do
+    assert Breeze.KeyDecoder.decode("\e[A") == "ArrowUp"
+    assert Breeze.KeyDecoder.decode("\e[B") == "ArrowDown"
+    assert Breeze.KeyDecoder.decode("\e[3~") == "Delete"
+    assert Breeze.KeyDecoder.decode("\e[Z") == "ShiftTab"
+    assert Breeze.KeyDecoder.decode("\e") == "Escape"
+    assert Breeze.KeyDecoder.decode("\r") == "Enter"
+  end
+end

--- a/test/breeze/terminal_overlay_test.exs
+++ b/test/breeze/terminal_overlay_test.exs
@@ -1,0 +1,17 @@
+defmodule Breeze.TerminalOverlayTest do
+  use ExUnit.Case, async: true
+
+  alias Breeze.TerminalOverlay
+
+  test "blink visibility toggles on 500ms boundaries" do
+    assert TerminalOverlay.blink_visible?(0)
+    refute TerminalOverlay.blink_visible?(500)
+    assert TerminalOverlay.blink_visible?(1_000)
+  end
+
+  test "recent interaction keeps the cursor visible" do
+    assert TerminalOverlay.visible?(500, 1)
+    assert TerminalOverlay.visible?(999, 500)
+    refute TerminalOverlay.visible?(1_500, 500)
+  end
+end

--- a/test/breeze/viewport_test.exs
+++ b/test/breeze/viewport_test.exs
@@ -5,8 +5,17 @@ defmodule Breeze.ViewportTest do
 
   describe "from_dimensions/1" do
     test "normalizes a dimension map" do
-      viewport = Viewport.from_dimensions(%{height: 10, viewport_height: 4, content_height: 20})
+      viewport =
+        Viewport.from_dimensions(%{
+          left: 3,
+          top: 4,
+          height: 10,
+          viewport_height: 4,
+          content_height: 20
+        })
 
+      assert viewport.left == 3
+      assert viewport.top == 4
       assert viewport.height == 10
       assert viewport.viewport_height == 4
       assert viewport.content_height == 20
@@ -15,6 +24,8 @@ defmodule Breeze.ViewportTest do
     test "falls back to sane defaults" do
       viewport = Viewport.from_dimensions(nil)
 
+      assert viewport.left == 0
+      assert viewport.top == 0
       assert viewport.height == 0
       assert viewport.viewport_height == 0
       assert viewport.content_height == 0


### PR DESCRIPTION
The input implicit requires a cursor, which we handle after rendering with an `animate` callback on an implicit. This specifies the overlay that can be used, which will blink the cursor without re-rendering the entire frame.

Since more keybindings are being handled now, they have been moved out itno a separate module that will be expanded to include all special keys in the future.