### PR TITLE
feat(Breeze.Server): render a crash screen on view failures

### DIFF
--- a/examples/crash_handler.exs
+++ b/examples/crash_handler.exs
@@ -1,0 +1,66 @@
+try do
+  :ok = :logger.set_handler_config(:default, :level, :emergency)
+rescue
+  _ -> :ok
+end
+
+defmodule CrashHandlerExample do
+  use Breeze.View
+
+  @tick_ms 1_000
+
+  def mount(_opts, term) do
+    Process.send_after(self(), :tick, @tick_ms)
+    {:ok, term |> assign(counter: 0) |> focus("boom")}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <box style="width-screen height-screen">
+      <box style="height-1 bold">Crash Handler Demo</box>
+      <box style="height-1">
+      </box>
+      <box style="grid grid-cols-1 grid-rows-2 height-full">
+        <box id="boom" focusable style="border-rounded width-32 height-3 focus:border-4">
+          <box>Press c to raise</box>
+          <box>Counter {@counter}</box>
+        </box>
+        <box style="height-1">
+        </box>
+        <box>q quits, r restarts after a crash</box>
+        <box style="height-1">
+        </box>
+        <live
+          id="logs"
+          view={Breeze.Logger}
+          start_opts={[title: "Captured logs", width: 72, height: 12, min_level: :debug, max_lines: 40, clear_key: nil]}
+        >
+        </live>
+      </box>
+    </box>
+    """
+  end
+
+  def handle_event(_, %{"key" => "c"}, _term) do
+    raise "crash demo"
+  end
+
+  def handle_event(_, %{"key" => "Enter"}, term) do
+    {:noreply, assign(term, counter: term.assigns.counter + 1)}
+  end
+
+  def handle_event(_, _, term), do: {:noreply, term}
+
+  def handle_info(:tick, term) do
+    Process.send_after(self(), :tick, @tick_ms)
+    {:noreply, assign(term, counter: term.assigns.counter + 1)}
+  end
+
+  def handle_info(_, term), do: {:noreply, term}
+end
+
+Breeze.Example.run(
+  view: CrashHandlerExample,
+  hide_cursor: true,
+  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+)

--- a/lib/breeze/error_view.ex
+++ b/lib/breeze/error_view.ex
@@ -1,0 +1,567 @@
+defmodule Breeze.ErrorView do
+  @moduledoc false
+
+  use Breeze.View
+
+  @stacktrace_id "error-stacktrace"
+  @history_id "error-history"
+  @focus_order [@stacktrace_id, @history_id]
+
+  def render_assigns(view, crash, %{width: width, height: height} = size) do
+    outer_width = max(width, 40)
+    outer_height = max(height, 12)
+    inner_width = max(outer_width - 2, 1)
+    inner_height = max(outer_height - 2, 1)
+    header_height = min(5, inner_height)
+    body_height = max(inner_height - header_height - 1, 1)
+    footer_height = max(inner_height - header_height - body_height, 0)
+    pane_gap = 1
+    pane_outer_width = max(div(max(inner_width - pane_gap, 1), 2), 24)
+    right_outer_width = max(inner_width - pane_outer_width - pane_gap, 24)
+    left_inner_width = max(pane_outer_width - 2, 1)
+    right_inner_width = max(right_outer_width - 2, 1)
+    pane_inner_height = max(body_height - 2, 1)
+    stacktrace_list_height = max(pane_inner_height - 1, 1)
+    history_scroll_height = max(pane_inner_height - 1, 1)
+
+    crash = prepare_crash(view, crash, size)
+    entries = frame_entries(crash)
+    selected_index = selected_index(crash, entries)
+    message_lines = message_lines(view, crash, entries, selected_index)
+    message_content_width = message_content_width(message_lines, right_inner_width)
+
+    %{
+      crash: crash,
+      outer_width: outer_width,
+      outer_height: outer_height,
+      header_height: header_height,
+      body_height: body_height,
+      footer_height: footer_height,
+      pane_gap: pane_gap,
+      left_pane_width: pane_outer_width,
+      right_pane_width: right_outer_width,
+      pane_inner_height: pane_inner_height,
+      selected_index: selected_index,
+      entry_count: length(entries),
+      stacktrace_pane_style:
+        pane_style(crash.focused == @stacktrace_id, pane_outer_width, body_height),
+      history_pane_style:
+        pane_style(crash.focused == @history_id, right_outer_width, body_height),
+      stacktrace_title_style: pane_title_style(left_inner_width),
+      history_title_style: pane_title_style(right_inner_width),
+      header_lines: header_lines(view, crash, inner_width, header_height),
+      footer_lines: footer_lines(inner_width, footer_height),
+      stacktrace_items:
+        Enum.with_index(entries)
+        |> Enum.map(fn {entry, index} ->
+          %{index: index, label: pad_line(entry.summary, left_inner_width)}
+        end),
+      history_lines: message_lines,
+      history_content_height: length(message_lines),
+      history_content_width: message_content_width,
+      stacktrace_list_width: left_inner_width,
+      stacktrace_list_height: stacktrace_list_height,
+      history_scroll_width: right_inner_width,
+      history_scroll_height: history_scroll_height
+    }
+  end
+
+  def frame_count(crash) do
+    length(frame_entries(crash))
+  end
+
+  def prepare_crash(view, crash, size) do
+    assigns = base_assigns(view, crash, size)
+    entries = frame_entries(crash)
+    selected_index = selected_index(crash, entries)
+    focused = normalize_focus(crash[:focused])
+
+    implicit_state =
+      normalize_implicit_state(crash[:implicit_state] || %{}, entries, assigns, selected_index)
+
+    crash
+    |> Map.put(:focused, focused)
+    |> Map.put(:implicit_state, implicit_state)
+    |> Map.put(:selected_index, selected_index_from_state(implicit_state, selected_index))
+  end
+
+  def handle_input(view, crash, input, size) do
+    crash = prepare_crash(view, crash, size)
+    assigns = render_assigns(view, crash, size)
+    entries = frame_entries(crash)
+
+    case input do
+      {:key, "r"} ->
+        :restart
+
+      {:key, key} when key in ["\t", "ArrowRight", "l"] ->
+        {:update, %{crash | focused: rotate_focus(crash.focused, 1)}}
+
+      {:key, key} when key in ["ShiftTab", "ArrowLeft", "h"] ->
+        {:update, %{crash | focused: rotate_focus(crash.focused, -1)}}
+
+      {:key, key} ->
+        {:update, dispatch_focused_key(crash, entries, assigns, key)}
+
+      _ ->
+        {:update, crash}
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <box style="border-rounded width-screen height-screen">
+      <box :for={line <- @header_lines} style={"width-#{@outer_width - 2}"}>{line}</box>
+      <box style={"inline width-#{@outer_width - 2} height-#{@body_height}"}>
+        <box style={@stacktrace_pane_style}>
+          <box style={@stacktrace_title_style}>Stacktrace</box>
+          <box
+            id="error-stacktrace"
+            focusable
+            implicit={Breeze.Implicit.List}
+            list-loop="true"
+            list-scroll-padding={1}
+            list-initial-index={@selected_index}
+            list-width={@stacktrace_list_width}
+            style={"width-#{@stacktrace_list_width} height-#{@stacktrace_list_height} overflow-scroll scrollbar-arrows focus:scrollbar-3"}
+          >
+            <box
+              :for={item <- @stacktrace_items}
+              value={Integer.to_string(item.index)}
+              style={"selected:bg-4 selected:text-7 focus:selected:text-7 focus:selected:bg-4 width-#{@stacktrace_list_width}"}
+            >
+              {item.label}
+            </box>
+          </box>
+        </box>
+        <box style={"width-#{@pane_gap}"}>
+        </box>
+        <box style={@history_pane_style}>
+          <box style={@history_title_style}>Crash Details</box>
+          <box
+            id="error-history"
+            focusable
+            implicit={Breeze.Implicit.Scroll}
+            style={"width-#{@history_scroll_width} height-#{@history_scroll_height} overflow-scroll scrollbar-arrows focus:scrollbar-3"}
+          >
+            <box :for={line <- @history_lines} style={"width-#{@history_content_width} height-1"}>
+              {line}
+            </box>
+          </box>
+        </box>
+      </box>
+      <box :for={line <- @footer_lines} style={"width-#{@outer_width - 2}"}>{line}</box>
+    </box>
+    """
+  end
+
+  def handle_event(_, _, term), do: {:noreply, term}
+  def handle_info(_, term), do: {:noreply, term}
+
+  defp dispatch_focused_key(crash, entries, assigns, key) do
+    case crash.focused do
+      @stacktrace_id ->
+        dispatch_stacktrace_key(crash, entries, assigns, key)
+
+      @history_id ->
+        dispatch_history_key(crash, assigns, key)
+
+      _ ->
+        crash
+    end
+  end
+
+  defp dispatch_stacktrace_key(crash, _entries, assigns, key) do
+    case Map.get(crash.implicit_state, @stacktrace_id) do
+      {Breeze.Implicit.List, implicit} ->
+        payload = %{"key" => key, "element" => list_element(assigns)}
+
+        case Breeze.Implicit.List.handle_event(:ignore_me, payload, implicit) do
+          {{:change, %{index: index}}, updated} ->
+            put_crash_implicit(crash, @stacktrace_id, Breeze.Implicit.List, updated, index)
+
+          {:noreply, updated} ->
+            put_crash_implicit(
+              crash,
+              @stacktrace_id,
+              Breeze.Implicit.List,
+              updated,
+              updated.selected_index
+            )
+        end
+
+      _ ->
+        crash
+    end
+  end
+
+  defp dispatch_history_key(crash, assigns, key) do
+    case Map.get(crash.implicit_state, @history_id) do
+      {Breeze.Implicit.Scroll, implicit} ->
+        payload = %{"key" => key, "element" => scroll_element(assigns)}
+
+        case Breeze.Implicit.Scroll.handle_event(:ignore_me, payload, implicit) do
+          {:noreply, updated} ->
+            put_crash_implicit(
+              crash,
+              @history_id,
+              Breeze.Implicit.Scroll,
+              updated,
+              crash.selected_index
+            )
+        end
+
+      _ ->
+        crash
+    end
+  end
+
+  defp put_crash_implicit(crash, id, mod, state, selected_index) do
+    crash
+    |> Map.put(:implicit_state, Map.put(crash.implicit_state || %{}, id, {mod, state}))
+    |> Map.put(:selected_index, selected_index || 0)
+  end
+
+  defp base_assigns(_view, _crash, %{width: width, height: height}) do
+    outer_width = max(width, 40)
+    outer_height = max(height, 12)
+    inner_width = max(outer_width - 2, 1)
+    inner_height = max(outer_height - 2, 1)
+    header_height = min(5, inner_height)
+    body_height = max(inner_height - header_height - 1, 1)
+    pane_gap = 1
+    pane_outer_width = max(div(max(inner_width - pane_gap, 1), 2), 24)
+    right_outer_width = max(inner_width - pane_outer_width - pane_gap, 24)
+    left_inner_width = max(pane_outer_width - 2, 1)
+    right_inner_width = max(right_outer_width - 2, 1)
+    pane_inner_height = max(body_height - 2, 1)
+
+    %{
+      left_inner_width: left_inner_width,
+      right_inner_width: right_inner_width,
+      pane_inner_height: pane_inner_height,
+      stacktrace_list_height: max(pane_inner_height - 1, 1),
+      history_scroll_height: max(pane_inner_height - 1, 1)
+    }
+  end
+
+  defp normalize_implicit_state(implicit_state, entries, assigns, selected_index) do
+    stacktrace_children =
+      Enum.with_index(entries)
+      |> Enum.map(fn {_entry, index} -> %{value: Integer.to_string(index)} end)
+
+    list_state =
+      case Map.get(implicit_state, @stacktrace_id) do
+        {Breeze.Implicit.List, state} ->
+          Breeze.Implicit.List.init(
+            stacktrace_children,
+            list_root_attrs(assigns, selected_index),
+            state
+          )
+
+        _ ->
+          Breeze.Implicit.List.init(
+            stacktrace_children,
+            list_root_attrs(assigns, selected_index),
+            %{}
+          )
+      end
+
+    history_state =
+      case Map.get(implicit_state, @history_id) do
+        {Breeze.Implicit.Scroll, state} ->
+          Breeze.Implicit.Scroll.init([], %{}, state)
+
+        _ ->
+          Breeze.Implicit.Scroll.init([], %{}, %{})
+      end
+
+    %{
+      @stacktrace_id => {Breeze.Implicit.List, list_state},
+      @history_id => {Breeze.Implicit.Scroll, history_state}
+    }
+  end
+
+  defp selected_index(crash, entries) do
+    default = default_selected_index(entries)
+
+    case Map.get(crash[:implicit_state] || %{}, @stacktrace_id) do
+      {Breeze.Implicit.List, state} ->
+        normalize_index(state.selected_index, length(entries), default)
+
+      _ ->
+        normalize_index(crash[:selected_index], length(entries), default)
+    end
+  end
+
+  defp selected_index_from_state(implicit_state, fallback) do
+    case Map.get(implicit_state, @stacktrace_id) do
+      {Breeze.Implicit.List, state} -> state.selected_index || fallback
+      _ -> fallback
+    end
+  end
+
+  defp list_root_attrs(assigns, selected_index) do
+    %{
+      :"list-loop" => true,
+      :"list-scroll-padding" => 1,
+      :"list-initial-index" => selected_index,
+      :"list-width" => assigns.left_inner_width
+    }
+  end
+
+  defp list_element(assigns) do
+    %{
+      width: assigns.stacktrace_list_width,
+      height: assigns.stacktrace_list_height,
+      viewport_width: assigns.stacktrace_list_width,
+      viewport_height: assigns.stacktrace_list_height
+    }
+  end
+
+  defp scroll_element(assigns) do
+    %{
+      width: assigns.history_scroll_width,
+      height: assigns.history_scroll_height,
+      viewport_width: assigns.history_scroll_width,
+      viewport_height: assigns.history_scroll_height,
+      content_width: assigns.history_content_width,
+      content_height: assigns.history_content_height
+    }
+  end
+
+  defp pane_title_style(width), do: "width-#{width}"
+
+  defp pane_style(true, pane_outer_width, body_height),
+    do: "border border-4 width-#{pane_outer_width - 2} height-#{body_height - 2}"
+
+  defp pane_style(false, pane_outer_width, body_height),
+    do: "border width-#{pane_outer_width - 2} height-#{body_height - 2}"
+
+  defp rotate_focus(current, delta) do
+    index = Enum.find_index(@focus_order, &(&1 == current)) || 0
+    size = length(@focus_order)
+    Enum.at(@focus_order, rem(index + delta + size, size))
+  end
+
+  defp normalize_focus(focused) when focused in @focus_order, do: focused
+  defp normalize_focus(_focused), do: @stacktrace_id
+
+  defp header_lines(view, crash, width, height) do
+    [
+      "Breeze Error",
+      "View #{inspect(view)}",
+      "",
+      Exception.format_banner(crash.kind, crash.reason, crash.stacktrace)
+    ]
+    |> Enum.flat_map(&split_lines/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.take(max(height, 1))
+    |> pad_lines(width, height)
+  end
+
+  defp footer_lines(_width, 0), do: []
+
+  defp footer_lines(width, height) do
+    [
+      "Tab switches panes. Arrow keys or j/k move and scroll. Press r to restart. Press q to quit."
+    ]
+    |> pad_lines(width, height)
+  end
+
+  defp message_lines(view, _crash, [], _selected_index) do
+    ["Selected Frame", "", "View #{inspect(view)}", "", "No stacktrace frames captured"]
+  end
+
+  defp message_lines(view, crash, entries, selected_index) do
+    selected = Enum.at(entries, selected_index)
+
+    [
+      "Selected Frame",
+      "",
+      "View #{inspect(view)}"
+      | selected.detail_lines
+    ] ++ ["", "Crash Message", ""] ++ wrap_lines(crash_message_lines(crash), 80)
+  end
+
+  defp crash_message_lines(crash) do
+    case formatted_exception_lines(crash) do
+      [] -> ["No crash message available"]
+      lines -> lines
+    end
+  end
+
+  defp selected_frame_lines(nil), do: ["No stacktrace frames captured"]
+
+  defp selected_frame_lines(frame) do
+    [
+      "",
+      "Module   #{inspect(frame.module)}",
+      "Function #{frame.function}/#{frame.arity}",
+      "File     #{frame.file}",
+      "Line     #{frame.line}"
+    ]
+  end
+
+  defp frame_entries(crash) do
+    frames = frame_maps(crash.stacktrace)
+
+    if frames == [] do
+      fallback_entries(crash)
+    else
+      Enum.map(frames, fn frame ->
+        %{
+          summary:
+            "#{String.pad_leading(Integer.to_string(frame.index), 2)} #{frame_summary(frame)}",
+          detail_lines: selected_frame_lines(frame),
+          app?: app_frame?(frame)
+        }
+      end)
+    end
+  end
+
+  defp app_frame?(%{file: file}) when is_binary(file) do
+    String.contains?(file, "/lib/") or String.contains?(file, "/test/")
+  end
+
+  defp app_frame?(_frame), do: false
+
+  defp frame_maps(stacktrace) do
+    stacktrace
+    |> Enum.with_index(1)
+    |> Enum.map(fn {frame, index} -> frame_map(frame, index) end)
+  end
+
+  defp frame_map({module, function, arity, location}, index) do
+    %{
+      index: index,
+      module: module,
+      module_name: inspect(module),
+      function: function,
+      arity: arity,
+      file: normalize_file(location[:file]),
+      line: location[:line] || 0
+    }
+  end
+
+  defp frame_map(other, index) do
+    %{
+      index: index,
+      module: :unknown,
+      module_name: inspect(other),
+      function: :unknown,
+      arity: 0,
+      file: inspect(other),
+      line: 0
+    }
+  end
+
+  defp frame_summary(frame) do
+    "#{frame.module_name}.#{frame.function}/#{frame.arity} #{Path.basename(frame.file)}:#{frame.line}"
+  end
+
+  defp fallback_entries(crash) do
+    formatted_lines = formatted_exception_lines(crash)
+
+    [
+      %{
+        summary: "01 No structured stacktrace captured",
+        detail_lines:
+          [
+            "",
+            "No structured stacktrace captured",
+            ""
+          ] ++ formatted_lines,
+        app?: true
+      }
+    ]
+  end
+
+  defp default_selected_index(entries) do
+    case Enum.find_index(entries, & &1.app?) do
+      nil -> 0
+      index -> index
+    end
+  end
+
+  defp normalize_file(nil), do: "unknown"
+  defp normalize_file(file), do: file |> to_string() |> Path.relative_to_cwd()
+
+  defp formatted_exception_lines(crash) do
+    crash.kind
+    |> Exception.format(crash.reason, crash.stacktrace)
+    |> String.split("\n", trim: true)
+  end
+
+  defp normalize_index(nil, _length, default), do: default
+  defp normalize_index(_index, 0, _default), do: 0
+
+  defp normalize_index(index, length, _default) when is_integer(index),
+    do: min(max(index, 0), length - 1)
+
+  defp normalize_index(_index, _length, default), do: default
+
+  defp split_lines(text), do: String.split(to_string(text), "\n", trim: false)
+
+  defp pad_lines(lines, width, height) do
+    padded = Enum.map(lines, &pad_line(&1, width))
+    padded ++ List.duplicate(String.duplicate(" ", width), max(height - length(padded), 0))
+  end
+
+  defp pad_line(line, width) do
+    line
+    |> truncate_line(width)
+    |> String.pad_trailing(width)
+  end
+
+  defp truncate_line(line, width) when byte_size(line) <= width, do: line
+  defp truncate_line(line, width) when width > 1, do: String.slice(line, 0, width - 1) <> "..."
+  defp truncate_line(line, width), do: String.slice(line, 0, width)
+
+  defp message_content_width(lines, min_width) do
+    Enum.reduce(lines, min_width, fn line, width ->
+      max(width, String.length(to_string(line)))
+    end)
+  end
+
+  defp wrap_lines(lines, width) do
+    Enum.flat_map(lines, &wrap_line(&1, width))
+  end
+
+  defp wrap_line(line, width) when width <= 1, do: [String.slice(to_string(line), 0, 1)]
+
+  defp wrap_line(line, width) do
+    line = to_string(line)
+
+    cond do
+      line == "" ->
+        [""]
+
+      String.length(line) <= width ->
+        [line]
+
+      true ->
+        segment = String.slice(line, 0, width)
+
+        split_at =
+          case String.split(segment, " ") do
+            [_single] ->
+              width
+
+            parts ->
+              parts
+              |> Enum.drop(-1)
+              |> Enum.join(" ")
+              |> String.length()
+          end
+
+        split_at = if split_at <= 0, do: width, else: split_at
+        chunk = String.slice(line, 0, split_at)
+
+        rest =
+          line |> String.slice(split_at, String.length(line) - split_at) |> String.trim_leading()
+
+        [chunk | wrap_line(rest, width)]
+    end
+  end
+end

--- a/lib/breeze/logger.ex
+++ b/lib/breeze/logger.ex
@@ -26,6 +26,12 @@ defmodule Breeze.Logger do
        width: Keyword.get(opts, :width, 80),
        height: Keyword.get(opts, :height, 18),
        min_level: Keyword.get(opts, :min_level, :debug),
+       clear_key: Keyword.get(opts, :clear_key, "c"),
+       helper_text:
+         helper_text(
+           Keyword.get(opts, :min_level, :debug),
+           Keyword.get(opts, :clear_key, "c")
+         ),
        max_lines: Keyword.get(opts, :max_lines, @default_max_lines),
        lines: []
      )}
@@ -35,7 +41,7 @@ defmodule Breeze.Logger do
     ~H"""
     <box style={"width-#{@width}"}>
       <box style="bold">{@title}</box>
-      <box>Showing {@min_level}+ logs. Use j/k or arrows to scroll. Press c to clear.</box>
+      <box>{@helper_text}</box>
       <box
         id="logger"
         focusable
@@ -49,7 +55,8 @@ defmodule Breeze.Logger do
     """
   end
 
-  def handle_event(_, %{"key" => "c"}, term) do
+  def handle_event(_, %{"key" => key}, %{assigns: %{clear_key: key}} = term)
+      when is_binary(key) do
     :ok = Breeze.LoggerCollector.clear()
     {:noreply, assign(term, lines: [])}
   end
@@ -102,4 +109,13 @@ defmodule Breeze.Logger do
   defp level_style(:alert), do: "text-1 bold"
   defp level_style(:emergency), do: "text-1 bold bg-11"
   defp level_style(_), do: "text-7"
+
+  defp helper_text(min_level, nil), do: "Showing #{min_level}+ logs. Use j/k or arrows to scroll."
+
+  defp helper_text(min_level, false),
+    do: "Showing #{min_level}+ logs. Use j/k or arrows to scroll."
+
+  defp helper_text(min_level, clear_key) do
+    "Showing #{min_level}+ logs. Use j/k or arrows to scroll. Press #{clear_key} to clear."
+  end
 end

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -44,7 +44,11 @@ defmodule Breeze.Server do
     :terminal,
     :reader,
     :view_pid,
+    :view,
+    :start_opts,
+    :mouse_mode,
     :focused,
+    :crash,
     :base_output,
     :last_frame_payload,
     :pending_ref,
@@ -139,6 +143,9 @@ defmodule Breeze.Server do
       terminal: terminal,
       reader: Keyword.get(opts, :reader, terminal.reader),
       view_pid: view_pid,
+      view: view,
+      start_opts: start_opts,
+      mouse_mode: Keyword.get(opts, :mouse, false),
       focused: focused,
       global_keybindings: Keyword.get(opts, :global_keybindings, []),
       busy_delay_ms: Keyword.get(opts, :busy_delay_ms, 120),
@@ -187,26 +194,44 @@ defmodule Breeze.Server do
   end
 
   def handle_info({reader, {:signal, :winch}}, %{reader: reader} = state) do
-    terminal = Termite.Terminal.resize(state.terminal)
-    state = %{state | terminal: terminal}
+    if crashed?(state) do
+      terminal = Termite.Terminal.resize(state.terminal)
+      {:noreply, render_crash(%{state | terminal: terminal})}
+    else
+      terminal = Termite.Terminal.resize(state.terminal)
+      state = %{state | terminal: terminal}
 
-    case Breeze.ChildServer.dispatch_info(state.view_pid, :resize, terminal) do
-      {:stop, _focused} ->
-        stop(state)
+      case safe_call(fn ->
+             Breeze.ChildServer.dispatch_info(state.view_pid, :resize, terminal)
+           end) do
+        {:ok, {:stop, _focused}} ->
+          stop(state)
 
-      {:noreply, focused} ->
-        {:noreply, maybe_render_base(%{state | focused: focused}, :resize)}
+        {:ok, {:noreply, focused}} ->
+          {:noreply, maybe_render_base(%{state | focused: focused}, :resize)}
+
+        {:crash, crash} ->
+          {:noreply, enter_crash_state(state, crash)}
+      end
     end
   end
 
   def handle_info(:child_invalidated, state) do
-    state = increment_debug_stat(state, :child_invalidated_count)
-    {:noreply, maybe_render_base(state, :child_invalidated)}
+    if crashed?(state) do
+      {:noreply, state}
+    else
+      state = increment_debug_stat(state, :child_invalidated_count)
+      {:noreply, maybe_render_base(state, :child_invalidated)}
+    end
   end
 
   def handle_info({:child_invalidated, child_id}, state) do
-    state = increment_debug_stat(state, :child_invalidated_count)
-    {:noreply, maybe_render_invalidated_child(state, child_id)}
+    if crashed?(state) do
+      {:noreply, state}
+    else
+      state = increment_debug_stat(state, :child_invalidated_count)
+      {:noreply, maybe_render_invalidated_child(state, child_id)}
+    end
   end
 
   def handle_info(@flush_input_batch, state) do
@@ -259,6 +284,9 @@ defmodule Breeze.Server do
 
   def handle_info({:event_reply, ref, reply}, %{pending_ref: ref} = state) do
     case reply do
+      {:crash, crash} ->
+        {:noreply, enter_crash_state(state, crash)}
+
       {:stop, _focused} ->
         stop(state)
 
@@ -292,7 +320,18 @@ defmodule Breeze.Server do
   def handle_info(message, state) do
     case message do
       {:DOWN, _, :process, pid, _reason} when pid == state.view_pid ->
-        stop(state)
+        reason = elem(message, 4)
+
+        cond do
+          crashed?(state) ->
+            {:noreply, state}
+
+          reason == :normal ->
+            stop(state)
+
+          true ->
+            {:noreply, enter_crash_state(state, crash_info(:exit, reason, []))}
+        end
 
       {:DOWN, ref, :process, _pid, _reason} ->
         cond do
@@ -358,20 +397,28 @@ defmodule Breeze.Server do
   end
 
   defp handle_decoded_sync_input({:mouse, event}, state) do
-    handle_mouse(event, state)
+    if crashed?(state), do: {:noreply, state}, else: handle_mouse(event, state)
   end
 
   defp handle_decoded_sync_input({:key, key}, state) do
-    case key do
-      key when key in ["\t", "ShiftTab"] ->
-        state
-        |> touch_interaction()
-        |> apply_input_reply(Breeze.ChildServer.dispatch_input(state.view_pid, key))
+    if crashed?(state) do
+      {:noreply, dispatch_crash_input({:key, key}, touch_interaction(state))}
+    else
+      case key do
+        key when key in ["\t", "ShiftTab"] ->
+          state
+          |> touch_interaction()
+          |> safe_apply_input_reply(fn state ->
+            Breeze.ChildServer.dispatch_input(state.view_pid, key)
+          end)
 
-      key ->
-        state
-        |> touch_interaction()
-        |> apply_input_reply(dispatch_input_hierarchy(state, key))
+        key ->
+          state
+          |> touch_interaction()
+          |> safe_apply_input_reply(fn state ->
+            dispatch_input_hierarchy(state, key)
+          end)
+      end
     end
   end
 
@@ -380,13 +427,19 @@ defmodule Breeze.Server do
   end
 
   defp handle_deferred_input({:key, key}, state) do
-    {:noreply, start_async_dispatch(touch_interaction(state), key)}
+    if crashed?(state) do
+      {:noreply, dispatch_crash_input({:key, key}, touch_interaction(state))}
+    else
+      {:noreply, start_async_dispatch(touch_interaction(state), key)}
+    end
   end
 
   defp handle_deferred_input(_decoded, state), do: {:noreply, state}
 
   defp sync_input_message?({:mouse, _event}, %{pending_ref: nil}), do: true
   defp sync_input_message?({:mouse, _event}, _state), do: false
+
+  defp sync_input_message?({:key, _key}, %{crash: crash}) when not is_nil(crash), do: true
 
   defp sync_input_message?({:key, key}, state) do
     stop_global_key?(key, state) or
@@ -451,117 +504,144 @@ defmodule Breeze.Server do
   defp focused_implicit?(state) do
     case focused_child_chain(state) do
       [{_child_id, %{pid: pid}} | _] ->
-        match?(%{focused_implicit_id: id} when not is_nil(id), Breeze.ChildServer.metadata(pid))
+        case safe_call(fn -> Breeze.ChildServer.metadata(pid) end) do
+          {:ok, metadata} -> match?(%{focused_implicit_id: id} when not is_nil(id), metadata)
+          {:crash, _crash} -> false
+        end
 
       [] ->
-        match?(
-          %{focused_implicit_id: id} when not is_nil(id),
-          Breeze.ChildServer.metadata(state.view_pid)
-        )
+        case safe_call(fn -> Breeze.ChildServer.metadata(state.view_pid) end) do
+          {:ok, metadata} -> match?(%{focused_implicit_id: id} when not is_nil(id), metadata)
+          {:crash, _crash} -> false
+        end
     end
   end
 
   defp handle_mouse(event, state) do
     state
     |> touch_interaction()
-    |> apply_input_reply(Breeze.ChildServer.dispatch_input(state.view_pid, %{"mouse" => event}))
+    |> safe_apply_input_reply(fn state ->
+      Breeze.ChildServer.dispatch_input(state.view_pid, %{"mouse" => event})
+    end)
   end
 
   defp render_base(state, cause \\ :unknown, attempts \\ 1)
 
   defp render_base(state, cause, attempts) do
-    tracking_ref = begin_render_tracking()
-    started_at = System.monotonic_time(:microsecond)
-    profile_scope = make_ref()
-    Breeze.DebugProfiler.reset(profile_scope)
-    root_started_at = System.monotonic_time(:microsecond)
-
-    {:ok, acc, box, decorations} =
-      Breeze.ChildServer.render_snapshot(state.view_pid,
-        implicit_state: %{},
-        terminal: state.terminal,
-        render_tracking_ref: tracking_ref,
-        profile_scope: profile_scope,
-        profile_label: inspect(root_view_module(state)),
-        live_view: fn attrs, opts ->
-          render_live_child(attrs, opts, state, profile_scope, tracking_ref)
-        end
-      )
-
-    root_snapshot_us = System.monotonic_time(:microsecond) - root_started_at
-
-    focused =
-      case Breeze.ChildServer.metadata(state.view_pid) do
-        %{focused: focused} -> focused
-        _ -> state.focused
-      end
-
-    %{
-      missing: missing,
-      decorations: child_decorations,
-      child_timings: child_timings
-    } = finish_render_tracking(tracking_ref)
-
-    profile_entries = Breeze.DebugProfiler.snapshot(profile_scope)
-    {state, started?} = ensure_children(state, missing)
-
-    if started? do
-      render_base(state, cause, attempts)
+    if crashed?(state) do
+      state
     else
-      cond do
-        attempts > 0 and focused != state.focused ->
-          render_base(%{state | focused: focused}, cause, attempts - 1)
+      try do
+        tracking_ref = begin_render_tracking()
+        started_at = System.monotonic_time(:microsecond)
+        profile_scope = make_ref()
+        Breeze.DebugProfiler.reset(profile_scope)
+        root_started_at = System.monotonic_time(:microsecond)
 
-        true ->
-          decorations = decorations ++ child_decorations
-          state = %{state | focused: focused}
-          prep_started_at = System.monotonic_time(:microsecond)
-          {base_output, decorations} = prepare_decorations(box.content, decorations, state)
-          prepare_decorations_us = System.monotonic_time(:microsecond) - prep_started_at
-          render_base_us = System.monotonic_time(:microsecond) - started_at
+        {:ok, acc, box, decorations} =
+          case safe_call(fn ->
+                 Breeze.ChildServer.render_snapshot(state.view_pid,
+                   implicit_state: %{},
+                   terminal: state.terminal,
+                   render_tracking_ref: tracking_ref,
+                   profile_scope: profile_scope,
+                   profile_label: inspect(root_view_module(state)),
+                   live_view: fn attrs, opts ->
+                     render_live_child(attrs, opts, state, profile_scope, tracking_ref)
+                   end
+                 )
+               end) do
+            {:ok, result} ->
+              result
 
-          debug_live_child_us = debug_live_child_us(child_timings)
-          app_live_children = non_debug_child_timings(child_timings)
+            {:crash, crash} ->
+              throw({:crash_state, enter_crash_state(state, crash)})
+          end
 
-          state
-          |> increment_debug_stat(:render_base_count)
-          |> Map.put(:base_output, base_output)
-          |> Map.put(:rendered_elements, viewports_from_acc(acc))
-          |> Map.put(:rendered_boxes, acc.boxes)
-          |> Map.put(:decorations, decorations)
-          |> Map.put(:focused, focused)
-          |> Map.put(:last_render_at, System.monotonic_time(:millisecond))
-          |> put_debug_stat(:last_render_cause, cause)
-          |> put_debug_stat(:last_root_snapshot_us, root_snapshot_us)
-          |> put_debug_stat(
-            :last_root_snapshot_app_us,
-            max(root_snapshot_us - debug_live_child_us, 0)
-          )
-          |> put_debug_stat(:last_live_children_us, sum_timing_us(child_timings))
-          |> put_debug_stat(:last_live_children_app_us, sum_timing_us(app_live_children))
-          |> put_debug_stat(:last_live_children, normalize_child_timings(app_live_children))
-          |> put_debug_stat(:last_render_profile, summarize_profile(profile_entries))
-          |> put_debug_stat(:last_reconcile_passes, 0)
-          |> put_debug_stat(:last_reconcile_changed_ids, nil)
-          |> put_debug_stat(:last_prepare_decorations_us, prepare_decorations_us)
-          |> put_debug_stat(:last_render_base_us, render_base_us)
-          |> put_debug_stat(
-            :last_render_base_app_us,
-            max(render_base_us - debug_live_child_us, 0)
-          )
-          |> render_frame()
-          |> schedule_animation()
+        root_snapshot_us = System.monotonic_time(:microsecond) - root_started_at
+
+        focused =
+          case safe_call(fn -> Breeze.ChildServer.metadata(state.view_pid) end) do
+            {:ok, %{focused: focused}} -> focused
+            {:ok, _} -> state.focused
+            {:crash, crash} -> throw({:crash_state, enter_crash_state(state, crash)})
+          end
+
+        %{
+          missing: missing,
+          decorations: child_decorations,
+          child_timings: child_timings
+        } = finish_render_tracking(tracking_ref)
+
+        profile_entries = Breeze.DebugProfiler.snapshot(profile_scope)
+        {state, started?} = ensure_children(state, missing)
+
+        if started? do
+          render_base(state, cause, attempts)
+        else
+          cond do
+            attempts > 0 and focused != state.focused ->
+              render_base(%{state | focused: focused}, cause, attempts - 1)
+
+            true ->
+              decorations = decorations ++ child_decorations
+              state = %{state | focused: focused}
+              prep_started_at = System.monotonic_time(:microsecond)
+              {base_output, decorations} = prepare_decorations(box.content, decorations, state)
+              prepare_decorations_us = System.monotonic_time(:microsecond) - prep_started_at
+              render_base_us = System.monotonic_time(:microsecond) - started_at
+
+              debug_live_child_us = debug_live_child_us(child_timings)
+              app_live_children = non_debug_child_timings(child_timings)
+
+              state
+              |> increment_debug_stat(:render_base_count)
+              |> Map.put(:base_output, base_output)
+              |> Map.put(:rendered_elements, viewports_from_acc(acc))
+              |> Map.put(:rendered_boxes, acc.boxes)
+              |> Map.put(:decorations, decorations)
+              |> Map.put(:focused, focused)
+              |> Map.put(:last_render_at, System.monotonic_time(:millisecond))
+              |> put_debug_stat(:last_render_cause, cause)
+              |> put_debug_stat(:last_root_snapshot_us, root_snapshot_us)
+              |> put_debug_stat(
+                :last_root_snapshot_app_us,
+                max(root_snapshot_us - debug_live_child_us, 0)
+              )
+              |> put_debug_stat(:last_live_children_us, sum_timing_us(child_timings))
+              |> put_debug_stat(:last_live_children_app_us, sum_timing_us(app_live_children))
+              |> put_debug_stat(:last_live_children, normalize_child_timings(app_live_children))
+              |> put_debug_stat(:last_render_profile, summarize_profile(profile_entries))
+              |> put_debug_stat(:last_reconcile_passes, 0)
+              |> put_debug_stat(:last_reconcile_changed_ids, nil)
+              |> put_debug_stat(:last_prepare_decorations_us, prepare_decorations_us)
+              |> put_debug_stat(:last_render_base_us, render_base_us)
+              |> put_debug_stat(
+                :last_render_base_app_us,
+                max(render_base_us - debug_live_child_us, 0)
+              )
+              |> render_frame()
+              |> schedule_animation()
+          end
+        end
+      catch
+        {:crash_state, crash_state} -> crash_state
       end
     end
   end
 
   defp maybe_render_base(%{view_pid: pid} = state, cause) do
-    if Process.alive?(pid), do: render_base(state, cause), else: state
+    if crashed?(state) do
+      state
+    else
+      if Process.alive?(pid), do: render_base(state, cause), else: state
+    end
   end
 
   defp maybe_render_invalidated_child(state, child_id) do
     case render_invalidated_child(state, child_id) do
       {:ok, state} -> state
+      {:crash, state} -> state
       :error -> maybe_render_base(state, :child_invalidated)
     end
   end
@@ -587,18 +667,29 @@ defmodule Breeze.Server do
           child_started_at = System.monotonic_time(:microsecond)
 
           {:ok, child_acc, child_box, child_decorations} =
-            Breeze.ChildServer.render_snapshot(pid,
-              focused: local_focused,
-              implicit_state: %{},
-              terminal: state.terminal,
-              live_prefix: full_id,
-              render_tracking_ref: tracking_ref,
-              profile_scope: profile_scope,
-              profile_label: "#{full_id} #{inspect(state.children[full_id].view)}",
-              live_view: fn child_attrs, child_opts ->
-                render_live_child(child_attrs, child_opts, state, profile_scope, tracking_ref)
-              end
-            )
+            case safe_call(fn ->
+                   Breeze.ChildServer.render_snapshot(pid,
+                     focused: local_focused,
+                     implicit_state: %{},
+                     terminal: state.terminal,
+                     live_prefix: full_id,
+                     render_tracking_ref: tracking_ref,
+                     profile_scope: profile_scope,
+                     profile_label: "#{full_id} #{inspect(state.children[full_id].view)}",
+                     live_view: fn child_attrs, child_opts ->
+                       render_live_child(
+                         child_attrs,
+                         child_opts,
+                         state,
+                         profile_scope,
+                         tracking_ref
+                       )
+                     end
+                   )
+                 end) do
+              {:ok, result} -> result
+              {:crash, crash} -> throw({:crash_state, enter_crash_state(state, crash)})
+            end
 
           track_child_timing(tracking_ref, %{
             id: full_id,
@@ -616,82 +707,97 @@ defmodule Breeze.Server do
   end
 
   defp render_invalidated_child(state, child_id) do
-    with true <- patchable_live_child?(child_id),
-         %{pid: pid, view: view} <- Map.get(state.children, child_id),
-         %Breeze.Viewport{} = viewport <- Map.get(state.rendered_elements, child_id) do
-      tracking_ref = begin_render_tracking()
-      profile_scope = make_ref()
-      Breeze.DebugProfiler.reset(profile_scope)
-      started_at = System.monotonic_time(:microsecond)
+    try do
+      with true <- patchable_live_child?(child_id),
+           %{pid: pid, view: view} <- Map.get(state.children, child_id),
+           %Breeze.Viewport{} = viewport <- Map.get(state.rendered_elements, child_id) do
+        tracking_ref = begin_render_tracking()
+        profile_scope = make_ref()
+        Breeze.DebugProfiler.reset(profile_scope)
+        started_at = System.monotonic_time(:microsecond)
 
-      {:ok, _child_acc, child_box, child_decorations} =
-        Breeze.ChildServer.render_snapshot(pid,
-          focused: strip_live_prefix(state.focused, child_id),
-          implicit_state: %{},
-          terminal: state.terminal,
-          live_prefix: child_id,
-          render_tracking_ref: tracking_ref,
-          profile_scope: profile_scope,
-          profile_label: "#{child_id} #{inspect(view)}",
-          live_view: fn child_attrs, child_opts ->
-            render_live_child(child_attrs, child_opts, state, profile_scope, tracking_ref)
+        {:ok, _child_acc, child_box, child_decorations} =
+          case safe_call(fn ->
+                 Breeze.ChildServer.render_snapshot(pid,
+                   focused: strip_live_prefix(state.focused, child_id),
+                   implicit_state: %{},
+                   terminal: state.terminal,
+                   live_prefix: child_id,
+                   render_tracking_ref: tracking_ref,
+                   profile_scope: profile_scope,
+                   profile_label: "#{child_id} #{inspect(view)}",
+                   live_view: fn child_attrs, child_opts ->
+                     render_live_child(
+                       child_attrs,
+                       child_opts,
+                       state,
+                       profile_scope,
+                       tracking_ref
+                     )
+                   end
+                 )
+               end) do
+            {:ok, result} -> result
+            {:crash, crash} -> throw({:crash_state, enter_crash_state(state, crash)})
           end
-        )
 
-      child_render_us = System.monotonic_time(:microsecond) - started_at
+        child_render_us = System.monotonic_time(:microsecond) - started_at
 
-      %{missing: missing, decorations: tracked_decorations, child_timings: child_timings} =
-        finish_render_tracking(tracking_ref)
+        %{missing: missing, decorations: tracked_decorations, child_timings: child_timings} =
+          finish_render_tracking(tracking_ref)
 
-      cond do
-        missing != [] ->
-          :error
+        cond do
+          missing != [] ->
+            :error
 
-        child_decorations != [] or tracked_decorations != [] or child_timings != [] ->
-          :error
+          child_decorations != [] or tracked_decorations != [] or child_timings != [] ->
+            :error
 
-        true ->
-          fragment =
-            child_box
-            |> wrap_child_fragment(viewport)
-            |> BackBreeze.Box.render(terminal: state.terminal)
-            |> Map.fetch!(:content)
+          true ->
+            fragment =
+              child_box
+              |> wrap_child_fragment(viewport)
+              |> BackBreeze.Box.render(terminal: state.terminal)
+              |> Map.fetch!(:content)
 
-          composed_at = System.monotonic_time(:microsecond)
-          payload = child_patch_payload(fragment, viewport)
-          terminal = Termite.Terminal.write(state.terminal, payload)
-          written_at = System.monotonic_time(:microsecond)
-          total_us = written_at - started_at
-          write_us = written_at - composed_at
-          profile_entries = Breeze.DebugProfiler.snapshot(profile_scope)
+            composed_at = System.monotonic_time(:microsecond)
+            payload = child_patch_payload(fragment, viewport)
+            terminal = Termite.Terminal.write(state.terminal, payload)
+            written_at = System.monotonic_time(:microsecond)
+            total_us = written_at - started_at
+            write_us = written_at - composed_at
+            profile_entries = Breeze.DebugProfiler.snapshot(profile_scope)
 
-          {:ok,
-           state
-           |> Map.put(:terminal, terminal)
-           |> Map.put(:last_frame_payload, nil)
-           |> put_debug_stat(:last_render_cause, :child_patch)
-           |> put_debug_stat(:last_root_snapshot_us, 0)
-           |> put_debug_stat(:last_root_snapshot_app_us, 0)
-           |> put_debug_stat(:last_live_children_us, child_render_us)
-           |> put_debug_stat(:last_live_children_app_us, child_render_us)
-           |> put_debug_stat(
-             :last_live_children,
-             normalize_child_timings([%{id: child_id, view: view, us: child_render_us}])
-           )
-           |> put_debug_stat(:last_render_profile, summarize_profile(profile_entries))
-           |> put_debug_stat(:last_reconcile_passes, 1)
-           |> put_debug_stat(:last_reconcile_changed_ids, [child_id])
-           |> put_debug_stat(:last_prepare_decorations_us, 0)
-           |> put_debug_stat(:last_render_base_us, total_us)
-           |> put_debug_stat(:last_render_base_app_us, total_us)
-           |> put_debug_stat(:last_frame_compose_us, composed_at - started_at)
-           |> put_debug_stat(:last_terminal_write_us, write_us)
-           |> put_debug_stat(:last_frame_us, total_us)
-           |> put_debug_stat(:last_frame_bytes, byte_size(fragment))
-           |> put_debug_stat(:overlay_count, 0)}
+            {:ok,
+             state
+             |> Map.put(:terminal, terminal)
+             |> Map.put(:last_frame_payload, nil)
+             |> put_debug_stat(:last_render_cause, :child_patch)
+             |> put_debug_stat(:last_root_snapshot_us, 0)
+             |> put_debug_stat(:last_root_snapshot_app_us, 0)
+             |> put_debug_stat(:last_live_children_us, child_render_us)
+             |> put_debug_stat(:last_live_children_app_us, child_render_us)
+             |> put_debug_stat(
+               :last_live_children,
+               normalize_child_timings([%{id: child_id, view: view, us: child_render_us}])
+             )
+             |> put_debug_stat(:last_render_profile, summarize_profile(profile_entries))
+             |> put_debug_stat(:last_reconcile_passes, 1)
+             |> put_debug_stat(:last_reconcile_changed_ids, [child_id])
+             |> put_debug_stat(:last_prepare_decorations_us, 0)
+             |> put_debug_stat(:last_render_base_us, total_us)
+             |> put_debug_stat(:last_render_base_app_us, total_us)
+             |> put_debug_stat(:last_frame_compose_us, composed_at - started_at)
+             |> put_debug_stat(:last_terminal_write_us, write_us)
+             |> put_debug_stat(:last_frame_us, total_us)
+             |> put_debug_stat(:last_frame_bytes, byte_size(fragment))
+             |> put_debug_stat(:overlay_count, 0)}
+        end
+      else
+        _ -> :error
       end
-    else
-      _ -> :error
+    catch
+      {:crash_state, crash_state} -> {:crash, crash_state}
     end
   end
 
@@ -984,6 +1090,162 @@ defmodule Breeze.Server do
 
     Termite.Terminal.write(terminal, "\r")
     System.halt()
+  end
+
+  defp crashed?(%{crash: crash}), do: not is_nil(crash)
+
+  defp safe_apply_input_reply(state, fun) do
+    case safe_call(fn -> fun.(state) end) do
+      {:ok, {:crash, crash}} -> {:noreply, enter_crash_state(state, crash)}
+      {:ok, reply} -> apply_input_reply(state, reply)
+      {:crash, crash} -> {:noreply, enter_crash_state(state, crash)}
+    end
+  end
+
+  defp safe_call(fun) when is_function(fun, 0) do
+    try do
+      {:ok, fun.()}
+    rescue
+      exception ->
+        {:crash, crash_info(:error, exception, __STACKTRACE__)}
+    catch
+      :exit, reason ->
+        {:crash, crash_info(:exit, reason, __STACKTRACE__)}
+
+      kind, reason ->
+        {:crash, crash_info(kind, reason, __STACKTRACE__)}
+    end
+  end
+
+  defp crash_info(kind, reason, stacktrace) do
+    %{
+      kind: kind,
+      reason: reason,
+      stacktrace: stacktrace,
+      selected_index: nil,
+      focused: "error-stacktrace",
+      implicit_state: %{}
+    }
+  end
+
+  defp enter_crash_state(state, crash) do
+    cancel_timer(state.animation_timer)
+    terminal = apply_mouse_mode(state.terminal, false)
+    crash = Breeze.ErrorView.prepare_crash(state.view, crash, terminal.size)
+
+    state
+    |> Map.put(:terminal, terminal)
+    |> Map.put(:crash, crash)
+    |> Map.put(:pending_ref, nil)
+    |> Map.put(:pending_started_at, nil)
+    |> Map.put(:input_flush_scheduled?, false)
+    |> Map.put(:queued_input, [])
+    |> Map.put(:animation_timer, nil)
+    |> Map.put(:next_tick_at, nil)
+    |> Map.put(:decorations, [])
+    |> put_debug_stat(:last_render_cause, :crash)
+    |> render_crash()
+  end
+
+  defp cancel_timer(nil), do: :ok
+  defp cancel_timer(timer), do: Process.cancel_timer(timer)
+
+  defp render_crash(state) do
+    crash = Breeze.ErrorView.prepare_crash(state.view, state.crash, state.terminal.size)
+
+    content =
+      Breeze.ErrorView.render_assigns(state.view, crash, state.terminal.size)
+      |> then(
+        &Breeze.Renderer.render_to_string(Breeze.ErrorView, &1,
+          terminal: state.terminal,
+          focused: crash.focused,
+          implicit_state: crash.implicit_state
+        )
+      )
+
+    state
+    |> Map.put(:crash, crash)
+    |> Map.put(:base_output, content)
+    |> Map.put(:last_frame_payload, nil)
+    |> render_frame()
+  end
+
+  defp dispatch_crash_input(input, %{crash: crash} = state) do
+    case Breeze.ErrorView.handle_input(state.view, crash, input, state.terminal.size) do
+      :restart ->
+        restart_after_crash(state)
+
+      {:update, updated_crash} ->
+        state |> Map.put(:crash, updated_crash) |> render_crash()
+    end
+  end
+
+  defp restart_after_crash(state) do
+    state = %{state | terminal: apply_mouse_mode(state.terminal, state.mouse_mode)}
+
+    case start_root_view(state) do
+      {:ok, pid, focused} ->
+        state
+        |> Map.put(:view_pid, pid)
+        |> Map.put(:focused, focused)
+        |> Map.put(:crash, nil)
+        |> Map.put(:children, %{})
+        |> Map.put(:decorations, [])
+        |> Map.put(:base_output, "")
+        |> Map.put(:last_frame_payload, nil)
+        |> Map.put(:pending_ref, nil)
+        |> Map.put(:pending_started_at, nil)
+        |> Map.put(:queued_input, [])
+        |> Map.put(:input_flush_scheduled?, false)
+        |> maybe_render_base(:restart)
+
+      {:error, crash} ->
+        enter_crash_state(state, crash)
+    end
+  end
+
+  defp apply_mouse_mode(terminal, false), do: Termite.Screen.disable_mouse(terminal)
+  defp apply_mouse_mode(terminal, nil), do: Termite.Screen.disable_mouse(terminal)
+  defp apply_mouse_mode(terminal, true), do: Termite.Screen.enable_mouse(terminal)
+
+  defp apply_mouse_mode(terminal, opts) when is_list(opts),
+    do: Termite.Screen.enable_mouse(terminal, opts)
+
+  defp start_root_view(state) do
+    session = self()
+
+    case safe_call(fn ->
+           Breeze.ChildServer.start(
+             view: state.view,
+             start_opts: state.start_opts || [],
+             terminal: state.terminal,
+             server: self(),
+             global_keybindings: state.global_keybindings || [],
+             invalidate: fn -> send(session, :child_invalidated) end
+           )
+         end) do
+      {:ok, {:ok, pid}} ->
+        Process.monitor(pid)
+
+        focused =
+          case safe_call(fn -> Breeze.ChildServer.metadata(pid) end) do
+            {:ok, %{focused: focused}} -> focused
+            _ -> nil
+          end
+
+        {:ok, pid, focused}
+
+      {:ok, other} ->
+        {:error,
+         crash_info(
+           :error,
+           RuntimeError.exception("unexpected child start result: #{inspect(other)}"),
+           []
+         )}
+
+      {:crash, crash} ->
+        {:error, crash}
+    end
   end
 
   defp ensure_children(state, missing) do
@@ -1281,8 +1543,8 @@ defmodule Breeze.Server do
   end
 
   defp root_view_module(%{children: _} = state) do
-    case Breeze.ChildServer.metadata(state.view_pid) do
-      %{view: view} -> view
+    case safe_call(fn -> Breeze.ChildServer.metadata(state.view_pid) end) do
+      {:ok, %{view: view}} -> view
       _ -> nil
     end
   end
@@ -1292,16 +1554,34 @@ defmodule Breeze.Server do
       state
       |> focused_child_chain()
       |> Enum.reduce_while(nil, fn {child_id, %{pid: pid}}, _acc ->
-        reply = Breeze.ChildServer.dispatch_input(pid, key) |> namespace_child_reply(child_id)
+        case safe_call(fn -> Breeze.ChildServer.dispatch_input(pid, key) end) do
+          {:ok, reply} ->
+            reply = namespace_child_reply(reply, child_id)
 
-        case reply do
-          {:noreply, _focused, true} -> {:halt, reply}
-          {:stop, _focused, _consumed} -> {:halt, reply}
-          _ -> {:cont, nil}
+            case reply do
+              {:noreply, _focused, true} -> {:halt, reply}
+              {:stop, _focused, _consumed} -> {:halt, reply}
+              _ -> {:cont, nil}
+            end
+
+          {:crash, crash} ->
+            {:halt, {:crash, crash}}
         end
       end)
 
-    child_reply || Breeze.ChildServer.dispatch_input(state.view_pid, key)
+    case child_reply do
+      {:crash, _crash} = crash ->
+        crash
+
+      nil ->
+        case safe_call(fn -> Breeze.ChildServer.dispatch_input(state.view_pid, key) end) do
+          {:ok, reply} -> reply
+          {:crash, crash} -> {:crash, crash}
+        end
+
+      reply ->
+        reply
+    end
   end
 
   defp focused_child_chain(%{focused: nil}), do: []

--- a/test/breeze/live_view_test.exs
+++ b/test/breeze/live_view_test.exs
@@ -4,6 +4,7 @@ defmodule Breeze.LiveViewTest do
   alias Breeze.ChildServer
   alias Breeze.Renderer
   alias Breeze.Template
+  import ExUnit.CaptureLog
 
   defmodule FakeAdapter do
     @behaviour Termite.Terminal.Adapter
@@ -123,6 +124,27 @@ defmodule Breeze.LiveViewTest do
       <box id="spinner" implicit={Breeze.Implicit.AsyncSpinner} style="width-1">
       </box>
       """
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule CrashingView do
+    use Breeze.View
+
+    def mount(_opts, term) do
+      {:ok, term |> assign(label: "ready") |> focus("boom")}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <box id="boom" focusable>{@label}</box>
+      """
+    end
+
+    def handle_event(_, %{"key" => "c"}, _term) do
+      raise "boom"
     end
 
     def handle_event(_, _, term), do: {:noreply, term}
@@ -421,13 +443,135 @@ defmodule Breeze.LiveViewTest do
       )
 
     send(pid, {reader, {:data, "\eOQ"}})
-    Process.sleep(50)
+
+    wait_until(fn ->
+      state = :sys.get_state(pid)
+      Map.has_key?(state.children, "debug") and state.base_output =~ "Count: 1"
+    end)
 
     state = :sys.get_state(pid)
     assert Map.has_key?(state.children, "debug")
     assert state.base_output =~ "Count: 1"
 
     Process.exit(pid, :normal)
+  end
+
+  test "server renders a crash screen instead of tearing down the terminal on view exceptions" do
+    capture_log(fn ->
+      terminal = Termite.Terminal.start(adapter: FakeAdapter)
+      reader = terminal.reader
+
+      {:ok, pid} =
+        Breeze.Server.start_app_link(
+          view: CrashingView,
+          terminal: terminal,
+          reader: reader,
+          global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+        )
+
+      send(pid, {reader, {:data, "c"}})
+
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+
+        state.crash &&
+          state.base_output =~ "Breeze Error" &&
+          state.base_output =~ "CrashingView" &&
+          state.base_output =~ "RuntimeError"
+      end)
+
+      state = :sys.get_state(pid)
+
+      assert state.crash
+      assert state.base_output =~ "Breeze Error"
+      assert state.base_output =~ "CrashingView"
+      assert state.base_output =~ "RuntimeError"
+      assert state.base_output =~ "Crash Details"
+      assert state.base_output =~ "Selected Frame"
+      assert state.base_output =~ "Stacktrace"
+      assert state.base_output =~ "boom"
+
+      Process.exit(pid, :normal)
+    end)
+  end
+
+  test "crash screen tab switches focus between panes" do
+    capture_log(fn ->
+      terminal = Termite.Terminal.start(adapter: FakeAdapter)
+      reader = terminal.reader
+
+      {:ok, pid} =
+        Breeze.Server.start_app_link(
+          view: CrashingView,
+          terminal: terminal,
+          reader: reader,
+          global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+        )
+
+      send(pid, {reader, {:data, "c"}})
+
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+        state.crash && state.crash.focused == "error-stacktrace"
+      end)
+
+      initial_state = :sys.get_state(pid)
+      assert initial_state.crash
+      assert initial_state.crash.focused == "error-stacktrace"
+
+      send(pid, {reader, {:data, "\t"}})
+
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+        state.crash && state.crash.focused == "error-history"
+      end)
+
+      next_state = :sys.get_state(pid)
+      assert next_state.crash.focused == "error-history"
+
+      Process.exit(pid, :normal)
+    end)
+  end
+
+  test "server restarts from a clean slate after a crash when r is pressed" do
+    capture_log(fn ->
+      terminal = Termite.Terminal.start(adapter: FakeAdapter)
+      reader = terminal.reader
+
+      {:ok, pid} =
+        Breeze.Server.start_app_link(
+          view: CrashingView,
+          terminal: terminal,
+          reader: reader,
+          global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+        )
+
+      send(pid, {reader, {:data, "c"}})
+
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+        not is_nil(state.crash)
+      end)
+
+      crashed_state = :sys.get_state(pid)
+      assert crashed_state.crash
+
+      send(pid, {reader, {:data, "r"}})
+
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+
+        is_nil(state.crash) and state.base_output =~ "ready" and
+          not String.contains?(state.base_output, "Breeze Error")
+      end)
+
+      restarted_state = :sys.get_state(pid)
+      refute restarted_state.crash
+      assert restarted_state.base_output =~ "ready"
+      refute restarted_state.base_output =~ "Breeze Error"
+
+      Process.exit(pid, :normal)
+    end)
   end
 
   test "server patches fixed live child invalidations without rerendering the root" do
@@ -455,7 +599,11 @@ defmodule Breeze.LiveViewTest do
 
     child = state.children["debug"]
     assert {:noreply, "button", true} = Breeze.ChildServer.dispatch_input(child.pid, "+")
-    Process.sleep(100)
+
+    wait_until(fn ->
+      next_state = :sys.get_state(pid)
+      next_state.debug_stats[:last_render_cause] == :child_patch
+    end)
 
     writes = drain_terminal_writes()
     next_state = :sys.get_state(pid)
@@ -486,7 +634,11 @@ defmodule Breeze.LiveViewTest do
     drain_terminal_writes()
 
     assert {:noreply, "button", true} = Breeze.ChildServer.dispatch_input(child.pid, "+")
-    Process.sleep(100)
+
+    wait_until(fn ->
+      next_state = :sys.get_state(pid)
+      next_state.debug_stats[:render_base_count] > initial_render_count
+    end)
 
     next_state = :sys.get_state(pid)
 
@@ -518,4 +670,17 @@ defmodule Breeze.LiveViewTest do
       10 -> Enum.reverse(writes)
     end
   end
+
+  defp wait_until(fun, attempts \\ 20)
+
+  defp wait_until(fun, attempts) when attempts > 0 do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(10)
+      wait_until(fun, attempts - 1)
+    end
+  end
+
+  defp wait_until(_fun, 0), do: flunk("condition not met")
 end

--- a/test/breeze/logger_test.exs
+++ b/test/breeze/logger_test.exs
@@ -105,6 +105,31 @@ defmodule Breeze.LoggerTest do
     end)
   end
 
+  test "logger can disable the clear shortcut" do
+    {:ok, pid} =
+      ChildServer.start(
+        view: Breeze.Logger,
+        start_opts: [height: 6, max_lines: 20, clear_key: nil]
+      )
+
+    {:ok, _acc, _box} = ChildServer.render(pid, focused: "logger", implicit_state: %{})
+
+    Logger.info("dont-clear-me-#{System.unique_integer([:positive])}")
+    Logger.flush()
+
+    wait_until(fn ->
+      {:ok, _acc, box} = ChildServer.render(pid, focused: "logger", implicit_state: %{})
+      box.content =~ "dont-clear-me-"
+    end)
+
+    assert {:noreply, "logger", false} =
+             ChildServer.dispatch_event(pid, :ignore_me, %{"key" => "c"})
+
+    {:ok, _acc, box} = ChildServer.render(pid, focused: "logger", implicit_state: %{})
+    assert box.content =~ "dont-clear-me-"
+    refute box.content =~ "Press c to clear."
+  end
+
   test "logger autoscrolls while pinned to the bottom" do
     lines =
       for index <- 1..8 do


### PR DESCRIPTION
Catch render and input crashes in the server and enter a crash state instead of tearing down the terminal session. Render a dedicated error view for the crash, route input to it, and allow restarting the root view with `r`.

Add Breeze.ErrorView to show the stacktrace, selected frame details, and the full wrapped crash message. Keep the error view self-contained and free of implicits so the crash path does not depend on more runtime machinery while handling a failure.

Add a crash_handler example for manual testing, make the logger clear shortcut configurable, and cover the crash flow and logger option in tests.