### PR TITLE
feat(Breeze.Server): toggle terminal background with themes

### DIFF
--- a/lib/breeze/input_router.ex
+++ b/lib/breeze/input_router.ex
@@ -260,15 +260,8 @@ defmodule Breeze.InputRouter do
 
   defp stop(state) do
     if Process.alive?(state.server_pid) do
-      Process.exit(state.server_pid, :normal)
+      GenServer.stop(state.server_pid, :normal, 1_000)
     end
-
-    state.terminal
-    |> Termite.Screen.disable_mouse()
-    |> Termite.Screen.clear_screen()
-    |> Termite.Screen.show_cursor()
-    |> Termite.Screen.exit_alt_screen()
-    |> Termite.Terminal.write("\r")
 
     {:stop, :normal, state}
   end

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -91,7 +91,8 @@ defmodule Breeze.Server do
     rendered_flags: %{},
     rendered_focus_meta: %{},
     rendered_implicit_state: %{},
-    rendered_implicit_meta: %{}
+    rendered_implicit_meta: %{},
+    last_terminal_background: nil
   ]
 
   @type option ::
@@ -160,6 +161,11 @@ defmodule Breeze.Server do
     theme = Breeze.Theme.new(Keyword.get(opts, :theme), terminal: terminal)
     theme_source = Keyword.get(opts, :theme)
     apply_theme_defaults? = Breeze.Theme.defaults_enabled?(Keyword.get(opts, :theme))
+
+    store_initial_terminal_background(
+      terminal,
+      terminal_background_color(Breeze.Theme.new(:system, terminal: terminal))
+    )
 
     session = self()
 
@@ -249,6 +255,13 @@ defmodule Breeze.Server do
 
     state = Map.update!(state, :inspector_subscribers, &MapSet.put(&1, subscriber))
     {:noreply, push_inspector_snapshot_now(state)}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    teardown_terminal(state)
+    clear_initial_terminal_background(state.terminal)
+    :ok
   end
 
   @impl true
@@ -1027,11 +1040,14 @@ defmodule Breeze.Server do
 
     composed_at = System.monotonic_time(:microsecond)
 
+    {background_prefix, next_terminal_background} =
+      terminal_background_update(state.theme, state.last_terminal_background)
+
     {terminal, write_duration} =
-      if frame_payload == state.last_frame_payload do
+      if frame_payload == state.last_frame_payload and background_prefix == "" do
         {state.terminal, 0}
       else
-        terminal = Termite.Terminal.write(state.terminal, frame_payload)
+        terminal = Termite.Terminal.write(state.terminal, background_prefix <> frame_payload)
         written_at = System.monotonic_time(:microsecond)
         {terminal, written_at - composed_at}
       end
@@ -1040,6 +1056,7 @@ defmodule Breeze.Server do
     |> Map.put(:terminal, terminal)
     |> Map.put(:decorations, decorations)
     |> Map.put(:last_frame_payload, frame_payload)
+    |> Map.put(:last_terminal_background, next_terminal_background)
     |> Map.put(:last_frame_lines, lines)
     |> Map.put(:last_overlays, overlays)
     |> put_debug_stat(:last_frame_compose_us, composed_at - started_at)
@@ -1427,6 +1444,52 @@ defmodule Breeze.Server do
       Process.exit(state.view_pid, :normal)
     end
 
+    {:stop, :normal, teardown_terminal(state)}
+  end
+
+  defp crashed?(%{crash: crash}), do: not is_nil(crash)
+
+  defp terminal_background_update(theme, last_background) do
+    case terminal_background_color(theme) do
+      color when color == last_background ->
+        {"", last_background}
+
+      {red, green, blue} = color ->
+        {"\e]11;#{hex_color(red, green, blue)}\a", color}
+
+      nil when is_tuple(last_background) ->
+        {"\e]111\a", nil}
+
+      _ ->
+        {"", nil}
+    end
+  end
+
+  defp terminal_background_color(theme) do
+    case Breeze.Theme.resolve_color(theme, :background_color) do
+      {red, green, blue} when red in 0..255 and green in 0..255 and blue in 0..255 ->
+        {red, green, blue}
+
+      _ ->
+        nil
+    end
+  end
+
+  defp hex_color(red, green, blue) do
+    "#" <>
+      String.upcase(Base.encode16(<<red, green, blue>>))
+  end
+
+  defp terminal_background_reset_sequence({red, green, blue}, _last_background),
+    do: "\e]11;#{hex_color(red, green, blue)}\a"
+
+  defp terminal_background_reset_sequence(_initial_terminal_background, last_background)
+       when is_tuple(last_background),
+       do: "\e]111\a"
+
+  defp terminal_background_reset_sequence(_initial_terminal_background, _last_background), do: ""
+
+  defp teardown_terminal(state) do
     terminal =
       state.terminal
       |> Termite.Screen.disable_mouse()
@@ -1434,11 +1497,34 @@ defmodule Breeze.Server do
       |> Termite.Screen.show_cursor()
       |> Termite.Screen.exit_alt_screen()
 
-    terminal = Termite.Terminal.write(terminal, "\r")
-    {:stop, :normal, %{state | terminal: terminal}}
+    terminal =
+      Termite.Terminal.write(
+        terminal,
+        "\r" <>
+          terminal_background_reset_sequence(
+            initial_terminal_background(state.terminal),
+            state.last_terminal_background
+          )
+      )
+
+    %{state | terminal: terminal}
   end
 
-  defp crashed?(%{crash: crash}), do: not is_nil(crash)
+  defp store_initial_terminal_background(terminal, color) do
+    :persistent_term.put(initial_terminal_background_key(terminal), color)
+  end
+
+  defp initial_terminal_background(terminal) do
+    :persistent_term.get(initial_terminal_background_key(terminal), nil)
+  end
+
+  defp clear_initial_terminal_background(terminal) do
+    :persistent_term.erase(initial_terminal_background_key(terminal))
+  end
+
+  defp initial_terminal_background_key(terminal) do
+    {__MODULE__, :initial_terminal_background, Map.get(terminal, :reader)}
+  end
 
   defp safe_apply_input_reply(state, fun) do
     case safe_call(fn -> fun.(state) end) do

--- a/test/breeze/input_router_test.exs
+++ b/test/breeze/input_router_test.exs
@@ -1,6 +1,8 @@
 defmodule Breeze.InputRouterTest do
   use ExUnit.Case, async: true
 
+  alias Breeze.Theme
+
   defmodule FakeAdapter do
     @behaviour Termite.Terminal.Adapter
 
@@ -10,6 +12,28 @@ defmodule Breeze.InputRouterTest do
 
     def reader(term), do: {:ok, term.ref}
     def write(term, _str), do: {:ok, term}
+    def resize(term), do: term.size
+  end
+
+  defmodule RecordingAdapter do
+    @behaviour Termite.Terminal.Adapter
+
+    def start(opts) do
+      {:ok,
+       %{
+         ref: make_ref(),
+         size: %{width: 80, height: 24},
+         owner: Keyword.fetch!(opts, :owner)
+       }}
+    end
+
+    def reader(term), do: {:ok, term.ref}
+
+    def write(term, str) do
+      send(term.owner, {:terminal_write, str})
+      {:ok, term}
+    end
+
     def resize(term), do: term.size
   end
 
@@ -35,6 +59,36 @@ defmodule Breeze.InputRouterTest do
 
     def handle_event(_, _, term), do: {:noreply, term}
     def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule ToggleView do
+    use Breeze.View
+
+    def mount(_opts, term) do
+      {:ok, term |> put_theme(Theme.system16()) |> assign(mode: :system16)}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <box class="text-primary">Theme: {@mode}</box>
+      """
+    end
+
+    def handle_event(_, %{"key" => "t"}, term) do
+      theme =
+        Theme.new(
+          defaults: %{
+            foreground_color: "#839496",
+            background_color: "#002b36",
+            border_color: "#586e75"
+          },
+          palette: %{primary: "#268bd2"}
+        )
+
+      {:noreply, term |> put_theme(theme) |> assign(mode: :custom)}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
   end
 
   test "stop global keys are handled even while the app server is blocked" do
@@ -85,4 +139,66 @@ defmodule Breeze.InputRouterTest do
     assert_receive :halted
     assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
   end
+
+  test "shutdown waits for server teardown writes before halting" do
+    parent = self()
+
+    {:ok, pid} =
+      Breeze.InputRouter.start_link(
+        view: ToggleView,
+        hide_cursor: false,
+        terminal_opts: [adapter: RecordingAdapter, owner: parent],
+        halt_fun: fn -> send(parent, :halted) end,
+        global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+      )
+
+    ref = Process.monitor(pid)
+    reader = :sys.get_state(pid).reader
+
+    drain_terminal_writes()
+
+    send(pid, {reader, {:data, "t"}})
+
+    assert wait_until(fn ->
+             writes = drain_terminal_writes()
+             if IO.iodata_to_binary(writes) =~ "\e]11;#002B36\a", do: writes, else: false
+           end)
+
+    send(pid, {reader, {:data, "q"}})
+
+    writes =
+      wait_until(fn ->
+        writes = drain_terminal_writes()
+        if writes == [], do: false, else: writes
+      end)
+
+    output = IO.iodata_to_binary(writes)
+
+    assert output =~ "\e]111\a"
+    assert_receive :halted
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+  end
+
+  defp drain_terminal_writes(writes \\ []) do
+    receive do
+      {:terminal_write, str} -> drain_terminal_writes([str | writes])
+    after
+      10 -> Enum.reverse(writes)
+    end
+  end
+
+  defp wait_until(fun, attempts \\ 20)
+
+  defp wait_until(fun, attempts) when attempts > 0 do
+    case fun.() do
+      false ->
+        Process.sleep(10)
+        wait_until(fun, attempts - 1)
+
+      value ->
+        value
+    end
+  end
+
+  defp wait_until(_fun, 0), do: false
 end

--- a/test/breeze/theme_test.exs
+++ b/test/breeze/theme_test.exs
@@ -32,6 +32,28 @@ defmodule Breeze.ThemeTest do
     end
   end
 
+  defmodule RecordingAdapter do
+    @behaviour Termite.Terminal.Adapter
+
+    def start(opts) do
+      {:ok,
+       %{
+         ref: make_ref(),
+         size: %{width: 80, height: 24},
+         owner: Keyword.fetch!(opts, :owner)
+       }}
+    end
+
+    def reader(term), do: {:ok, term.ref}
+
+    def write(term, str) do
+      send(term.owner, {:terminal_write, str})
+      {:ok, term}
+    end
+
+    def resize(term), do: term.size
+  end
+
   defmodule ToggleView do
     use Breeze.View
 
@@ -288,6 +310,65 @@ defmodule Breeze.ThemeTest do
     assert Breeze.Test.render!(session) =~ "\e[38;2;38;139;210mTheme: custom\e[0m"
   end
 
+  test "server writes an OSC background update when switching to an RGB theme" do
+    terminal = Termite.Terminal.start(adapter: RecordingAdapter, owner: self())
+    reader = terminal.reader
+
+    {:ok, pid} =
+      Breeze.Server.start_app_link(
+        view: ToggleView,
+        terminal: terminal
+      )
+
+    on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :normal) end)
+
+    drain_terminal_writes()
+
+    send(pid, {reader, {:data, "t"}})
+
+    writes =
+      wait_until(fn ->
+        writes = drain_terminal_writes()
+        if writes == [], do: false, else: writes
+      end)
+
+    output = IO.iodata_to_binary(writes)
+
+    assert output =~ "\e]11;#002B36\a"
+  end
+
+  test "server resets the terminal background on close after setting an RGB theme" do
+    terminal = Termite.Terminal.start(adapter: RecordingAdapter, owner: self())
+    reader = terminal.reader
+
+    {:ok, pid} =
+      Breeze.Server.start_app_link(
+        view: ToggleView,
+        terminal: terminal
+      )
+
+    drain_terminal_writes()
+
+    send(pid, {reader, {:data, "t"}})
+
+    assert wait_until(fn ->
+             writes = drain_terminal_writes()
+             if IO.iodata_to_binary(writes) =~ "\e]11;#002B36\a", do: writes, else: false
+           end)
+
+    GenServer.stop(pid, :normal)
+
+    writes =
+      wait_until(fn ->
+        writes = drain_terminal_writes()
+        if writes == [], do: false, else: writes
+      end)
+
+    output = IO.iodata_to_binary(writes)
+
+    assert output =~ "\e]111\a"
+  end
+
   test "child metadata reflects theme changes" do
     {:ok, pid} = Breeze.ChildServer.start(view: ToggleView, start_opts: [])
     on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid, :normal) end)
@@ -296,4 +377,27 @@ defmodule Breeze.ThemeTest do
     assert {:noreply, _focused, true} = Breeze.ChildServer.dispatch_input(pid, "t")
     assert Breeze.ChildServer.metadata(pid).theme.mode == :custom
   end
+
+  defp drain_terminal_writes(writes \\ []) do
+    receive do
+      {:terminal_write, str} -> drain_terminal_writes([str | writes])
+    after
+      10 -> Enum.reverse(writes)
+    end
+  end
+
+  defp wait_until(fun, attempts \\ 20)
+
+  defp wait_until(fun, attempts) when attempts > 0 do
+    case fun.() do
+      false ->
+        Process.sleep(10)
+        wait_until(fun, attempts - 1)
+
+      value ->
+        value
+    end
+  end
+
+  defp wait_until(_fun, 0), do: false
 end


### PR DESCRIPTION
Store the initial terminal background, write OSC background updates when RGB themes are applied, and restore the background during server teardown. Also make Breeze.InputRouter stop the server synchronously so teardown writes complete before halt, with tests covering both update and reset paths.