### PR TITLE
feat(Breeze.ErrorView): add crash detail clipboard export

### DIFF
--- a/examples/crash_handler.exs
+++ b/examples/crash_handler.exs
@@ -20,7 +20,7 @@ defmodule CrashHandlerExample do
       <box style="height-1 bold">Crash Handler Demo</box>
       <box style="height-1">
       </box>
-      <box style="grid grid-cols-1 grid-rows-2 height-full">
+      <box>
         <box id="boom" focusable style="border-rounded width-32 height-5 focus:border-4">
           <box>Press c to raise</box>
           <box>Counter {@counter}</box>
@@ -42,7 +42,7 @@ defmodule CrashHandlerExample do
   end
 
   def handle_event(_, %{"key" => "c"}, _term) do
-    raise "crash demo"
+    run_request_preview!("POST", "/api/demo", %{counter: :not_an_integer})
   end
 
   def handle_event(_, %{"key" => "Enter"}, term) do
@@ -57,6 +57,48 @@ defmodule CrashHandlerExample do
   end
 
   def handle_info(_, term), do: {:noreply, term}
+
+  defp run_request_preview!(method, path, params) do
+    result =
+      %{method: method, path: path, params: params}
+      |> load_fixture_request!()
+
+    {:ok, result}
+  end
+
+  defp load_fixture_request!(request) do
+    request = Map.put(request, :fixture, "examples/crash_handler/request.json")
+    result = authorize_preview!(request)
+    Map.put(result, :fixture_loaded?, true)
+  end
+
+  defp authorize_preview!(request) do
+    request = Map.put(request, :principal, %{id: 42, role: :developer})
+    result = decode_preview_payload!(request)
+    Map.put(result, :authorized?, true)
+  end
+
+  defp decode_preview_payload!(%{params: params} = request) do
+    request = Map.put(request, :counter, Map.fetch!(params, :counter))
+    result = render_preview_response!(request)
+    Map.put(result, :decoded?, true)
+  end
+
+  defp render_preview_response!(request) do
+    if is_integer(request.counter) do
+      %{status: 200, body: "counter=#{request.counter}"}
+    else
+      raise """
+      crash demo could not render request preview
+
+      method=#{request.method}
+      path=#{request.path}
+      fixture=#{request.fixture}
+      principal=#{inspect(request.principal)}
+      counter=#{inspect(request[:counter])}
+      """
+    end
+  end
 end
 
 Breeze.Example.run(

--- a/lib/breeze/error_view.ex
+++ b/lib/breeze/error_view.ex
@@ -8,6 +8,8 @@ defmodule Breeze.ErrorView do
   @focus_order [@stacktrace_id, @history_id]
 
   def render_assigns(view, crash, %{width: width, height: height} = size) do
+    crash = prepare_crash(view, crash, size)
+
     outer_width = max(width, 40)
     outer_height = max(height, 12)
     inner_width = max(outer_width - 2, 1)
@@ -15,20 +17,12 @@ defmodule Breeze.ErrorView do
     header_height = min(5, inner_height)
     body_height = max(inner_height - header_height - 1, 1)
     footer_height = max(inner_height - header_height - body_height, 0)
-    pane_gap = 1
-    pane_outer_width = max(div(max(inner_width - pane_gap, 1), 2), 24)
-    right_outer_width = max(inner_width - pane_outer_width - pane_gap, 24)
-    left_inner_width = max(pane_outer_width - 2, 1)
-    right_inner_width = max(right_outer_width - 2, 1)
-    pane_inner_height = max(body_height - 2, 1)
-    stacktrace_list_height = max(pane_inner_height - 2, 1)
-    history_scroll_height = max(pane_inner_height - 2, 1)
+    layout = pane_layout(inner_width, body_height, crash.focused)
 
-    crash = prepare_crash(view, crash, size)
     entries = frame_entries(crash)
     selected_index = selected_index(crash, entries)
-    message_lines = message_lines(view, crash, entries, selected_index)
-    message_content_width = message_content_width(message_lines, right_inner_width)
+    message_lines = message_lines(view, crash, entries, selected_index, layout.right_inner_width)
+    message_content_width = message_content_width(message_lines, layout.right_inner_width)
 
     %{
       crash: crash,
@@ -37,32 +31,32 @@ defmodule Breeze.ErrorView do
       header_height: header_height,
       body_height: body_height,
       footer_height: footer_height,
-      pane_gap: pane_gap,
-      left_pane_width: pane_outer_width,
-      right_pane_width: right_outer_width,
-      pane_inner_height: pane_inner_height,
+      pane_gap: layout.pane_gap,
+      left_pane_width: layout.left_outer_width,
+      right_pane_width: layout.right_outer_width,
+      pane_inner_height: layout.pane_inner_height,
       selected_index: selected_index,
       entry_count: length(entries),
       stacktrace_pane_style:
-        pane_style(crash.focused == @stacktrace_id, pane_outer_width, body_height),
+        pane_style(crash.focused == @stacktrace_id, layout.left_outer_width, body_height),
       history_pane_style:
-        pane_style(crash.focused == @history_id, right_outer_width, body_height),
-      stacktrace_title_style: pane_title_style(left_inner_width),
-      history_title_style: pane_title_style(right_inner_width),
+        pane_style(crash.focused == @history_id, layout.right_outer_width, body_height),
+      stacktrace_title_style: pane_title_style(layout.left_inner_width),
+      history_title_style: pane_title_style(layout.right_inner_width),
       header_lines: header_lines(view, crash, inner_width, header_height),
-      footer_lines: footer_lines(inner_width, footer_height),
+      footer_lines: footer_lines(inner_width, footer_height, crash),
       stacktrace_items:
         Enum.with_index(entries)
         |> Enum.map(fn {entry, index} ->
-          %{index: index, label: pad_line(entry.summary, left_inner_width)}
+          %{index: index, label: pad_line(entry.summary, layout.left_inner_width)}
         end),
       history_lines: message_lines,
       history_content_height: length(message_lines),
       history_content_width: message_content_width,
-      stacktrace_list_width: left_inner_width,
-      stacktrace_list_height: stacktrace_list_height,
-      history_scroll_width: right_inner_width,
-      history_scroll_height: history_scroll_height
+      stacktrace_list_width: layout.left_inner_width,
+      stacktrace_list_height: layout.stacktrace_list_height,
+      history_scroll_width: layout.right_inner_width,
+      history_scroll_height: layout.history_scroll_height
     }
   end
 
@@ -91,8 +85,11 @@ defmodule Breeze.ErrorView do
     entries = frame_entries(crash)
 
     case input do
-      {:key, "r"} ->
+      {:key, key} when key in ["r", "R"] ->
         :restart
+
+      {:key, key} when key in ["y", "Y", "c", "C"] ->
+        {:copy_details, crash}
 
       {:key, key} when key in ["\t", "ArrowRight", "l"] ->
         {:update, %{crash | focused: rotate_focus(crash.focused, 1)}}
@@ -158,6 +155,21 @@ defmodule Breeze.ErrorView do
   def handle_event(_, _, term), do: {:noreply, term}
   def handle_info(_, term), do: {:noreply, term}
 
+  def details_text(view, crash) do
+    entries = frame_entries(crash)
+    selected_index = selected_index(crash, entries)
+
+    [
+      "Breeze Error",
+      "View #{inspect(view)}",
+      "",
+      "Crash Details",
+      ""
+      | message_lines(view, crash, entries, selected_index, 100)
+    ]
+    |> Enum.join("\n")
+  end
+
   defp dispatch_focused_key(crash, entries, assigns, key) do
     case crash.focused do
       @stacktrace_id ->
@@ -222,21 +234,44 @@ defmodule Breeze.ErrorView do
     |> Map.put(:selected_index, selected_index || 0)
   end
 
-  defp base_assigns(_view, _crash, %{width: width, height: height}) do
+  defp base_assigns(_view, crash, %{width: width, height: height}) do
     outer_width = max(width, 40)
     outer_height = max(height, 12)
     inner_width = max(outer_width - 2, 1)
     inner_height = max(outer_height - 2, 1)
     header_height = min(5, inner_height)
     body_height = max(inner_height - header_height - 1, 1)
+    layout = pane_layout(inner_width, body_height, normalize_focus(crash[:focused]))
+
+    %{
+      left_inner_width: layout.left_inner_width,
+      right_inner_width: layout.right_inner_width,
+      pane_inner_height: layout.pane_inner_height,
+      stacktrace_list_height: layout.stacktrace_list_height,
+      history_scroll_height: layout.history_scroll_height
+    }
+  end
+
+  defp pane_layout(inner_width, body_height, focused) do
     pane_gap = 1
-    pane_outer_width = max(div(max(inner_width - pane_gap, 1), 2), 24)
-    right_outer_width = max(inner_width - pane_outer_width - pane_gap, 24)
-    left_inner_width = max(pane_outer_width - 2, 1)
+
+    {left_outer_width, right_outer_width} =
+      if focused == @history_id and inner_width >= 40 do
+        left_outer_width = 12
+        {left_outer_width, max(inner_width - left_outer_width - pane_gap, 1)}
+      else
+        left_outer_width = max(div(max(inner_width - pane_gap, 1), 2), 24)
+        {left_outer_width, max(inner_width - left_outer_width - pane_gap, 24)}
+      end
+
+    left_inner_width = max(left_outer_width - 2, 1)
     right_inner_width = max(right_outer_width - 2, 1)
     pane_inner_height = max(body_height - 2, 1)
 
     %{
+      pane_gap: pane_gap,
+      left_outer_width: left_outer_width,
+      right_outer_width: right_outer_width,
       left_inner_width: left_inner_width,
       right_inner_width: right_inner_width,
       pane_inner_height: pane_inner_height,
@@ -367,28 +402,36 @@ defmodule Breeze.ErrorView do
     |> pad_lines(width, height)
   end
 
-  defp footer_lines(_width, 0), do: []
+  defp footer_lines(_width, 0, _crash), do: []
 
-  defp footer_lines(width, height) do
+  defp footer_lines(width, height, crash) do
+    default =
+      "Tab switches panes. Arrows or j/k move and scroll. y copies details. r restarts. q quits."
+
     [
-      "Tab switches panes. Arrow keys or j/k move and scroll. Press r to restart. Press q to quit."
+      crash[:notice] || default
     ]
     |> pad_lines(width, height)
   end
 
-  defp message_lines(view, _crash, [], _selected_index) do
+  defp message_lines(view, _crash, [], _selected_index, width) do
     ["Selected Frame", "", "View #{inspect(view)}", "", "No stacktrace frames captured"]
+    |> wrap_lines(width)
   end
 
-  defp message_lines(view, crash, entries, selected_index) do
+  defp message_lines(view, crash, entries, selected_index, width) do
     selected = Enum.at(entries, selected_index)
 
-    [
-      "Selected Frame",
-      "",
-      "View #{inspect(view)}"
-      | selected.detail_lines
-    ] ++ ["", "Crash Message", ""] ++ wrap_lines(crash_message_lines(crash), 80)
+    selected_lines =
+      [
+        "Selected Frame",
+        "",
+        "View #{inspect(view)}"
+        | selected.detail_lines
+      ]
+      |> wrap_lines(width)
+
+    selected_lines ++ ["", "Crash Message", ""] ++ wrap_lines(crash_message_lines(crash), width)
   end
 
   defp crash_message_lines(crash) do
@@ -522,7 +565,8 @@ defmodule Breeze.ErrorView do
   end
 
   defp truncate_line(line, width) when byte_size(line) <= width, do: line
-  defp truncate_line(line, width) when width > 1, do: String.slice(line, 0, width - 1) <> "..."
+  defp truncate_line(line, width) when width > 3, do: String.slice(line, 0, width - 3) <> "..."
+  defp truncate_line(_line, width) when width > 0, do: String.duplicate(".", width)
   defp truncate_line(line, width), do: String.slice(line, 0, width)
 
   defp message_content_width(lines, min_width) do

--- a/lib/breeze/error_view/clipboard.ex
+++ b/lib/breeze/error_view/clipboard.ex
@@ -1,0 +1,100 @@
+defmodule Breeze.ErrorView.Clipboard do
+  @moduledoc false
+
+  def copy(text, opts \\ []) when is_binary(text) do
+    timeout = Keyword.get(opts, :timeout, 500)
+
+    task =
+      Task.async(fn ->
+        case Keyword.get(opts, :copy_fun) do
+          fun when is_function(fun, 1) ->
+            fun.(text)
+
+          _ ->
+            with {:ok, command} <- command(opts) do
+              run_command(command, text, opts)
+            end
+        end
+      end)
+
+    case Task.yield(task, timeout) || Task.shutdown(task, :brutal_kill) do
+      {:ok, result} -> normalize_result(result)
+      nil -> {:error, :timeout}
+    end
+  rescue
+    exception -> {:error, exception}
+  catch
+    kind, reason -> {:error, {kind, reason}}
+  end
+
+  def command(opts \\ []) do
+    os_type = Keyword.get(opts, :os_type, :os.type())
+    find_executable = Keyword.get(opts, :find_executable, &System.find_executable/1)
+
+    os_type
+    |> candidates()
+    |> Enum.find_value(fn name ->
+      case find_executable.(name) do
+        nil -> nil
+        path -> {name, path}
+      end
+    end)
+    |> case do
+      nil -> {:error, :unavailable}
+      command -> {:ok, command}
+    end
+  end
+
+  defp candidates({:unix, :darwin}), do: ["pbcopy"]
+  defp candidates({:unix, _}), do: ["wl-copy"]
+  defp candidates(_), do: []
+
+  defp run_command({name, path}, text, opts) do
+    case Keyword.get(opts, :run_fun) do
+      fun when is_function(fun, 3) ->
+        fun.(name, path, text)
+
+      _ ->
+        copy_with_shell(name, path, text)
+    end
+  end
+
+  defp copy_with_shell(name, path, text) do
+    tmp_path =
+      Path.join(System.tmp_dir!(), "breeze-clipboard-#{System.unique_integer([:positive])}")
+
+    try do
+      with :ok <- File.write(tmp_path, text),
+           {:ok, shell} <- find_shell(),
+           {output, 0} <- run_shell_copy(shell, tmp_path, path) do
+        _ = output
+        {:ok, name}
+      else
+        {:error, reason} ->
+          {:error, reason}
+
+        {output, status} ->
+          {:error, {:exit_status, status, output}}
+      end
+    after
+      File.rm(tmp_path)
+    end
+  end
+
+  defp find_shell do
+    case System.find_executable("sh") do
+      nil -> {:error, :unavailable}
+      shell -> {:ok, shell}
+    end
+  end
+
+  defp run_shell_copy(shell, tmp_path, path) do
+    System.cmd(shell, ["-c", "\"$2\" < \"$1\" >/dev/null 2>&1", "breeze-copy", tmp_path, path],
+      stderr_to_stdout: true
+    )
+  end
+
+  defp normalize_result({:ok, command}), do: {:ok, command}
+  defp normalize_result({:error, reason}), do: {:error, reason}
+  defp normalize_result(other), do: {:error, {:unexpected_result, other}}
+end

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -17,13 +17,17 @@ defmodule Breeze.Server do
     :view,
     :start_opts,
     :alt_screen?,
+    :alt_screen_active?,
+    :hide_cursor?,
     :mouse_mode,
     :reload_opts,
     :reloader_pid,
     :focused,
     :theme,
     :apply_theme_defaults?,
+    :clipboard_opts,
     :crash,
+    :crash_scrollback?,
     :last_render_at,
     :last_interaction_at,
     children: %{},
@@ -43,6 +47,7 @@ defmodule Breeze.Server do
           | {:mouse, boolean() | keyword()}
           | {:reload, boolean() | keyword()}
           | {:theme, Breeze.Theme.t() | map() | keyword() | atom()}
+          | {:clipboard, keyword()}
           | {:global_keybindings, list()}
           | {:inspector, boolean() | keyword()}
           | {:debug_push_interval_ms, pos_integer()}
@@ -145,6 +150,8 @@ defmodule Breeze.Server do
         view: view,
         start_opts: start_opts,
         alt_screen?: Keyword.get(opts, :alt_screen, true),
+        alt_screen_active?: Keyword.get(opts, :alt_screen, true),
+        hide_cursor?: Keyword.get(opts, :hide_cursor, true),
         mouse_mode: Keyword.get(opts, :mouse, false),
         reload_opts:
           normalize_reload_opts(
@@ -153,6 +160,7 @@ defmodule Breeze.Server do
         focused: focused,
         theme: theme,
         apply_theme_defaults?: apply_theme_defaults?,
+        clipboard_opts: Keyword.get(opts, :clipboard, []),
         global_keybindings: Keyword.get(opts, :global_keybindings, []),
         last_render_at: System.monotonic_time(:millisecond),
         last_interaction_at: nil,
@@ -228,7 +236,7 @@ defmodule Breeze.Server do
   def handle_info({reader, {:signal, :winch}}, %{reader: reader, crash: crash} = state)
       when not is_nil(crash) do
     terminal = Termite.Terminal.resize(state.terminal)
-    {:noreply, render_crash(%{state | terminal: terminal})}
+    {:noreply, render_crash(%{state | terminal: terminal}, force_full_redraw?: true)}
   end
 
   def handle_info({reader, {:signal, :winch}}, %{reader: reader} = state) do
@@ -254,6 +262,13 @@ defmodule Breeze.Server do
     send(pid, {:ensure_runtime_palette, :system})
     {:noreply, state}
   end
+
+  def handle_info({:clear_crash_notice, ref}, %{crash: %{notice_ref: ref} = crash} = state) do
+    crash = Map.drop(crash, [:notice, :notice_ref])
+    {:noreply, state |> Map.put(:crash, crash) |> render_crash()}
+  end
+
+  def handle_info({:clear_crash_notice, _ref}, state), do: {:noreply, state}
 
   def handle_info(:child_invalidated, %{crash: crash} = state) when not is_nil(crash) do
     {:noreply, state}
@@ -430,7 +445,7 @@ defmodule Breeze.Server do
   end
 
   defp handle_decoded_sync_input({:key, key}, %{crash: crash} = state) when not is_nil(crash) do
-    {:noreply, dispatch_crash_input({:key, key}, touch_interaction(state))}
+    handle_crash_input({:key, key}, touch_interaction(state))
   end
 
   defp handle_decoded_sync_input({:key, key}, state) do
@@ -445,7 +460,7 @@ defmodule Breeze.Server do
   end
 
   defp handle_deferred_input({:key, key}, %{crash: crash} = state) when not is_nil(crash) do
-    {:noreply, dispatch_crash_input({:key, key}, touch_interaction(state))}
+    handle_crash_input({:key, key}, touch_interaction(state))
   end
 
   defp handle_deferred_input({:key, key}, state) do
@@ -1381,7 +1396,7 @@ defmodule Breeze.Server do
       |> Termite.Screen.disable_mouse()
       |> Termite.Screen.clear_screen()
       |> Termite.Screen.show_cursor()
-      |> maybe_exit_alt_screen(state.alt_screen?)
+      |> maybe_exit_alt_screen(state.alt_screen_active?)
 
     terminal = Termite.Terminal.write(terminal, "\r")
     {:stop, :normal, %{state | terminal: terminal}}
@@ -1471,6 +1486,8 @@ defmodule Breeze.Server do
   end
 
   defp crash_info(kind, reason, stacktrace) do
+    {kind, reason, stacktrace} = normalize_crash_info(kind, reason, stacktrace)
+
     %{
       kind: kind,
       reason: reason,
@@ -1480,6 +1497,28 @@ defmodule Breeze.Server do
       implicit_state: %{}
     }
   end
+
+  defp normalize_crash_info(:exit, {{%_exception{} = exception, stacktrace}, _call}, _stacktrace)
+       when is_list(stacktrace) do
+    {:error, exception, stacktrace}
+  end
+
+  defp normalize_crash_info(:exit, {%_exception{} = exception, stacktrace}, _stacktrace)
+       when is_list(stacktrace) do
+    {:error, exception, stacktrace}
+  end
+
+  defp normalize_crash_info(:exit, {{{kind, reason, stacktrace}, _location}, _call}, _stacktrace)
+       when is_list(stacktrace) do
+    {kind, reason, stacktrace}
+  end
+
+  defp normalize_crash_info(:exit, {kind, reason, stacktrace}, _stacktrace)
+       when is_list(stacktrace) do
+    {kind, reason, stacktrace}
+  end
+
+  defp normalize_crash_info(kind, reason, stacktrace), do: {kind, reason, stacktrace}
 
   defp enter_crash_state(state, crash) do
     cancel_timer(state.frame.animation_timer)
@@ -1497,13 +1536,13 @@ defmodule Breeze.Server do
     )
     |> update_frame(animation_timer: nil, next_tick_at: nil, decorations: [])
     |> Debug.put_stat(:last_render_cause, :crash)
-    |> render_crash()
+    |> render_crash(force_full_redraw?: true)
   end
 
   defp cancel_timer(nil), do: :ok
   defp cancel_timer(timer), do: Process.cancel_timer(timer)
 
-  defp render_crash(state) do
+  defp render_crash(state, opts \\ []) do
     crash = Breeze.ErrorView.prepare_crash(state.view, state.crash, state.terminal.size)
 
     content =
@@ -1516,21 +1555,95 @@ defmodule Breeze.Server do
         )
       )
 
+    state = Map.put(state, :crash, crash)
+
+    frame_opts =
+      if Keyword.get(opts, :force_full_redraw?, false) do
+        [base_output: content, last_payload: nil, last_lines: nil, last_overlays: []]
+      else
+        [base_output: content]
+      end
+
     state
-    |> Map.put(:crash, crash)
-    |> update_frame(base_output: content, last_payload: nil, last_lines: nil, last_overlays: [])
+    |> update_frame(frame_opts)
     |> render_frame()
   end
 
-  defp dispatch_crash_input(input, %{crash: crash} = state) do
+  defp handle_crash_input(input, %{crash: crash} = state) do
     case Breeze.ErrorView.handle_input(state.view, crash, input, state.terminal.size) do
       :restart ->
-        restart_root(state, :restart)
+        {:noreply, restart_root(state, :restart)}
+
+      {:copy_details, crash} ->
+        copy_or_print_crash_details(state, crash)
 
       {:update, updated_crash} ->
-        state |> Map.put(:crash, updated_crash) |> render_crash()
+        {:noreply, state |> Map.put(:crash, updated_crash) |> render_crash()}
     end
   end
+
+  defp copy_or_print_crash_details(state, crash) do
+    details = Breeze.ErrorView.details_text(state.view, crash)
+
+    case Breeze.ErrorView.Clipboard.copy(details, state.clipboard_opts || []) do
+      {:ok, command} ->
+        {:noreply,
+         show_temporary_crash_notice(state, crash, "Copied crash details to #{command}.")}
+
+      {:error, :unavailable} ->
+        print_crash_details_to_scrollback(state, details)
+
+      {:error, reason} ->
+        details = details <> "\n\nClipboard copy failed: #{inspect(reason)}"
+        print_crash_details_to_scrollback(state, details)
+    end
+  end
+
+  defp show_temporary_crash_notice(state, crash, notice) do
+    ref = make_ref()
+    Process.send_after(self(), {:clear_crash_notice, ref}, 1_000)
+
+    crash =
+      crash
+      |> Map.put(:notice, notice)
+      |> Map.put(:notice_ref, ref)
+
+    state
+    |> Map.put(:crash, crash)
+    |> render_crash()
+  end
+
+  defp print_crash_details_to_scrollback(state, details) do
+    terminal =
+      state.terminal
+      |> Termite.Screen.disable_mouse()
+      |> Termite.Screen.show_cursor()
+      |> maybe_exit_alt_screen(state.alt_screen_active?)
+      |> Termite.Terminal.write("\r\n" <> details <> "\r\n\nPress q to quit, r to restart.\r\n")
+
+    {:noreply, %{state | terminal: terminal, alt_screen_active?: false, crash_scrollback?: true}}
+  end
+
+  defp restore_terminal_after_crash_scrollback(%{crash_scrollback?: true} = state) do
+    terminal =
+      state.terminal
+      |> maybe_enter_alt_screen(state.alt_screen?, state.alt_screen_active?)
+      |> maybe_hide_cursor(state.hide_cursor?)
+      |> Termite.Screen.clear_screen()
+
+    state
+    |> Map.put(:terminal, terminal)
+    |> Map.put(:alt_screen_active?, state.alt_screen?)
+    |> update_frame(last_payload: nil, last_lines: nil, last_overlays: [])
+  end
+
+  defp restore_terminal_after_crash_scrollback(state), do: state
+
+  defp maybe_enter_alt_screen(terminal, true, false), do: Termite.Screen.alt_screen(terminal)
+  defp maybe_enter_alt_screen(terminal, _configured?, _active?), do: terminal
+
+  defp maybe_hide_cursor(terminal, true), do: Termite.Screen.hide_cursor(terminal)
+  defp maybe_hide_cursor(terminal, _), do: terminal
 
   defp reload_after_code_change(state) do
     state = prune_dead_children(state)
@@ -1548,7 +1661,11 @@ defmodule Breeze.Server do
   end
 
   defp restart_root(state, cause) do
-    state = %{state | terminal: apply_mouse_mode(state.terminal, state.mouse_mode)}
+    state =
+      state
+      |> restore_terminal_after_crash_scrollback()
+      |> then(&%{&1 | terminal: apply_mouse_mode(&1.terminal, &1.mouse_mode)})
+
     shutdown_root_view(state.view_pid)
 
     case start_root_view(state) do
@@ -1558,6 +1675,7 @@ defmodule Breeze.Server do
         |> Map.put(:focused, focused)
         |> Map.put(:theme, theme)
         |> Map.put(:crash, nil)
+        |> Map.put(:crash_scrollback?, false)
         |> Map.put(:children, %{})
         |> update_frame(
           decorations: [],

--- a/test/breeze/error_view/clipboard_test.exs
+++ b/test/breeze/error_view/clipboard_test.exs
@@ -1,0 +1,27 @@
+defmodule Breeze.ErrorView.ClipboardTest do
+  use ExUnit.Case, async: true
+
+  alias Breeze.ErrorView.Clipboard
+
+  test "returns timeout when clipboard command does not finish" do
+    assert {:error, :timeout} =
+             Clipboard.copy("details",
+               timeout: 10,
+               run_fun: fn _name, _path, _text ->
+                 Process.sleep(1_000)
+                 {:ok, "slow-copy"}
+               end,
+               find_executable: fn "wl-copy" -> "/usr/bin/wl-copy" end
+             )
+  end
+
+  test "returns unavailable when no clipboard command exists" do
+    assert {:error, :unavailable} =
+             Clipboard.copy("details", find_executable: fn _name -> nil end)
+  end
+
+  test "normalizes unexpected clipboard function results" do
+    assert {:error, {:unexpected_result, :ok}} =
+             Clipboard.copy("details", copy_fun: fn _text -> :ok end)
+  end
+end

--- a/test/breeze/live_view_test.exs
+++ b/test/breeze/live_view_test.exs
@@ -945,6 +945,8 @@ defmodule Breeze.LiveViewTest do
       assert state.frame.base_output =~ "Selected Frame"
       assert state.frame.base_output =~ "Stacktrace"
       assert state.frame.base_output =~ "boom"
+      assert Breeze.ErrorView.frame_count(state.crash) > 1
+      refute state.frame.base_output =~ "No structured stacktrace captured"
 
       Process.exit(pid, :normal)
     end)
@@ -973,6 +975,11 @@ defmodule Breeze.LiveViewTest do
       assert initial_state.crash
       assert initial_state.crash.focused == "error-stacktrace"
 
+      initial_assigns =
+        Breeze.ErrorView.render_assigns(CrashingView, initial_state.crash, terminal.size)
+
+      assert initial_assigns.stacktrace_list_width > 10
+
       send(pid, {reader, {:data, "\t"}})
 
       wait_until(fn ->
@@ -982,6 +989,243 @@ defmodule Breeze.LiveViewTest do
 
       next_state = :sys.get_state(pid)
       assert next_state.crash.focused == "error-history"
+
+      assigns = Breeze.ErrorView.render_assigns(CrashingView, next_state.crash, terminal.size)
+      assert assigns.stacktrace_list_width == 10
+      assert assigns.history_scroll_width > 50
+
+      Process.exit(pid, :normal)
+    end)
+  end
+
+  test "crash details text wraps to the details pane width" do
+    crash = %{
+      kind: :error,
+      reason:
+        RuntimeError.exception(
+          "a long crash message with enough words to wrap inside the details pane instead of scrolling horizontally"
+        ),
+      stacktrace: [
+        {Very.Long.CrashHandler.ModuleName.ForWrapping, :function_name_with_a_long_suffix, 3,
+         [file: ~c"test/support/a/very/long/path/to/a/crashing/file_for_wrapping.exs", line: 123]}
+      ],
+      selected_index: nil,
+      focused: "error-stacktrace",
+      implicit_state: %{}
+    }
+
+    assigns = Breeze.ErrorView.render_assigns(CrashingView, crash, %{width: 60, height: 20})
+
+    assert assigns.history_content_width == assigns.history_scroll_width
+    assert Enum.any?(assigns.history_lines, &String.contains?(&1, "horizontally"))
+    assert Enum.all?(assigns.history_lines, &(String.length(&1) <= assigns.history_scroll_width))
+  end
+
+  test "crash screen keypresses patch rows instead of forcing full redraws" do
+    capture_log(fn ->
+      terminal = Termite.Terminal.start(adapter: RecordingAdapter, owner: self())
+      reader = terminal.reader
+
+      {:ok, pid} =
+        Breeze.Server.start_app_link(
+          view: CrashingView,
+          terminal: terminal,
+          global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+        )
+
+      drain_terminal_writes()
+      send(pid, {reader, {:data, "c"}})
+
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+        state.crash && state.frame.base_output =~ "Breeze Error"
+      end)
+
+      drain_terminal_writes()
+      send(pid, {reader, {:data, "\t"}})
+
+      writes =
+        wait_until(fn ->
+          writes = drain_terminal_writes()
+
+          if :sys.get_state(pid).crash.focused == "error-history" and writes != [] do
+            IO.iodata_to_binary(writes)
+          else
+            false
+          end
+        end)
+
+      refute writes =~ "\e[2J"
+      assert writes =~ "Crash Details"
+
+      Process.exit(pid, :normal)
+    end)
+  end
+
+  test "crash screen copies plain details when clipboard is available" do
+    parent = self()
+
+    capture_log(fn ->
+      terminal = Termite.Terminal.start(adapter: FakeAdapter)
+      reader = terminal.reader
+
+      {:ok, pid} =
+        Breeze.Server.start_app_link(
+          view: CrashingView,
+          terminal: terminal,
+          clipboard: [
+            copy_fun: fn text ->
+              send(parent, {:copied_crash_details, text})
+              {:ok, "test-clipboard"}
+            end
+          ],
+          global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+        )
+
+      send(pid, {reader, {:data, "c"}})
+
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+        state.crash && state.frame.base_output =~ "Breeze Error"
+      end)
+
+      send(pid, {reader, {:data, "y"}})
+
+      assert_receive {:copied_crash_details, details}
+      assert details =~ "Breeze Error"
+      assert details =~ "Crash Details"
+      assert details =~ "CrashingView"
+      assert details =~ "RuntimeError"
+      assert details =~ "boom"
+
+      wait_until(fn ->
+        :sys.get_state(pid).frame.base_output =~ "Copied crash details to test-clipboard."
+      end)
+
+      Process.sleep(1_050)
+
+      wait_until(fn ->
+        output = :sys.get_state(pid).frame.base_output
+
+        output =~ "y copies details" and
+          not String.contains?(output, "Copied crash details to test-clipboard.")
+      end)
+
+      Process.exit(pid, :normal)
+    end)
+  end
+
+  test "crash screen accepts uppercase yank key" do
+    parent = self()
+
+    capture_log(fn ->
+      terminal = Termite.Terminal.start(adapter: FakeAdapter)
+      reader = terminal.reader
+
+      {:ok, pid} =
+        Breeze.Server.start_app_link(
+          view: CrashingView,
+          terminal: terminal,
+          clipboard: [
+            copy_fun: fn text ->
+              send(parent, {:copied_crash_details, text})
+              {:ok, "test-clipboard"}
+            end
+          ],
+          global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+        )
+
+      send(pid, {reader, {:data, "c"}})
+
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+        state.crash && state.frame.base_output =~ "Breeze Error"
+      end)
+
+      send(pid, {reader, {:data, "Y"}})
+
+      assert_receive {:copied_crash_details, details}
+      assert details =~ "Breeze Error"
+      assert details =~ "RuntimeError"
+
+      wait_until(fn ->
+        :sys.get_state(pid).frame.base_output =~ "Copied crash details to test-clipboard."
+      end)
+
+      Process.exit(pid, :normal)
+    end)
+  end
+
+  test "crash screen prints details to scrollback when clipboard copy times out" do
+    capture_log(fn ->
+      terminal = Termite.Terminal.start(adapter: RecordingAdapter, owner: self())
+      reader = terminal.reader
+
+      {:ok, pid} =
+        Breeze.Server.start_app_link(
+          view: CrashingView,
+          terminal: terminal,
+          clipboard: [
+            timeout: 10,
+            find_executable: fn "wl-copy" -> "/usr/bin/wl-copy" end,
+            run_fun: fn _name, _path, _text ->
+              Process.sleep(1_000)
+              {:ok, "slow-copy"}
+            end
+          ],
+          global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+        )
+
+      drain_terminal_writes()
+
+      send(pid, {reader, {:data, "c"}})
+
+      wait_until(fn ->
+        state = :sys.get_state(pid)
+        state.crash && state.frame.base_output =~ "Breeze Error"
+      end)
+
+      drain_terminal_writes()
+      send(pid, {reader, {:data, "y"}})
+
+      writes =
+        wait_until(fn ->
+          writes = drain_terminal_writes()
+          output = IO.iodata_to_binary(writes)
+
+          if output =~ "Crash Details" and output =~ "Clipboard copy failed: :timeout" and
+               output =~ "Press q to quit, r to restart." do
+            output
+          else
+            false
+          end
+        end)
+
+      assert writes =~ "\e[?1049l"
+      assert writes =~ "Breeze Error"
+      assert writes =~ "CrashingView"
+      assert writes =~ "RuntimeError"
+      assert :sys.get_state(pid).alt_screen_active? == false
+
+      drain_terminal_writes()
+      send(pid, {reader, {:data, "r"}})
+
+      restarted_state =
+        wait_until(fn ->
+          state = :sys.get_state(pid)
+
+          if is_nil(state.crash) and state.frame.base_output =~ "ready" do
+            state
+          else
+            false
+          end
+        end)
+
+      assert restarted_state.alt_screen_active? == true
+
+      restart_writes = IO.iodata_to_binary(drain_terminal_writes())
+      assert restart_writes =~ "\e[?1049h"
+      assert restart_writes =~ "ready"
 
       Process.exit(pid, :normal)
     end)


### PR DESCRIPTION
Add crash-screen support for copying plain crash details with y/c, using pbcopy on macOS and wl-copy on other Unix systems. Fall back to printing details into normal scrollback when no clipboard command is available or copying fails, and restarting cleanly after the scrollback fallback.