### PR TITLE
feat(Breeze.Mouse): add mouse support for views

### DIFF
--- a/examples/docs.exs
+++ b/examples/docs.exs
@@ -63,6 +63,13 @@ defmodule Docs do
     """
   end
 
+  def handle_info(:resize, term) do
+    {screen_width, _} = BackBreeze.screen_dimensions(term.terminal)
+    doc_width = div(screen_width, 2) - 2
+
+    {:noreply, assign(term, doc_width: doc_width)}
+  end
+
   def handle_info(_, term) do
     {:noreply, term}
   end
@@ -107,6 +114,7 @@ defmodule Docs do
   def handle_event("function", %{value: value}, term) do
     doc = fetch_function_doc(term.assigns.selected, value)
     term = assign(term, fun_selected: value, fun_doc: doc)
+
     term = reset(term, "doc")
     {:noreply, term}
   end

--- a/examples/mouse.exs
+++ b/examples/mouse.exs
@@ -1,0 +1,71 @@
+defmodule MouseExample do
+  use Breeze.View
+
+  def mount(_opts, term) do
+    term =
+      term
+      |> assign(clicks: 0, last_mouse: "none")
+      |> focus("left-panel")
+
+    {:ok, term}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <box style="width-screen height-screen">
+      <box style="bold">Mouse example</box>
+      <box>Left click either panel to focus it. Press q to quit.</box>
+      <box>Last mouse event: {@last_mouse}</box>
+      <box>Click count: {@clicks}</box>
+      <box>
+      </box>
+      <box style="inline">
+        <box id="left-panel" focusable style="border-rounded width-24 height-6 focus:border-4">
+          <box style="bold">Left panel</box>
+          <box>Expected target: left-panel</box>
+        </box>
+        <box>
+        </box>
+        <box id="right-panel" focusable style="border-rounded width-24 height-6 focus:border-4">
+          <box style="bold">Right panel</box>
+          <box>Expected target: right-panel</box>
+        </box>
+      </box>
+    </box>
+    """
+  end
+
+  def handle_event(
+        _,
+        %{"mouse" => %{button: :left, action: :press} = mouse, "target" => target},
+        term
+      ) do
+    summary =
+      "#{mouse.button}/#{mouse.action} x=#{mouse.x} y=#{mouse.y} target=#{target}"
+
+    {:noreply,
+     assign(term,
+       clicks: term.assigns.clicks + 1,
+       last_mouse: summary
+     )}
+  end
+
+  def handle_event(_, %{"mouse" => mouse, "target" => target}, term) do
+    summary = "#{mouse.button}/#{mouse.action} x=#{mouse.x} y=#{mouse.y} target=#{target}"
+    {:noreply, assign(term, last_mouse: summary)}
+  end
+
+  def handle_event(_, %{"mouse" => mouse}, term) do
+    summary = "#{mouse.button}/#{mouse.action} x=#{mouse.x} y=#{mouse.y} target=none"
+    {:noreply, assign(term, last_mouse: summary)}
+  end
+
+  def handle_event(_, _, term), do: {:noreply, term}
+end
+
+Breeze.Example.run(
+  view: MouseExample,
+  hide_cursor: true,
+  mouse: true,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)

--- a/examples/posting.exs
+++ b/examples/posting.exs
@@ -270,9 +270,8 @@ defmodule Posting do
   def handle_info(_, term), do: {:noreply, term}
 end
 
-unless System.get_env("BREEZE_EXAMPLE_NO_START") == "1" do
-  Breeze.Server.start_link(view: Posting, hide_cursor: true)
-
-  receive do
-  end
-end
+Breeze.Example.run(
+  view: Posting,
+  hide_cursor: true,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)

--- a/examples/scroll.exs
+++ b/examples/scroll.exs
@@ -48,6 +48,7 @@ end
 Breeze.Example.run(
   [
     view: Scroll,
+    mouse: true,
     global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
   ],
   keep_alive: 100_000

--- a/lib/breeze/child_server.ex
+++ b/lib/breeze/child_server.ex
@@ -19,8 +19,8 @@ defmodule Breeze.ChildServer do
     GenServer.call(pid, {:render_snapshot, opts})
   end
 
-  def dispatch_input(pid, key) do
-    GenServer.call(pid, {:input, key})
+  def dispatch_input(pid, input) do
+    GenServer.call(pid, {:input, input})
   end
 
   def dispatch_event(pid, change, event) do
@@ -75,9 +75,9 @@ defmodule Breeze.ChildServer do
     reply_from_input_result(handle_event(change, event, touched_term), touched_term)
   end
 
-  def handle_call({:input, key}, _from, term) do
+  def handle_call({:input, input}, _from, term) do
     touched_term = touch_interaction(term)
-    reply_from_input_result(process_input(key, touched_term), touched_term)
+    reply_from_input_result(process_input(input, touched_term), touched_term)
   end
 
   def handle_call({:info, message, terminal}, _from, term) do
@@ -176,7 +176,9 @@ defmodule Breeze.ChildServer do
 
     {acc, box} = Breeze.Renderer.render(term.view, term.assigns, final_opts)
     term = Breeze.RenderState.build(term, acc)
+
     term = %{term | focus_meta: Breeze.Focus.build_meta(acc.elements, term.implicit_state)}
+
     decorations = extract_async_decorations(term)
 
     {term, acc, box, decorations}
@@ -234,6 +236,29 @@ defmodule Breeze.ChildServer do
     {:noreply, %{term | focused: focused, allow_unfocused?: is_nil(focused)}}
   end
 
+  defp process_input(%{"mouse" => mouse} = event, term) do
+    case mouse_target(term, mouse) do
+      nil ->
+        normalize_result(term.view.handle_event(:ignore_me, event, term), term)
+
+      target ->
+        term =
+          if focus_mouse_target?(target, mouse, term) do
+            %{term | focused: target}
+          else
+            term
+          end
+
+        event =
+          event
+          |> Map.put("target", target)
+          |> Map.put("row", mouse_row(term, target, mouse))
+          |> Map.put("col", mouse_col(term, target, mouse))
+
+        handle_event(:ignore_me, event, term, target)
+    end
+  end
+
   defp process_input(key, term) do
     event = %{"key" => key}
 
@@ -249,11 +274,13 @@ defmodule Breeze.ChildServer do
     end
   end
 
-  defp handle_event(change, event, term) do
+  defp handle_event(change, event, term, target_id \\ nil) do
+    target_id = target_id || term.focused
+
     {view_state, implicit_consumed, term} =
       Breeze.RenderState.dispatch_implicit_event(
         term,
-        term.focused,
+        target_id,
         event,
         &handle_implicit_change/4
       )
@@ -377,4 +404,51 @@ defmodule Breeze.ChildServer do
       _ -> :ok
     end
   end
+
+  defp mouse_target(term, %{x: x, y: y}) do
+    x = x - 1
+    y = y - 1
+
+    term.mouse_targets
+    |> Enum.filter(fn {_id, bounds} ->
+      is_integer(bounds[:left]) and is_integer(bounds[:right]) and is_integer(bounds[:top]) and
+        is_integer(bounds[:bottom]) and x >= bounds.left and x <= bounds.right and
+        y >= bounds.top and y <= bounds.bottom
+    end)
+    |> Enum.sort_by(fn {_id, bounds} ->
+      area = (bounds.right - bounds.left + 1) * (bounds.bottom - bounds.top + 1)
+      {area, bounds.top, bounds.left}
+    end)
+    |> List.first()
+    |> case do
+      {id, _bounds} -> id
+      nil -> nil
+    end
+  end
+
+  defp mouse_row(term, target, %{y: y}) do
+    bounds = Map.fetch!(term.mouse_targets, target)
+    box = Map.get(term.rendered_boxes, target)
+    top_inset = border_inset(box, :top)
+    max(y - 1 - bounds.top - top_inset, 0)
+  end
+
+  defp mouse_col(term, target, %{x: x}) do
+    bounds = Map.fetch!(term.mouse_targets, target)
+    box = Map.get(term.rendered_boxes, target)
+    left_inset = border_inset(box, :left)
+    max(x - 1 - bounds.left - left_inset, 0)
+  end
+
+  defp border_inset(%BackBreeze.Box{style: %{border: border}}, side) do
+    if Map.get(border, side), do: 1, else: 0
+  end
+
+  defp border_inset(_, _side), do: 0
+
+  defp focus_mouse_target?(target, %{button: :left, action: :press}, term) do
+    target in term.focusables
+  end
+
+  defp focus_mouse_target?(_target, _mouse, _term), do: false
 end

--- a/lib/breeze/implicit/list.ex
+++ b/lib/breeze/implicit/list.ex
@@ -113,6 +113,35 @@ defmodule Breeze.Implicit.List do
     |> maybe_change()
   end
 
+  def handle_event(
+        _,
+        %{"mouse" => %{button: :left, action: :press}, "row" => row, "element" => element},
+        state
+      )
+      when is_integer(row) and row >= 0 do
+    case clicked_index_at_row(state.values, row + state.offset, state.width) do
+      nil ->
+        {:noreply, state}
+
+      index ->
+        state
+        |> set_selection(index, element)
+        |> maybe_change()
+    end
+  end
+
+  def handle_event(_, %{"mouse" => %{button: :wheel_down} = mouse, "element" => element}, state) do
+    viewport = Viewport.from_dimensions(element)
+    offset = Viewport.clamp_scroll_y(state.offset + wheel_repeat(mouse), viewport)
+    {:noreply, %{state | offset: offset}}
+  end
+
+  def handle_event(_, %{"mouse" => %{button: :wheel_up} = mouse, "element" => element}, state) do
+    viewport = Viewport.from_dimensions(element)
+    offset = Viewport.clamp_scroll_y(state.offset - wheel_repeat(mouse), viewport)
+    {:noreply, %{state | offset: offset}}
+  end
+
   def handle_event(_, _, state), do: {:noreply, state}
 
   @spec handle_modifiers(:root | :child, keyword(), state()) :: keyword()
@@ -168,6 +197,9 @@ defmodule Breeze.Implicit.List do
     {{:change, payload}, state}
   end
 
+  defp wheel_repeat(%{repeat: repeat}) when is_integer(repeat) and repeat > 0, do: repeat
+  defp wheel_repeat(_mouse), do: 1
+
   defp next_index(%{selected_index: nil}, delta) when delta >= 0, do: 0
   defp next_index(%{selected_index: nil, values: values}, _delta), do: max(length(values) - 1, 0)
 
@@ -220,6 +252,25 @@ defmodule Breeze.Implicit.List do
       end)
 
     idx
+  end
+
+  defp clicked_index_at_row(values, row, width) do
+    Enum.with_index(values)
+    |> Enum.reduce_while({0, nil}, fn {value, idx}, {cur_row, _found} ->
+      next_row = cur_row + item_rows(value, width)
+
+      cond do
+        row < cur_row ->
+          {:halt, {cur_row, nil}}
+
+        row < next_row ->
+          {:halt, {cur_row, idx}}
+
+        true ->
+          {:cont, {next_row, nil}}
+      end
+    end)
+    |> elem(1)
   end
 
   defp normalize_selected_index(_index, []), do: nil

--- a/lib/breeze/implicit/scroll.ex
+++ b/lib/breeze/implicit/scroll.ex
@@ -61,6 +61,30 @@ defmodule Breeze.Implicit.Scroll do
     {:noreply, put_offset(state, offset_y, viewport)}
   end
 
+  def handle_event(_, %{"mouse" => %{button: :wheel_down} = mouse, "element" => element}, state) do
+    viewport = Viewport.from_dimensions(element)
+
+    offset_y =
+      Viewport.clamp_scroll_y(
+        state.offset_y + wheel_step(viewport) * wheel_repeat(mouse),
+        viewport
+      )
+
+    {:noreply, put_offset(state, offset_y, viewport)}
+  end
+
+  def handle_event(_, %{"mouse" => %{button: :wheel_up} = mouse, "element" => element}, state) do
+    viewport = Viewport.from_dimensions(element)
+
+    offset_y =
+      Viewport.clamp_scroll_y(
+        state.offset_y - wheel_step(viewport) * wheel_repeat(mouse),
+        viewport
+      )
+
+    {:noreply, put_offset(state, offset_y, viewport)}
+  end
+
   def handle_event(_, _, state), do: {:noreply, state}
 
   def handle_modifiers(:root, _flags, state), do: [scroll_y: state.offset_y]
@@ -80,6 +104,13 @@ defmodule Breeze.Implicit.Scroll do
   end
 
   def reconcile(viewport, state), do: reconcile(Viewport.from_dimensions(viewport), state)
+
+  defp wheel_step(%Viewport{viewport_height: height}) do
+    max(div(height, 2), 1)
+  end
+
+  defp wheel_repeat(%{repeat: repeat}) when is_integer(repeat) and repeat > 0, do: repeat
+  defp wheel_repeat(_mouse), do: 1
 
   defp put_offset(state, offset_y, viewport) do
     max_offset = Viewport.max_scroll_y(viewport)

--- a/lib/breeze/mouse.ex
+++ b/lib/breeze/mouse.ex
@@ -1,0 +1,77 @@
+defmodule Breeze.Mouse do
+  @moduledoc false
+
+  import Bitwise
+
+  @type event :: %{
+          button: :left | :middle | :right | :release | :wheel_up | :wheel_down,
+          action: :press | :release | :move,
+          x: pos_integer(),
+          y: pos_integer(),
+          modifiers: [:shift | :alt | :ctrl]
+        }
+
+  @spec decode(binary()) :: {:ok, event()} | :error
+  def decode("\e[<" <> rest) do
+    with [raw_code, raw_x, raw_tail] <- String.split(rest, ";", parts: 3),
+         {code, ""} <- Integer.parse(raw_code),
+         {x, ""} <- Integer.parse(raw_x),
+         <<raw_y::binary-size(byte_size(raw_tail) - 1), suffix>> <- raw_tail,
+         {y, ""} <- Integer.parse(raw_y),
+         true <- suffix in [?M, ?m] do
+      {:ok,
+       %{
+         button: button(code),
+         action: action(code, suffix),
+         x: x,
+         y: y,
+         modifiers: modifiers(code)
+       }}
+    else
+      _ -> :error
+    end
+  end
+
+  def decode(_), do: :error
+
+  defp button(code) do
+    cond do
+      (code &&& 64) != 0 -> wheel_button(code)
+      (code &&& 3) == 3 -> :release
+      (code &&& 3) == 0 -> :left
+      (code &&& 3) == 1 -> :middle
+      true -> :right
+    end
+  end
+
+  defp modifiers(code) do
+    []
+    |> maybe_add_modifier(code, 4, :shift)
+    |> maybe_add_modifier(code, 8, :alt)
+    |> maybe_add_modifier(code, 16, :ctrl)
+  end
+
+  defp maybe_add_modifier(modifiers, code, mask, modifier) do
+    if (code &&& mask) != 0 do
+      modifiers ++ [modifier]
+    else
+      modifiers
+    end
+  end
+
+  defp action(code, suffix) do
+    cond do
+      (code &&& 32) != 0 -> :move
+      suffix == ?m -> :release
+      true -> :press
+    end
+  end
+
+  defp wheel_button(code) do
+    case code &&& 3 do
+      0 -> :wheel_up
+      1 -> :wheel_down
+      _ -> :release
+    end
+  end
+end

--- a/lib/breeze/render_state.ex
+++ b/lib/breeze/render_state.ex
@@ -20,11 +20,14 @@ defmodule Breeze.RenderState do
         if change, do: Map.put(events, id, %{change: change}), else: events
       end)
 
-    elements = build_dimensions(acc)
+    raw_dimensions = build_dimensions(acc)
+    elements = Map.new(raw_dimensions, fn {id, dims} -> {id, Viewport.from_dimensions(dims)} end)
+    mouse_targets = build_mouse_targets(raw_dimensions)
 
     %{
       term
       | elements: elements,
+        mouse_targets: mouse_targets,
         focusables: acc.focusables,
         implicit_state: implicits,
         implicit_meta: implicit_meta,
@@ -38,8 +41,24 @@ defmodule Breeze.RenderState do
     |> Enum.reduce(%{}, fn {{_idx, flags}, dims}, elements ->
       case Keyword.get(flags, :id) do
         nil -> elements
-        id -> Map.put(elements, id, Viewport.from_dimensions(dims))
+        id -> Map.put(elements, id, dims)
       end
+    end)
+  end
+
+  defp build_mouse_targets(raw_dimensions) do
+    Map.new(raw_dimensions, fn {id, dims} ->
+      width = Map.get(dims, :width) || Map.get(dims, :viewport_width) || 0
+      height = Map.get(dims, :height) || Map.get(dims, :viewport_height) || 0
+      left = Map.get(dims, :left, 0)
+      top = Map.get(dims, :top, 0)
+
+      {id,
+       dims
+       |> Map.put(:left, left)
+       |> Map.put(:top, top)
+       |> Map.put(:right, left + max(width - 1, 0))
+       |> Map.put(:bottom, top + max(height - 1, 0))}
     end)
   end
 

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -194,18 +194,21 @@ defmodule Breeze.Renderer do
       element.attributes
       |> merge_scroll_modifier(scroll_modifier)
       |> Map.put(:style, element.style)
+      |> Map.put(:owner_id, id)
 
     children = Enum.reverse(children)
     content = box.content
 
+    final_box = %{Box.new(opts) | children: children, content: content}
+
     acc =
       if root_id do
-        %{acc | focusables: focusables, boxes: Map.put(acc.boxes, root_id, box)}
+        %{acc | focusables: focusables, boxes: Map.put(acc.boxes, root_id, final_box)}
       else
         %{acc | focusables: focusables}
       end
 
-    {acc, %{Box.new(opts) | children: children, content: content}}
+    {acc, final_box}
   end
 
   defp parse_modifiers(modifiers, style_flags) when is_list(modifiers) do

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -20,6 +20,7 @@ defmodule Breeze.Term do
     implicit_meta: %{},
     rendered_contents: %{},
     rendered_boxes: %{},
+    mouse_targets: %{},
     children: %{},
     frame_delay_ms: 16,
     render_timer: nil
@@ -33,6 +34,9 @@ defmodule Breeze.Server do
 
   use GenServer
 
+  @render_tracking_key {__MODULE__, :render_tracking}
+  @flush_input_batch :flush_input_batch
+
   defstruct [
     :terminal,
     :reader,
@@ -43,6 +47,8 @@ defmodule Breeze.Server do
     :pending_started_at,
     :last_render_at,
     :last_interaction_at,
+    queued_input: [],
+    input_flush_scheduled?: false,
     decorations: [],
     children: %{},
     animation_timer: nil,
@@ -57,6 +63,7 @@ defmodule Breeze.Server do
           {:view, module()}
           | {:start_opts, keyword()}
           | {:hide_cursor, boolean()}
+          | {:mouse, boolean() | keyword()}
           | {:global_keybindings, list()}
           | {:frame_delay_ms, pos_integer()}
 
@@ -67,6 +74,7 @@ defmodule Breeze.Server do
 
     * `:view` - the view to run. This is required
     * `:hide_cursor` - hide the cursor on start. Defaults to `false`
+    * `:mouse` - enable mouse tracking. Defaults to `false`. Pass `true` for click mode or keyword options for `Termite.Screen.enable_mouse/2`
     * `:global_keybindings` - app-wide keybindings checked before focused event handling
 
   """
@@ -96,9 +104,11 @@ defmodule Breeze.Server do
     start_opts = Keyword.get(opts, :start_opts, [])
     hide_cursor? = Keyword.get(opts, :hide_cursor, true)
     frame_delay_ms = Keyword.get(opts, :frame_delay_ms, 80)
+    mouse = Keyword.get(opts, :mouse, false)
 
     terminal = Termite.Terminal.start()
     terminal = if hide_cursor?, do: Termite.Screen.hide_cursor(terminal), else: terminal
+    terminal = enable_mouse(terminal, mouse)
     terminal = Termite.Screen.clear_screen(terminal)
 
     session = self()
@@ -140,21 +150,12 @@ defmodule Breeze.Server do
 
   @impl true
   def handle_info({reader, {:data, data}}, %{reader: reader} = state) do
-    {:key, key} = decode_input(data)
+    state =
+      state
+      |> enqueue_input(decode_input(data))
+      |> schedule_input_flush()
 
-    cond do
-      stop_global_key?(key, state) ->
-        stop(state)
-
-      sync_input?(state, key) ->
-        case process_input_batch(reader, data, state) do
-          {:stop, state} -> stop(state)
-          {:noreply, state} -> {:noreply, maybe_render_base(state)}
-        end
-
-      true ->
-        {:noreply, start_async_input(key, state)}
-    end
+    {:noreply, state}
   end
 
   def handle_info({reader, {:signal, :winch}}, %{reader: reader} = state) do
@@ -176,6 +177,23 @@ defmodule Breeze.Server do
 
   def handle_info({:child_invalidated, _id}, state) do
     {:noreply, maybe_render_base(state)}
+  end
+
+  def handle_info(@flush_input_batch, state) do
+    state = %{state | input_flush_scheduled?: false}
+
+    case flush_input_batch(state) do
+      {:stop, state} ->
+        stop(state)
+
+      {:noreply, state} ->
+        state =
+          state
+          |> maybe_render_base()
+          |> schedule_input_flush()
+
+        {:noreply, state}
+    end
   end
 
   def handle_info(:animation_tick, %{decorations: []} = state) do
@@ -244,28 +262,43 @@ defmodule Breeze.Server do
     end
   end
 
-  defp process_input_batch(reader, data, state) do
-    case handle_key(data, state) do
+  defp flush_input_batch(%{queued_input: []} = state), do: {:noreply, state}
+
+  defp flush_input_batch(%{queued_input: [decoded | rest]} = state) do
+    state = %{state | queued_input: rest}
+
+    case process_batched_input(decoded, state) do
       {:stop, state} ->
         {:stop, state}
 
       {:noreply, state} ->
-        drain_input_batch(reader, state)
+        continue_flushing_or_pause(state)
     end
   end
 
-  defp drain_input_batch(reader, state) do
-    receive do
-      {^reader, {:data, data}} ->
-        process_input_batch(reader, data, state)
-    after
-      0 -> {:noreply, state}
+  defp process_batched_input({:mouse, %{button: button} = event}, state)
+       when button in [:wheel_down, :wheel_up] do
+    {event, state} = coalesce_wheel_events_from_queue(event, state, 1)
+    handle_mouse(event, state)
+  end
+
+  defp process_batched_input(decoded, state), do: handle_decoded_sync_input(decoded, state)
+
+  defp continue_flushing_or_pause(%{queued_input: [next | _]} = state) do
+    if sync_input_message?(next, state) do
+      flush_input_batch(state)
+    else
+      {:noreply, state}
     end
   end
 
-  defp handle_key(raw_key, state) do
-    {:key, key} = decode_input(raw_key)
+  defp continue_flushing_or_pause(state), do: {:noreply, state}
 
+  defp handle_decoded_sync_input({:mouse, event}, state) do
+    handle_mouse(event, state)
+  end
+
+  defp handle_decoded_sync_input({:key, key}, state) do
     case key do
       key when key in ["\t", "ShiftTab"] ->
         state
@@ -277,6 +310,36 @@ defmodule Breeze.Server do
         |> touch_interaction()
         |> apply_input_reply(dispatch_input_hierarchy(state, key))
     end
+  end
+
+  defp sync_input_message?({:mouse, _event}, _state), do: true
+
+  defp sync_input_message?({:key, key}, state) do
+    key in ["\t", "ShiftTab"] or stop_global_key?(key, state) or sync_input?(state, key)
+  end
+
+  defp sync_input_message?(_, _state), do: false
+
+  defp coalesce_wheel_events_from_queue(event, %{queued_input: [next | rest]} = state, repeat) do
+    case next do
+      {:mouse, %{button: button} = next_event} ->
+        if button == event.button and wheel_match?(event, next_event) do
+          coalesce_wheel_events_from_queue(event, %{state | queued_input: rest}, repeat + 1)
+        else
+          {Map.put(event, :repeat, repeat), state}
+        end
+
+      _ ->
+        {Map.put(event, :repeat, repeat), state}
+    end
+  end
+
+  defp coalesce_wheel_events_from_queue(event, state, repeat),
+    do: {Map.put(event, :repeat, repeat), state}
+
+  defp wheel_match?(left, right) do
+    left.action == right.action and left.x == right.x and left.y == right.y and
+      left.modifiers == right.modifiers
   end
 
   defp apply_input_reply(state, reply) do
@@ -330,36 +393,22 @@ defmodule Breeze.Server do
     end
   end
 
-  defp start_async_input(_key, %{pending_ref: ref} = state) when not is_nil(ref), do: state
-
-  defp start_async_input(key, state) do
-    ref = make_ref()
-    session = self()
-
-    Task.start(fn ->
-      reply = dispatch_input_hierarchy(state, key)
-      send(session, {:event_reply, ref, reply})
-    end)
-
+  defp handle_mouse(event, state) do
     state
-    |> Map.put(:pending_ref, ref)
-    |> Map.put(:pending_started_at, System.monotonic_time(:millisecond))
-    |> Map.put(:last_interaction_at, System.monotonic_time(:millisecond))
-    |> render_frame()
-    |> schedule_animation()
+    |> touch_interaction()
+    |> apply_input_reply(Breeze.ChildServer.dispatch_input(state.view_pid, %{"mouse" => event}))
   end
 
   defp render_base(state, attempts \\ 1)
 
   defp render_base(state, attempts) do
-    token = make_ref()
-    collector = self()
+    begin_render_tracking()
 
     {:ok, _acc, box, decorations} =
       Breeze.ChildServer.render_snapshot(state.view_pid,
         implicit_state: %{},
         terminal: state.terminal,
-        live_view: fn attrs, opts -> render_live_child(attrs, opts, state, collector, token) end
+        live_view: fn attrs, opts -> render_live_child(attrs, opts, state) end
       )
 
     focused =
@@ -368,7 +417,7 @@ defmodule Breeze.Server do
         _ -> state.focused
       end
 
-    %{missing: missing, decorations: child_decorations} = collect_render_tracking(token)
+    %{missing: missing, decorations: child_decorations} = finish_render_tracking()
     {state, started?} = ensure_children(state, missing)
 
     if started? do
@@ -398,14 +447,14 @@ defmodule Breeze.Server do
     if Process.alive?(pid), do: render_base(state), else: state
   end
 
-  defp render_live_child(attrs, opts, state, collector, token) do
+  defp render_live_child(attrs, opts, state) do
     id = fetch_live_attr!(attrs, :id)
     full_id = live_id(Keyword.get(opts, :live_prefix), id)
     preload_only = fetch_live_attr(attrs, :preload_only, false)
 
     case Map.get(state.children, full_id) do
       nil ->
-        send(collector, {:breeze_live_track, token, :missing, {full_id, attrs}})
+        track_missing_live_child({full_id, attrs})
         if preload_only, do: :preloaded, else: :missing
 
       %{pid: pid} ->
@@ -421,15 +470,12 @@ defmodule Breeze.Server do
               terminal: state.terminal,
               live_prefix: full_id,
               live_view: fn child_attrs, child_opts ->
-                render_live_child(child_attrs, child_opts, state, collector, token)
+                render_live_child(child_attrs, child_opts, state)
               end
             )
 
           Enum.each(child_decorations, fn decoration ->
-            send(
-              collector,
-              {:breeze_live_track, token, :decoration, namespace_decoration(decoration, full_id)}
-            )
+            track_render_decoration(namespace_decoration(decoration, full_id))
           end)
 
           {:rendered, id, child_acc, child_box}
@@ -652,6 +698,13 @@ defmodule Breeze.Server do
     {box, %{}}
   end
 
+  defp enable_mouse(terminal, false), do: terminal
+  defp enable_mouse(terminal, nil), do: terminal
+  defp enable_mouse(terminal, true), do: Termite.Screen.enable_mouse(terminal)
+
+  defp enable_mouse(terminal, opts) when is_list(opts),
+    do: Termite.Screen.enable_mouse(terminal, opts)
+
   defp stop(state) do
     if Process.alive?(state.view_pid) do
       Process.exit(state.view_pid, :normal)
@@ -659,6 +712,7 @@ defmodule Breeze.Server do
 
     terminal =
       state.terminal
+      |> Termite.Screen.disable_mouse()
       |> Termite.Screen.clear_screen()
       |> Termite.Screen.show_cursor()
       |> Termite.Screen.exit_alt_screen()
@@ -667,7 +721,15 @@ defmodule Breeze.Server do
     System.halt()
   end
 
-  defp decode_input(raw_key), do: {:key, Breeze.KeyDecoder.decode(raw_key)}
+  defp decode_input(raw_key) do
+    case Breeze.Mouse.decode(raw_key) do
+      {:ok, event} ->
+        {:mouse, event}
+
+      :error ->
+        {:key, Breeze.KeyDecoder.decode(raw_key)}
+    end
+  end
 
   defp ensure_children(state, missing) do
     Enum.reduce(missing, {state, false}, fn {id, attrs}, {state, started?} ->
@@ -700,18 +762,48 @@ defmodule Breeze.Server do
     %{pid: pid, ref: ref, view: view, persistent: persistent}
   end
 
-  defp collect_render_tracking(token) do
-    receive do
-      {:breeze_live_track, ^token, :missing, item} ->
-        acc = collect_render_tracking(token)
-        %{acc | missing: [item | acc.missing]}
+  defp begin_render_tracking do
+    Process.put(@render_tracking_key, %{missing: [], decorations: []})
+  end
 
-      {:breeze_live_track, ^token, :decoration, decoration} ->
-        acc = collect_render_tracking(token)
-        %{acc | decorations: [decoration | acc.decorations]}
-    after
-      0 -> %{missing: [], decorations: []}
-    end
+  defp finish_render_tracking do
+    Process.get(@render_tracking_key, %{missing: [], decorations: []})
+    |> then(fn tracking ->
+      Process.delete(@render_tracking_key)
+
+      %{
+        missing: Enum.reverse(tracking.missing),
+        decorations: Enum.reverse(tracking.decorations)
+      }
+    end)
+  end
+
+  defp track_missing_live_child(item) do
+    update_render_tracking(fn tracking ->
+      %{tracking | missing: [item | tracking.missing]}
+    end)
+  end
+
+  defp track_render_decoration(decoration) do
+    update_render_tracking(fn tracking ->
+      %{tracking | decorations: [decoration | tracking.decorations]}
+    end)
+  end
+
+  defp update_render_tracking(fun) do
+    tracking = Process.get(@render_tracking_key, %{missing: [], decorations: []})
+    Process.put(@render_tracking_key, fun.(tracking))
+  end
+
+  defp enqueue_input(state, decoded) do
+    update_in(state.queued_input, &(&1 ++ [decoded]))
+  end
+
+  defp schedule_input_flush(%{input_flush_scheduled?: true} = state), do: state
+
+  defp schedule_input_flush(state) do
+    send(self(), @flush_input_batch)
+    %{state | input_flush_scheduled?: true}
   end
 
   defp dispatch_input_hierarchy(state, key) do

--- a/test/breeze/child_server_test.exs
+++ b/test/breeze/child_server_test.exs
@@ -1,0 +1,106 @@
+defmodule Breeze.ChildServerTest do
+  use ExUnit.Case, async: true
+
+  defmodule MouseView do
+    use Breeze.View
+
+    def mount(_opts, term), do: {:ok, assign(term, clicks: [])}
+
+    def render(assigns) do
+      ~H"""
+      <box><%= length(@clicks) %></box>
+      """
+    end
+
+    def handle_event(_, %{"mouse" => mouse}, term) do
+      {:noreply, assign(term, clicks: [mouse | term.assigns.clicks])}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+  end
+
+  defmodule MouseTargetView do
+    use Breeze.View
+
+    def mount(_opts, term), do: {:ok, assign(term, last_target: "none")}
+
+    def render(assigns) do
+      ~H"""
+      <box style="inline">
+        <box id="left" focusable style="width-6 height-3 border">L</box>
+        <box>
+        </box>
+        <box id="right" focusable style="width-6 height-3 border">R</box>
+        <box>{@last_target}</box>
+      </box>
+      """
+    end
+
+    def handle_event(_, %{"target" => target}, term) do
+      {:noreply, assign(term, last_target: target)}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+  end
+
+  defmodule MouseFocusView do
+    use Breeze.View
+
+    def mount(_opts, term), do: {:ok, focus(term, "left")}
+
+    def render(assigns) do
+      ~H"""
+      <box style="inline">
+        <box id="left" focusable style="width-6 height-3 border">left</box>
+        <box>
+        </box>
+        <box id="right" focusable style="width-6 height-3 border">right</box>
+      </box>
+      """
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+  end
+
+  test "dispatches mouse input through handle_event/3" do
+    {:ok, pid} = Breeze.ChildServer.start(view: MouseView)
+
+    assert {:noreply, nil, true} =
+             Breeze.ChildServer.dispatch_input(pid, %{
+               "mouse" => %{button: :left, action: :press, x: 3, y: 4, modifiers: []}
+             })
+
+    assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, [])
+    assert box.content == "1"
+  end
+
+  test "wheel mouse events do not steal focus" do
+    terminal = %Termite.Terminal{size: %{width: 20, height: 5}}
+    {:ok, wheel_pid} = Breeze.ChildServer.start(view: MouseFocusView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(wheel_pid, terminal: terminal)
+    assert %{focused: "left"} = Breeze.ChildServer.metadata(wheel_pid)
+
+    assert {:noreply, "left", false} =
+             Breeze.ChildServer.dispatch_input(wheel_pid, %{
+               "mouse" => %{button: :wheel_down, action: :press, x: 14, y: 2, modifiers: []}
+             })
+
+    assert %{focused: "left"} = Breeze.ChildServer.metadata(wheel_pid)
+  end
+
+  test "mouse clicks detect the clicked target id" do
+    terminal = %Termite.Terminal{size: %{width: 20, height: 5}}
+    {:ok, pid} = Breeze.ChildServer.start(view: MouseTargetView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
+
+    assert {:noreply, "right", true} =
+             Breeze.ChildServer.dispatch_input(pid, %{
+               "mouse" => %{button: :left, action: :press, x: 11, y: 2, modifiers: []}
+             })
+
+    assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, terminal: terminal)
+    assert box.content =~ "right"
+  end
+end

--- a/test/breeze/implicit/list_test.exs
+++ b/test/breeze/implicit/list_test.exs
@@ -89,6 +89,85 @@ defmodule Breeze.Implicit.ListTest do
       assert state.selected == "c"
       assert state.selected_index == 2
     end
+
+    test "selects the clicked row and emits change" do
+      viewport = Viewport.from_dimensions(%{height: 4, viewport_height: 4, content_height: 6})
+
+      state = %{
+        values: ["alpha", "beta", "gamma"],
+        selected: "alpha",
+        selected_index: 0,
+        offset: 0,
+        loop: true,
+        scroll_padding: 0,
+        width: 0
+      }
+
+      {{:change, payload}, state} =
+        Implicit.List.handle_event(
+          :ignore,
+          %{
+            "mouse" => %{button: :left, action: :press},
+            "row" => 2,
+            "element" => viewport
+          },
+          state
+        )
+
+      assert state.selected == "gamma"
+      assert state.selected_index == 2
+      assert payload == %{value: "gamma", index: 2, offset: 0}
+    end
+
+    test "wheel scroll updates offset without changing selection" do
+      viewport = Viewport.from_dimensions(%{height: 3, viewport_height: 3, content_height: 8})
+
+      state = %{
+        values: Enum.map(1..8, &"item-#{&1}"),
+        selected: "item-2",
+        selected_index: 1,
+        offset: 1,
+        loop: true,
+        scroll_padding: 0,
+        width: 0
+      }
+
+      assert {:noreply, next_state} =
+               Implicit.List.handle_event(
+                 :ignore,
+                 %{"mouse" => %{button: :wheel_down}, "element" => viewport},
+                 state
+               )
+
+      assert next_state.offset == 2
+      assert next_state.selected == "item-2"
+      assert next_state.selected_index == 1
+    end
+
+    test "wheel scroll respects coalesced repeat counts" do
+      viewport = Viewport.from_dimensions(%{height: 3, viewport_height: 3, content_height: 8})
+
+      state = %{
+        values: Enum.map(1..8, &"item-#{&1}"),
+        selected: "item-2",
+        selected_index: 1,
+        offset: 1,
+        loop: true,
+        scroll_padding: 0,
+        width: 0
+      }
+
+      assert {:noreply, next_state} =
+               Implicit.List.handle_event(
+                 :ignore,
+                 %{"mouse" => %{button: :wheel_down, repeat: 3}, "element" => viewport},
+                 state
+               )
+
+      assert next_state.offset == 4
+      assert next_state.selected == "item-2"
+      assert next_state.selected_index == 1
+    end
   end
 
   describe "handle_modifiers/3" do

--- a/test/breeze/implicit/scroll_test.exs
+++ b/test/breeze/implicit/scroll_test.exs
@@ -49,6 +49,35 @@ defmodule Breeze.Implicit.ScrollTest do
       assert next_state.offset_y == 8
       assert next_state.pinned_bottom == true
     end
+
+    test "wheel scroll moves the viewport" do
+      viewport = %{viewport_height: 4, content_height: 12, height: 4}
+      state = %{offset_y: 3, autoscroll: nil, pinned_bottom: false}
+
+      assert {:noreply, next_state} =
+               Scroll.handle_event(
+                 :ignore_me,
+                 %{"mouse" => %{button: :wheel_down}, "element" => viewport},
+                 state
+               )
+
+      assert next_state.offset_y == 5
+      assert next_state.pinned_bottom == false
+    end
+
+    test "wheel scroll respects coalesced repeat counts" do
+      viewport = %{viewport_height: 4, content_height: 20, height: 4}
+      state = %{offset_y: 3, autoscroll: nil, pinned_bottom: false}
+
+      assert {:noreply, next_state} =
+               Scroll.handle_event(
+                 :ignore_me,
+                 %{"mouse" => %{button: :wheel_down, repeat: 3}, "element" => viewport},
+                 state
+               )
+
+      assert next_state.offset_y == 9
+    end
   end
 
   describe "reconcile/2" do

--- a/test/breeze/mouse_test.exs
+++ b/test/breeze/mouse_test.exs
@@ -1,0 +1,29 @@
+defmodule Breeze.MouseTest do
+  use ExUnit.Case, async: true
+
+  alias Breeze.Mouse
+
+  test "decodes sgr left click press" do
+    assert Mouse.decode("\e[<0;12;7M") ==
+             {:ok, %{button: :left, action: :press, x: 12, y: 7, modifiers: []}}
+  end
+
+  test "decodes sgr release" do
+    assert Mouse.decode("\e[<0;12;7m") ==
+             {:ok, %{button: :left, action: :release, x: 12, y: 7, modifiers: []}}
+  end
+
+  test "decodes sgr motion with modifiers" do
+    assert Mouse.decode("\e[<36;5;3M") ==
+             {:ok, %{button: :left, action: :move, x: 5, y: 3, modifiers: [:shift]}}
+  end
+
+  test "decodes sgr wheel scroll" do
+    assert Mouse.decode("\e[<65;20;4M") ==
+             {:ok, %{button: :wheel_down, action: :press, x: 20, y: 4, modifiers: []}}
+  end
+
+  test "rejects non mouse input" do
+    assert Mouse.decode("\e[A") == :error
+  end
+end

--- a/test/examples/posting_test.exs
+++ b/test/examples/posting_test.exs
@@ -1,9 +1,14 @@
 defmodule PostingTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   setup_all do
-    System.put_env("BREEZE_EXAMPLE_NO_START", "1")
+    Application.put_env(:breeze, :example_mode, :load_only)
     Code.require_file("examples/posting.exs")
+
+    on_exit(fn ->
+      Application.delete_env(:breeze, :example_mode)
+    end)
+
     :ok
   end
 


### PR DESCRIPTION
Mouse support is now enabled by passing `mouse: true` when starting the Breeze.Server. This uses hit detection on the rendered tree to determine which element is targetted, using the id. The mouse events are converted to a more meaningful input, with a map containing the button, location and target.

The scrolling and list implicits have been updated to support mouse-wheel based scrolling.