### PR TITLE
feat(Breeze.Server): support running apps from IEx

### DIFF
--- a/lib/breeze/input_router.ex
+++ b/lib/breeze/input_router.ex
@@ -3,12 +3,16 @@ defmodule Breeze.InputRouter do
 
   use GenServer
 
+  alias Breeze.InputRouter.{IExShellProxy, SilentGroupLeader, TerminalStart}
+
   defstruct [
     :terminal,
     :reader,
     :server_pid,
     :halt_fun,
     :theme_probe,
+    :iex_shell_proxy,
+    :silent_group_leader,
     alt_screen?: true,
     enhanced_keyboard?: true,
     global_keybindings: []
@@ -18,13 +22,24 @@ defmodule Breeze.InputRouter do
     GenServer.start_link(__MODULE__, opts)
   end
 
+  def start(opts) do
+    GenServer.start(__MODULE__, opts)
+  end
+
   @impl true
   def init(opts) do
+    opts = maybe_put_iex_terminal_size_override(opts)
     alt_screen? = Keyword.get(opts, :alt_screen, true)
     hide_cursor? = Keyword.get(opts, :hide_cursor, true)
     enhanced_keyboard? = Keyword.get(opts, :enhanced_keyboard, true)
     mouse = Keyword.get(opts, :mouse, false)
-    terminal = build_terminal(opts)
+
+    %TerminalStart{
+      terminal: terminal,
+      iex_shell_proxy: iex_shell_proxy,
+      silent_group_leader: silent_group_leader
+    } = build_terminal(opts)
+
     reader = terminal.reader
     terminal = if alt_screen?, do: Termite.Screen.alt_screen(terminal), else: terminal
     terminal = if enhanced_keyboard?, do: enable_enhanced_keyboard(terminal), else: terminal
@@ -47,9 +62,11 @@ defmodule Breeze.InputRouter do
       terminal: terminal,
       reader: reader,
       server_pid: server_pid,
-      halt_fun: Keyword.get(opts, :halt_fun, fn -> System.halt() end),
+      halt_fun: Keyword.get_lazy(opts, :halt_fun, &default_halt_fun/0),
       alt_screen?: alt_screen?,
       enhanced_keyboard?: enhanced_keyboard?,
+      iex_shell_proxy: iex_shell_proxy,
+      silent_group_leader: silent_group_leader,
       global_keybindings: Keyword.get(opts, :global_keybindings, [])
     }
 
@@ -106,6 +123,8 @@ defmodule Breeze.InputRouter do
 
   @impl true
   def terminate(_reason, state) do
+    IExShellProxy.stop(state.iex_shell_proxy)
+    SilentGroupLeader.stop(state.silent_group_leader)
     state.halt_fun.()
     :ok
   end
@@ -304,16 +323,118 @@ defmodule Breeze.InputRouter do
   defp build_terminal(opts) do
     case Keyword.get(opts, :terminal) do
       %Termite.Terminal{} = terminal ->
-        terminal
+        %TerminalStart{terminal: terminal}
 
       nil ->
-        Termite.Terminal.start(Keyword.get(opts, :terminal_opts, []))
+        %TerminalStart{terminal: terminal, silent_group_leader: silent_group_leader} =
+          start_terminal(opts)
+
+        iex_shell_proxy = maybe_replace_iex_shell_reader(terminal, opts)
+        terminal = Termite.Terminal.resize(terminal)
+
+        %TerminalStart{
+          terminal: terminal,
+          iex_shell_proxy: iex_shell_proxy,
+          silent_group_leader: silent_group_leader
+        }
     end
+  end
+
+  defp start_terminal(opts) do
+    if Keyword.get(opts, :pause_iex, false) and iex_started?() do
+      start_terminal_with_silent_group_leader(Keyword.get(opts, :terminal_opts, []))
+    else
+      %TerminalStart{terminal: Termite.Terminal.start(Keyword.get(opts, :terminal_opts, []))}
+    end
+  end
+
+  defp maybe_put_iex_terminal_size_override(opts) do
+    if Keyword.get(opts, :pause_iex, false) and iex_started?() do
+      # IEx keeps the physical bottom row for prompt editing after a resize.
+      # Let Breeze render inside the rows that remain stable while IEx is paused.
+      Keyword.put_new(opts, :terminal_size_override, &reserve_iex_prompt_row/1)
+    else
+      opts
+    end
+  end
+
+  defp reserve_iex_prompt_row(%{height: height} = size) when is_integer(height) do
+    %{size | height: max(height - 1, 1)}
+  end
+
+  defp reserve_iex_prompt_row(size), do: size
+
+  defp start_terminal_with_silent_group_leader(terminal_opts) do
+    original_group_leader = Process.group_leader()
+
+    {:ok, silent_group_leader} = SilentGroupLeader.start_link()
+
+    try do
+      Process.group_leader(self(), silent_group_leader)
+
+      %TerminalStart{
+        terminal: Termite.Terminal.start(terminal_opts),
+        silent_group_leader: silent_group_leader
+      }
+    after
+      Process.group_leader(self(), original_group_leader)
+    end
+  end
+
+  defp maybe_replace_iex_shell_reader(
+         %Termite.Terminal{
+           adapter: {Termite.Terminal.Shell, %Termite.Terminal.Shell{pid: shell_pid}}
+         },
+         opts
+       ) do
+    if Keyword.get(opts, :pause_iex, false) and iex_started?() do
+      replace_shell_reader(shell_pid)
+    end
+  end
+
+  defp maybe_replace_iex_shell_reader(_terminal, _opts), do: nil
+
+  defp replace_shell_reader(shell_pid) when is_pid(shell_pid) do
+    with %{reader: reader} when is_pid(reader) <- :sys.get_state(shell_pid),
+         true <- Process.alive?(reader),
+         {:ok, iex_shell_proxy} <- IExShellProxy.start_link(shell_pid) do
+      unlink_shell_reader(shell_pid, reader)
+      Process.exit(reader, :kill)
+      iex_shell_proxy
+    else
+      _ -> nil
+    end
+  catch
+    _kind, _reason -> nil
+  end
+
+  defp unlink_shell_reader(shell_pid, reader) do
+    :sys.replace_state(shell_pid, fn state ->
+      Process.unlink(reader)
+      state
+    end)
+
+    :ok
+  catch
+    _kind, _reason -> :ok
+  end
+
+  defp default_halt_fun do
+    if iex_started?() do
+      fn -> :ok end
+    else
+      fn -> System.halt() end
+    end
+  end
+
+  defp iex_started? do
+    Code.ensure_loaded?(IEx) and function_exported?(IEx, :started?, 0) and IEx.started?()
   end
 
   defp stop(state) do
     if Process.alive?(state.server_pid) do
-      Process.exit(state.server_pid, :normal)
+      Process.unlink(state.server_pid)
+      Process.exit(state.server_pid, :shutdown)
     end
 
     state.terminal

--- a/lib/breeze/input_router/iex_shell_proxy.ex
+++ b/lib/breeze/input_router/iex_shell_proxy.ex
@@ -1,0 +1,202 @@
+defmodule Breeze.InputRouter.IExShellProxy do
+  @moduledoc false
+
+  def start_link(target) do
+    previous_group_leader = Process.group_leader()
+
+    with {:ok, user_drv, previous_group, reader} <- start_reader(target) do
+      {:ok,
+       %{
+         pid: reader,
+         user_drv: user_drv,
+         previous_group: previous_group,
+         previous_group_leader: previous_group_leader
+       }}
+    end
+  end
+
+  def stop(nil), do: :ok
+
+  def stop(%{
+        pid: pid,
+        user_drv: user_drv,
+        previous_group: previous_group,
+        previous_group_leader: previous_group_leader
+      }) do
+    restore_user_drv_group(user_drv, previous_group)
+    restore_process_group_leader(previous_group_leader)
+    stop_proxy(pid)
+
+    :ok
+  end
+
+  defp start_reader(target) do
+    with user_drv when is_pid(user_drv) <- Process.whereis(:user_drv),
+         {:ok, previous_group, _user_group} <- current_user_drv_groups(user_drv) do
+      proxy = spawn_link(fn -> proxy_loop(target, user_drv, %{}) end)
+      set_user_drv_group(user_drv, proxy)
+      Process.group_leader(self(), proxy)
+
+      {:ok, user_drv, previous_group, proxy}
+    else
+      _ -> :error
+    end
+  catch
+    _kind, _reason -> :error
+  end
+
+  defp proxy_loop(target, user_drv, pending) do
+    receive do
+      {^user_drv, {:data, data}} ->
+        send(target, {:data, data})
+        proxy_loop(target, user_drv, pending)
+
+      {^user_drv, {:signal, signal}} ->
+        send(target, {:signal, signal})
+        proxy_loop(target, user_drv, pending)
+
+      {:io_request, from, reply_as, request} ->
+        proxy_loop(
+          target,
+          user_drv,
+          handle_io_request(user_drv, from, reply_as, request, pending)
+        )
+
+      {reply_kind, reply_key, reply} when reply_kind in [:reply, :io_reply] ->
+        reply_io_request(reply_key, reply)
+        proxy_loop(target, user_drv, Map.delete(pending, reply_key))
+
+      {^user_drv, :tty_geometry, geometry} ->
+        {pending_geometry, pending} = Map.pop(pending, :tty_geometry, [])
+        Enum.each(Enum.reverse(pending_geometry), &reply_geometry(&1, geometry))
+        proxy_loop(target, user_drv, pending)
+
+      :stop ->
+        :ok
+
+      _message ->
+        proxy_loop(target, user_drv, pending)
+    end
+  end
+
+  defp handle_io_request(user_drv, from, reply_as, {:requests, requests}, pending)
+       when is_list(requests) do
+    Enum.reduce(requests, pending, fn request, acc ->
+      handle_io_request(user_drv, from, reply_as, request, acc)
+    end)
+  end
+
+  defp handle_io_request(user_drv, from, reply_as, {:get_geometry, what}, pending) do
+    send(user_drv, {self(), :tty_geometry})
+
+    Map.update(
+      pending,
+      :tty_geometry,
+      [{from, reply_as, what}],
+      &[{from, reply_as, what} | &1]
+    )
+  end
+
+  defp handle_io_request(user_drv, from, reply_as, request, pending) do
+    case put_chars_request(request) do
+      {:ok, encoding, chars} ->
+        reply_key = {from, reply_as}
+        send(user_drv, {self(), {:put_chars_sync, encoding, chars, reply_key}})
+        Map.put(pending, reply_key, true)
+
+      :ignore ->
+        send(from, {:io_reply, reply_as, :ok})
+        pending
+
+      :error ->
+        send(from, {:io_reply, reply_as, {:error, :request}})
+        pending
+    end
+  end
+
+  defp put_chars_request({:put_chars, encoding, chars})
+       when encoding in [:unicode, :latin1] do
+    {:ok, encoding, IO.iodata_to_binary(chars)}
+  end
+
+  defp put_chars_request({:put_chars, chars}), do: {:ok, :latin1, IO.iodata_to_binary(chars)}
+
+  defp put_chars_request({:put_chars, encoding, module, function, args})
+       when encoding in [:unicode, :latin1] do
+    {:ok, encoding, IO.iodata_to_binary(apply(module, function, args))}
+  rescue
+    _ -> :error
+  end
+
+  defp put_chars_request({:put_chars, module, function, args}) do
+    {:ok, :latin1, IO.iodata_to_binary(apply(module, function, args))}
+  rescue
+    _ -> :error
+  end
+
+  defp put_chars_request({:setopts, _opts}), do: :ignore
+  defp put_chars_request(:getopts), do: :ignore
+  defp put_chars_request(_request), do: :error
+
+  defp reply_io_request({from, reply_as}, reply) when is_pid(from) do
+    send(from, {:io_reply, reply_as, reply})
+  end
+
+  defp reply_io_request(_reply_key, _reply), do: :ok
+
+  defp reply_geometry({from, reply_as, :columns}, {columns, _rows}) when is_integer(columns),
+    do: send(from, {:io_reply, reply_as, columns})
+
+  defp reply_geometry({from, reply_as, :rows}, {_columns, rows}) when is_integer(rows),
+    do: send(from, {:io_reply, reply_as, rows})
+
+  defp reply_geometry({from, reply_as, _what}, _geometry),
+    do: send(from, {:io_reply, reply_as, {:error, :enotsup}})
+
+  defp stop_proxy(pid) when is_pid(pid) do
+    if Process.alive?(pid) do
+      Process.unlink(pid)
+      send(pid, :stop)
+    end
+  end
+
+  defp stop_proxy(_pid), do: :ok
+
+  defp current_user_drv_groups(user_drv) do
+    case :sys.get_state(user_drv) do
+      {_state_name, data} -> {:ok, elem(data, 8), elem(data, 7)}
+      _state -> :error
+    end
+  rescue
+    _ -> :error
+  end
+
+  defp set_user_drv_group(user_drv, group) when is_pid(user_drv) and is_pid(group) do
+    :sys.replace_state(user_drv, fn
+      {state_name, data} ->
+        Process.put(:current_group, group)
+        {state_name, put_elem(data, 8, group)}
+
+      state ->
+        state
+    end)
+
+    :ok
+  catch
+    _kind, _reason -> :ok
+  end
+
+  defp restore_user_drv_group(user_drv, previous_group)
+       when is_pid(user_drv) and is_pid(previous_group) do
+    set_user_drv_group(user_drv, previous_group)
+    send(previous_group, {user_drv, :activate})
+  end
+
+  defp restore_user_drv_group(_user_drv, _previous_group), do: :ok
+
+  defp restore_process_group_leader(previous_group_leader) when is_pid(previous_group_leader) do
+    Process.group_leader(self(), previous_group_leader)
+  end
+
+  defp restore_process_group_leader(_previous_group_leader), do: :ok
+end

--- a/lib/breeze/input_router/silent_group_leader.ex
+++ b/lib/breeze/input_router/silent_group_leader.ex
@@ -1,0 +1,43 @@
+defmodule Breeze.InputRouter.SilentGroupLeader do
+  @moduledoc false
+
+  def start_link do
+    pid = spawn_link(fn -> loop() end)
+    {:ok, pid}
+  end
+
+  def stop(pid) when is_pid(pid) do
+    Process.unlink(pid)
+    Process.exit(pid, :shutdown)
+    :ok
+  end
+
+  def stop(_pid), do: :ok
+
+  defp loop do
+    receive do
+      {:io_request, from, reply_as, request} ->
+        handle_io_request(from, reply_as, request)
+        loop()
+
+      _message ->
+        loop()
+    end
+  end
+
+  defp handle_io_request(from, reply_as, request) do
+    cond do
+      input_request?(request) ->
+        :ok
+
+      true ->
+        send(from, {:io_reply, reply_as, :ok})
+    end
+  end
+
+  defp input_request?({:get_chars, _encoding, _prompt, _count}), do: true
+  defp input_request?({:get_line, _encoding, _prompt}), do: true
+  defp input_request?({:get_until, _encoding, _prompt, _module, _function, _args}), do: true
+  defp input_request?({:get_password, _encoding}), do: true
+  defp input_request?(_request), do: false
+end

--- a/lib/breeze/input_router/terminal_start.ex
+++ b/lib/breeze/input_router/terminal_start.ex
@@ -1,0 +1,5 @@
+defmodule Breeze.InputRouter.TerminalStart do
+  @moduledoc false
+
+  defstruct [:terminal, :iex_shell_proxy, :silent_group_leader]
+end

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -28,6 +28,7 @@ defmodule Breeze.Server do
     :clipboard_opts,
     :crash,
     :crash_scrollback?,
+    :terminal_size_override,
     :last_render_at,
     :last_interaction_at,
     children: %{},
@@ -72,6 +73,36 @@ defmodule Breeze.Server do
     Breeze.InputRouter.start_link(opts)
   end
 
+  @doc """
+  Run the Breeze application until it exits.
+
+  This is intended for interactive sessions such as IEx. It starts the terminal
+  input router without linking it to the caller, waits for the app to stop, and
+  returns `:ok` instead of halting the VM.
+  """
+  @spec run(keyword()) :: :ok | {:error, term()}
+  def run(opts) do
+    opts =
+      opts
+      |> Keyword.put_new_lazy(:halt_fun, fn -> fn -> :ok end end)
+      |> Keyword.put_new(:pause_iex, true)
+
+    case Breeze.InputRouter.start(opts) do
+      {:ok, pid} ->
+        ref = Process.monitor(pid)
+
+        receive do
+          {:DOWN, ^ref, :process, ^pid, :normal} -> :ok
+          {:DOWN, ^ref, :process, ^pid, :shutdown} -> :ok
+          {:DOWN, ^ref, :process, ^pid, {:shutdown, _}} -> :ok
+          {:DOWN, ^ref, :process, ^pid, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   @doc false
   @spec start_app_link(keyword()) :: GenServer.on_start()
   def start_app_link(opts) do
@@ -109,7 +140,11 @@ defmodule Breeze.Server do
     start_opts = Keyword.get(opts, :start_opts, [])
     frame_delay_ms = Keyword.get(opts, :frame_delay_ms, 80)
     debug_push_interval_ms = Keyword.get(opts, :debug_push_interval_ms, 250)
-    terminal = Keyword.fetch!(opts, :terminal)
+    terminal_size_override = Keyword.get(opts, :terminal_size_override)
+
+    terminal =
+      opts |> Keyword.fetch!(:terminal) |> apply_terminal_size_override(terminal_size_override)
+
     theme = Breeze.Theme.new(Keyword.get(opts, :theme), terminal: terminal)
     theme_source = Keyword.get(opts, :theme)
     apply_theme_defaults? = Breeze.Theme.defaults_enabled?(Keyword.get(opts, :theme))
@@ -161,6 +196,7 @@ defmodule Breeze.Server do
         theme: theme,
         apply_theme_defaults?: apply_theme_defaults?,
         clipboard_opts: Keyword.get(opts, :clipboard, []),
+        terminal_size_override: terminal_size_override,
         global_keybindings: Keyword.get(opts, :global_keybindings, []),
         last_render_at: System.monotonic_time(:millisecond),
         last_interaction_at: nil,
@@ -235,12 +271,12 @@ defmodule Breeze.Server do
 
   def handle_info({reader, {:signal, :winch}}, %{reader: reader, crash: crash} = state)
       when not is_nil(crash) do
-    terminal = Termite.Terminal.resize(state.terminal)
+    terminal = resize_terminal(state)
     {:noreply, render_crash(%{state | terminal: terminal}, force_full_redraw?: true)}
   end
 
   def handle_info({reader, {:signal, :winch}}, %{reader: reader} = state) do
-    terminal = Termite.Terminal.resize(state.terminal)
+    terminal = resize_terminal(state)
     state = %{state | terminal: terminal}
 
     case safe_call(fn ->
@@ -823,6 +859,19 @@ defmodule Breeze.Server do
     |> update_frame(last_payload: nil, last_lines: nil, last_overlays: [])
     |> maybe_render_base(cause)
   end
+
+  defp resize_terminal(state) do
+    state.terminal
+    |> Termite.Terminal.resize()
+    |> apply_terminal_size_override(state.terminal_size_override)
+  end
+
+  defp apply_terminal_size_override(%Termite.Terminal{} = terminal, fun)
+       when is_function(fun, 1) do
+    %{terminal | size: fun.(terminal.size)}
+  end
+
+  defp apply_terminal_size_override(%Termite.Terminal{} = terminal, _fun), do: terminal
 
   defp render_live_child(attrs, opts, state, profile_scope, tracking_ref) do
     ctx = live_child_context(attrs, opts, state)
@@ -1415,9 +1464,7 @@ defmodule Breeze.Server do
   defp live_placeholder_style(_child, _state, _terminal), do: %{}
 
   defp stop(state) do
-    if Process.alive?(state.view_pid) do
-      Process.exit(state.view_pid, :normal)
-    end
+    shutdown_root_view(state.view_pid)
 
     terminal =
       state.terminal

--- a/lib/breeze/server/frame.ex
+++ b/lib/breeze/server/frame.ex
@@ -90,11 +90,13 @@ defmodule Breeze.Server.Frame do
 
   defp changed_base_rows(prev_lines, lines) do
     lines
-    |> Enum.zip(prev_lines)
     |> Enum.with_index()
-    |> Enum.reduce(MapSet.new(), fn
-      {{line, line}, _row}, acc -> acc
-      {_pair, row}, acc -> MapSet.put(acc, row)
+    |> Enum.reduce(MapSet.new(), fn {line, row}, acc ->
+      if line == Enum.at(prev_lines, row, "") do
+        acc
+      else
+        MapSet.put(acc, row)
+      end
     end)
   end
 

--- a/test/breeze/input_router_test.exs
+++ b/test/breeze/input_router_test.exs
@@ -9,7 +9,14 @@ defmodule Breeze.InputRouterTest do
     @behaviour Termite.Terminal.Adapter
 
     def start(opts) do
-      {:ok, %{ref: make_ref(), size: %{width: 80, height: 24}, owner: Keyword.get(opts, :owner)}}
+      ref = make_ref()
+      owner = Keyword.get(opts, :owner)
+
+      if owner do
+        send(owner, {:terminal_started, self(), ref})
+      end
+
+      {:ok, %{ref: ref, size: %{width: 80, height: 24}, owner: owner}}
     end
 
     def reader(term), do: {:ok, term.ref}
@@ -21,25 +28,6 @@ defmodule Breeze.InputRouterTest do
 
     def write(term, _str), do: {:ok, term}
     def resize(term), do: term.size
-  end
-
-  defmodule RecordingAdapter do
-    @behaviour Termite.Terminal.Adapter
-
-    def start(opts) do
-      ref = make_ref()
-      owner = Keyword.fetch!(opts, :owner)
-      send(owner, {:terminal_started, self(), ref})
-      {:ok, %{ref: ref, owner: owner, size: %{width: 80, height: 24}}}
-    end
-
-    def reader(term), do: {:ok, term.ref}
-    def resize(term), do: term.size
-
-    def write(term, str) do
-      send(term.owner, {:terminal_write, str})
-      {:ok, term}
-    end
   end
 
   defmodule PaletteAdapter do
@@ -450,58 +438,26 @@ defmodule Breeze.InputRouterTest do
     assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
   end
 
-  test "enters the alternate screen by default" do
+  test "Server.run blocks until the app stops without halting" do
     parent = self()
 
-    {:ok, pid} =
-      Breeze.InputRouter.start_link(
-        view: BlockingView,
-        start_opts: [parent: parent],
-        hide_cursor: false,
-        terminal_opts: [adapter: RecordingAdapter, owner: parent],
-        halt_fun: fn -> send(parent, :halted) end,
-        global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
-      )
+    task =
+      Task.async(fn ->
+        Breeze.Server.run(
+          view: BlockingView,
+          start_opts: [parent: parent],
+          hide_cursor: false,
+          terminal_opts: [adapter: FakeAdapter, owner: parent],
+          global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+        )
+      end)
 
-    assert_receive {:terminal_started, ^pid, reader}
+    assert_receive {:terminal_started, router_pid, reader}
+    refute Task.yield(task, 50)
 
-    assert wait_until(fn ->
-             drain_terminal_writes()
-             |> IO.iodata_to_binary()
-             |> String.contains?("\e[?1049h")
-           end)
+    send(router_pid, {reader, {:data, "q"}})
 
-    send(pid, {reader, {:data, "q"}})
-    assert_receive :halted
-  end
-
-  test "alt_screen false does not enter or exit the alternate screen" do
-    parent = self()
-
-    {:ok, pid} =
-      Breeze.InputRouter.start_link(
-        view: BlockingView,
-        start_opts: [parent: parent],
-        alt_screen: false,
-        hide_cursor: false,
-        terminal_opts: [adapter: RecordingAdapter, owner: parent],
-        halt_fun: fn -> send(parent, :halted) end,
-        global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
-      )
-
-    ref = Process.monitor(pid)
-    assert_receive {:terminal_started, ^pid, reader}
-
-    send(pid, {reader, {:data, "q"}})
-    assert_receive :halted
-    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
-
-    payload =
-      drain_terminal_writes()
-      |> IO.iodata_to_binary()
-
-    refute String.contains?(payload, "\e[?1049h")
-    refute String.contains?(payload, "\e[?1049l")
+    assert Task.await(task) == :ok
   end
 
   test "stop global keys do not halt when a focused implicit captures printable input" do
@@ -568,13 +524,5 @@ defmodule Breeze.InputRouterTest do
     end)
 
     Process.exit(pid, :normal)
-  end
-
-  defp drain_terminal_writes(writes \\ []) do
-    receive do
-      {:terminal_write, str} -> drain_terminal_writes([str | writes])
-    after
-      10 -> Enum.reverse(writes)
-    end
   end
 end

--- a/test/breeze/live_view_test.exs
+++ b/test/breeze/live_view_test.exs
@@ -40,6 +40,29 @@ defmodule Breeze.LiveViewTest do
     def resize(term), do: term.size
   end
 
+  defmodule ResizeAdapter do
+    @behaviour Termite.Terminal.Adapter
+
+    def start(opts) do
+      {:ok,
+       %{
+         ref: make_ref(),
+         size: %{width: 80, height: 24},
+         resized: %{width: 120, height: 67},
+         owner: Keyword.fetch!(opts, :owner)
+       }}
+    end
+
+    def reader(term), do: {:ok, term.ref}
+
+    def write(term, str) do
+      send(term.owner, {:terminal_write, str})
+      {:ok, term}
+    end
+
+    def resize(term), do: term.resized
+  end
+
   defmodule FakeWatcher do
     use GenServer
 
@@ -90,6 +113,26 @@ defmodule Breeze.LiveViewTest do
       {:noreply, assign(term, count: term.assigns.count + 1)}
     end
 
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule GrowingRoot do
+    use Breeze.View
+
+    def mount(_opts, term) do
+      {:ok, term |> assign(height: 24) |> focus("root")}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <box id="root" focusable>
+        <box :for={row <- 1..@height}>{"row #{row}"}</box>
+      </box>
+      """
+    end
+
+    def handle_event(_, %{"key" => "+"}, term), do: {:noreply, assign(term, height: 26)}
     def handle_event(_, _, term), do: {:noreply, term}
     def handle_info(_, term), do: {:noreply, term}
   end
@@ -1755,7 +1798,73 @@ defmodule Breeze.LiveViewTest do
         if writes == [], do: false, else: writes
       end)
 
-    assert Enum.any?(writes, &String.starts_with?(&1, "\e[2J\e[H"))
+    payload = IO.iodata_to_binary(writes)
+
+    assert payload =~ "\e[2J\e[H"
+
+    Process.exit(pid, :normal)
+  end
+
+  test "terminal size override is reapplied after resize" do
+    terminal = Termite.Terminal.start(adapter: ResizeAdapter, owner: self())
+
+    {:ok, pid} =
+      Breeze.Server.start_app_link(
+        view: CounterChild,
+        terminal: terminal,
+        terminal_size_override: fn size -> %{size | height: max(size.height - 1, 1)} end
+      )
+
+    assert :sys.get_state(pid).terminal.size == %{width: 120, height: 66}
+
+    send(pid, {terminal.reader, {:signal, :winch}})
+
+    wait_until(fn ->
+      case :sys.get_state(pid).debug.stats[:last_render_cause] do
+        :resize -> true
+        _ -> false
+      end
+    end)
+
+    assert :sys.get_state(pid).terminal.size == %{width: 120, height: 66}
+
+    Process.exit(pid, :normal)
+  end
+
+  test "incremental frame diff writes rows introduced by a height increase" do
+    terminal = Termite.Terminal.start(adapter: RecordingAdapter, owner: self())
+
+    {:ok, pid} =
+      Breeze.Server.start_app_link(
+        view: GrowingRoot,
+        terminal: terminal
+      )
+
+    drain_terminal_writes()
+
+    :sys.replace_state(pid, fn state ->
+      terminal = %{state.terminal | size: %{state.terminal.size | height: 26}}
+      frame = %{state.frame | last_payload: nil}
+      %{state | terminal: terminal, frame: frame}
+    end)
+
+    send(pid, {terminal.reader, {:data, "+"}})
+
+    writes =
+      wait_until(fn ->
+        writes = drain_terminal_writes()
+        payload = IO.iodata_to_binary(writes)
+
+        if payload =~ "\e[25;1H" and payload =~ "\e[26;1H" do
+          writes
+        else
+          false
+        end
+      end)
+
+    payload = IO.iodata_to_binary(writes)
+    assert payload =~ "row 25"
+    assert payload =~ "row 26"
 
     Process.exit(pid, :normal)
   end


### PR DESCRIPTION
Add `Breeze.Server.run/1` for interactive sessions that should return to the IEx prompt instead of halting the VM.

Pause IEx input handling by proxying the shell adapter through an `IExShellProxy`, restore the previous shell group on exit, and reserve the bottom prompt row when rendering from IEx. Reapply the terminal size override after resize events.