### PR TITLE
feat(Breeze.Blocks): add table component

### DIFF
--- a/doc_support/block_previews.ex
+++ b/doc_support/block_previews.ex
@@ -40,6 +40,14 @@ defmodule Breeze.Docs.BlockPreviews do
             render_view(__MODULE__.SelectedListPreview, size: {28, 10}, focused: "preview-list")
           end}
        ]},
+      {"Table",
+       [
+         {"Initial", fn -> render_view(__MODULE__.TablePreview, size: {44, 8}) end},
+         {"Selected",
+          fn ->
+            render_view(__MODULE__.SelectedTablePreview, size: {44, 8}, focused: "preview-table")
+          end}
+       ]},
       {"Dropdown",
        [
          {"Closed", fn -> render_view(__MODULE__.DropdownPreview, size: {28, 4}) end},
@@ -175,6 +183,7 @@ defmodule Breeze.Docs.BlockPreviews do
   end
 
   defp component_ref("List"), do: "Breeze.Blocks.list/1"
+  defp component_ref("Table"), do: "Breeze.Blocks.table/1"
   defp component_ref("Dropdown"), do: "Breeze.Blocks.dropdown/1"
   defp component_ref("Tabs"), do: "Breeze.Blocks.tabs/1"
   defp component_ref("Markdown"), do: "Breeze.Blocks.markdown/1"
@@ -183,6 +192,7 @@ defmodule Breeze.Docs.BlockPreviews do
   defp component_ref("Modal"), do: "Breeze.Blocks.modal/1"
 
   defp component_code("List"), do: render_template_source(__MODULE__.ListPreview)
+  defp component_code("Table"), do: render_template_source(__MODULE__.TablePreview)
   defp component_code("Dropdown"), do: render_template_source(__MODULE__.DropdownPreview)
   defp component_code("Tabs"), do: render_template_source(__MODULE__.TabsPreview)
   defp component_code("Markdown"), do: render_template_source(__MODULE__.MarkdownPreview)
@@ -204,6 +214,14 @@ defmodule Breeze.Docs.BlockPreviews do
       {"small", "Small"},
       {"medium", "Medium"},
       {"large", "Large"}
+    ]
+  end
+
+  def table_rows do
+    [
+      %{id: "tokyo", rank: "1", city: "Tokyo", country: "Japan", population: "37.2m"},
+      %{id: "delhi", rank: "2", city: "Delhi", country: "India", population: "32.0m"},
+      %{id: "shanghai", rank: "3", city: "Shanghai", country: "China", population: "28.5m"}
     ]
   end
 
@@ -325,6 +343,48 @@ defmodule Breeze.Docs.BlockPreviews do
     end
   end
 
+  defmodule TablePreview do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def mount(_opts, term), do: {:ok, term}
+    def handle_event(_, _, term), do: {:noreply, term}
+
+    def render(assigns) do
+      assigns = Map.put(assigns, :rows, Breeze.Docs.BlockPreviews.table_rows())
+
+      ~H"""
+      <.table id="preview-table" rows={@rows}>
+        <:col :let={city} label="#" width={4} align="right">{city.rank}</:col>
+        <:col :let={city} label="City" width={12}>{city.city}</:col>
+        <:col :let={city} label="Country" width={12}>{city.country}</:col>
+        <:col :let={city} label="Pop." width={10} align="right">{city.population}</:col>
+      </.table>
+      """
+    end
+  end
+
+  defmodule SelectedTablePreview do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def mount(_opts, term), do: {:ok, term}
+    def handle_event(_, _, term), do: {:noreply, term}
+
+    def render(assigns) do
+      assigns = Map.put(assigns, :rows, Breeze.Docs.BlockPreviews.table_rows())
+
+      ~H"""
+      <.table id="preview-table" rows={@rows} selected="delhi">
+        <:col :let={city} label="#" width={4} align="right">{city.rank}</:col>
+        <:col :let={city} label="City" width={12}>{city.city}</:col>
+        <:col :let={city} label="Country" width={12}>{city.country}</:col>
+        <:col :let={city} label="Pop." width={10} align="right">{city.population}</:col>
+      </.table>
+      """
+    end
+  end
+
   defmodule DropdownPreview do
     use Breeze.View
     import Breeze.Blocks
@@ -394,7 +454,7 @@ defmodule Breeze.Docs.BlockPreviews do
       assigns = Map.put(assigns, :content, Breeze.Docs.BlockPreviews.markdown_content())
 
       ~H"""
-      <.markdown id="preview-markdown" content={@content} width={36} style="width-40 height-8" />
+      <.markdown id="preview-markdown" content={@content} width={36} style="width-40 height-8"/>
       """
     end
   end

--- a/lib/breeze/blocks.ex
+++ b/lib/breeze/blocks.ex
@@ -470,6 +470,165 @@ defmodule Breeze.Blocks do
     """
   end
 
+  attr :id, :string, required: true
+  attr :rows, :list, default: []
+  attr :selected, :any, default: nil
+  attr :row_value, :any, default: :id
+  attr :loop, :boolean, default: true
+  attr :scroll_padding, :integer, default: 0
+  attr :empty, :string, default: "No rows"
+  attr :rest, :global
+
+  slot :col do
+    attr :label, :string, default: nil
+    attr :width, :integer, default: nil
+    attr :align, :any, default: "left"
+    attr :class, :string, default: nil
+    attr :style, :any, default: nil
+  end
+
+  def table(assigns) do
+    rows = Map.get(assigns, :rows, [])
+    columns = normalize_table_columns(assigns.col, rows)
+    rows = normalize_table_rows(rows, columns, Map.get(assigns, :row_value, :id))
+
+    assigns =
+      assigns
+      |> assign(columns: columns)
+      |> assign(rows: rows)
+      |> assign(cell_class: "height-1 overflow-hidden selected:bg-primary selected:text-bg")
+
+    ~H"""
+    <box
+      class="border width-full height-8 overflow-hidden bg-panel focus:border-primary"
+      focus-within="true"
+    >
+      <box
+        :if={@columns != []}
+        class="inline width-full height-1 overflow-hidden bold bg-emphasize-20"
+      >
+        <box :for={column <- @columns} class={column.header_class}>{column.label}</box>
+      </box>
+      <box
+        id={@id}
+        focusable
+        implicit={Breeze.Implicit.List}
+        list-loop={@loop}
+        list-selected={@selected}
+        list-scroll-padding={@scroll_padding}
+        class="height-full width-full overflow-scroll scrollbar-arrows focus:scrollbar-primary"
+        {@rest}
+      >
+        <box :if={@rows == []} class="width-full height-1 text-muted">{@empty}</box>
+        <box
+          :for={row <- @rows}
+          value={row.value}
+          focus-with-owner
+          class="inline width-full height-1 overflow-hidden selected:bg-primary selected:text-bg"
+        >
+          <box
+            :for={cell <- row.cells}
+            selected-with-owner
+            class={Breeze.Blocks.merge_class(@cell_class, cell.class)}
+            style={cell.style}
+          >
+            {render_slot(cell.slot, cell.row)}
+          </box>
+        </box>
+      </box>
+    </box>
+    """
+  end
+
+  defp normalize_table_columns(columns, rows) do
+    columns =
+      Enum.map(columns, fn column ->
+        %{
+          slot: column,
+          label: Map.get(column, :label) || "",
+          width: Map.get(column, :width),
+          align: normalize_align(Map.get(column, :align, "left")),
+          class: Map.get(column, :class),
+          style: Map.get(column, :style)
+        }
+      end)
+
+    Enum.map(columns, fn column ->
+      width = column.width || inferred_table_column_width(column, rows)
+      align_class = table_align_class(column.align)
+
+      column
+      |> Map.put(:width, width)
+      |> Map.put(
+        :header_class,
+        "width-#{width} padding-left-1 padding-right-1 overflow-hidden #{align_class}"
+      )
+      |> Map.put(
+        :cell_class,
+        "width-#{width} padding-left-1 padding-right-1 overflow-hidden #{align_class}"
+      )
+    end)
+  end
+
+  defp inferred_table_column_width(column, rows) do
+    rows
+    |> Enum.map(fn row -> render_slot(column.slot, row) |> Ucwidth.width() end)
+    |> Kernel.++([Ucwidth.width(column.label), 4])
+    |> Enum.max()
+  end
+
+  defp normalize_table_rows(rows, columns, row_value) do
+    Enum.map(rows, fn row ->
+      %{
+        value: table_row_value(row, row_value),
+        cells:
+          Enum.map(columns, fn column ->
+            %{
+              slot: column.slot,
+              row: row,
+              class: merge_class(column.cell_class, column.class),
+              style: column.style
+            }
+          end)
+      }
+    end)
+  end
+
+  defp table_row_value(row, fun) when is_function(fun, 1), do: fun.(row)
+
+  defp table_row_value(row, nil), do: row
+
+  defp table_row_value(row, key) when is_atom(key) or is_binary(key) do
+    table_row_lookup(row, key, row)
+  end
+
+  defp table_row_value(row, _row_value), do: row
+
+  defp table_row_lookup(row, key, default) when is_map(row) do
+    Map.get(row, key) || Map.get(row, to_string(key)) || Map.get(row, key_to_existing_atom(key)) ||
+      default
+  end
+
+  defp table_row_lookup(_row, _key, default), do: default
+
+  defp key_to_existing_atom(key) when is_atom(key), do: key
+
+  defp key_to_existing_atom(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp key_to_existing_atom(_key), do: nil
+
+  defp normalize_align(value) when value in [:right, "right"], do: :right
+  defp normalize_align(value) when value in [:center, "center"], do: :center
+  defp normalize_align(_value), do: :left
+
+  defp table_align_class(:right), do: "text-right"
+  defp table_align_class(:center), do: "text-center"
+  defp table_align_class(_align), do: "text-left"
+
   attr :id, :string, default: nil
   attr :focusable, :boolean, default: true
   attr :class, :string, default: nil

--- a/lib/breeze/html_formatter.ex
+++ b/lib/breeze/html_formatter.ex
@@ -168,6 +168,7 @@ defmodule Breeze.HTMLFormatter do
     directive_attrs =
       []
       |> maybe_add_for(directives[:for])
+      |> maybe_add_let(directives[:let])
       |> maybe_add_if(directives[:if])
 
     directive_attrs ++ Enum.map(attrs, &format_attr/1)
@@ -181,6 +182,11 @@ defmodule Breeze.HTMLFormatter do
 
   defp maybe_add_if(attrs, nil), do: attrs
   defp maybe_add_if(attrs, expr), do: attrs ++ [":if={" <> expr_to_string(expr) <> "}"]
+
+  defp maybe_add_let(attrs, nil), do: attrs
+
+  defp maybe_add_let(attrs, {pattern_string, _pattern_expr}),
+    do: attrs ++ [":let={" <> pattern_string <> "}"]
 
   defp format_attr({:boolean, name}), do: name
 

--- a/lib/breeze/implicit/common.ex
+++ b/lib/breeze/implicit/common.ex
@@ -1,0 +1,104 @@
+defmodule Breeze.Implicit.Common do
+  @moduledoc false
+
+  def normalize_selected_index(_index, []), do: nil
+
+  def normalize_selected_index(index, values) when is_integer(index) do
+    index
+    |> max(0)
+    |> min(length(values) - 1)
+  end
+
+  def normalize_selected_index(_index, _values), do: nil
+
+  def selected_value(_values, nil), do: nil
+  def selected_value(values, index), do: Enum.at(values, index)
+
+  def next_index(%{selected_index: nil}, delta) when delta >= 0, do: 0
+  def next_index(%{selected_index: nil, values: values}, _delta), do: max(length(values) - 1, 0)
+
+  def next_index(%{selected_index: selected_index, values: values, loop: loop?}, delta) do
+    max_index = max(length(values) - 1, 0)
+    next = selected_index + delta
+
+    cond do
+      loop? && next > max_index -> 0
+      loop? && next < 0 -> max_index
+      true -> next
+    end
+  end
+
+  def change_reply(state) do
+    {{:change, %{value: state.selected, index: state.selected_index, offset: state.offset}},
+     state}
+  end
+
+  def selected_modifier(flags, state) do
+    case Keyword.get(flags, :value) do
+      value when not is_nil(value) and state.selected == value -> [selected: true]
+      _ -> []
+    end
+  end
+
+  def root_scroll_modifier(state), do: [scroll_y: state.offset]
+
+  def wheel_repeat(%{repeat: repeat}) when is_integer(repeat) and repeat > 0, do: repeat
+  def wheel_repeat(_mouse), do: 1
+
+  def bool_option(attrs, key, default, opts \\ []) do
+    numeric? = Keyword.get(opts, :numeric, false)
+
+    case Map.get(attrs, key) do
+      true -> true
+      false -> false
+      "true" -> true
+      "false" -> false
+      "1" when numeric? -> true
+      "0" when numeric? -> false
+      nil -> default
+      _ -> default
+    end
+  end
+
+  def int_option(attrs, key, default, opts \\ []) do
+    clamp? = Keyword.get(opts, :clamp, true)
+
+    attrs
+    |> Map.get(key)
+    |> normalize_int(default, clamp?)
+  end
+
+  def normalize_int(value, default \\ 0)
+  def normalize_int(value, _default) when is_integer(value), do: max(value, 0)
+
+  def normalize_int(value, default) when is_binary(value) do
+    case Integer.parse(value) do
+      {value, ""} -> max(value, 0)
+      _ -> normalize_default_int(default, true)
+    end
+  end
+
+  def normalize_int(_value, default), do: normalize_default_int(default, true)
+
+  defp normalize_int(value, default, clamp?)
+  defp normalize_int(nil, default, clamp?), do: normalize_default_int(default, clamp?)
+
+  defp normalize_int(value, _default, true) when is_integer(value), do: max(value, 0)
+  defp normalize_int(value, _default, false) when is_integer(value), do: value
+
+  defp normalize_int(value, default, clamp?) when is_binary(value) do
+    case Integer.parse(value) do
+      {value, ""} when clamp? -> max(value, 0)
+      {value, ""} -> value
+      _ -> normalize_default_int(default, clamp?)
+    end
+  end
+
+  defp normalize_int(_value, default, clamp?), do: normalize_default_int(default, clamp?)
+
+  defp normalize_default_int(value, clamp?)
+  defp normalize_default_int(nil, _clamp?), do: nil
+  defp normalize_default_int(value, true) when is_integer(value), do: max(value, 0)
+  defp normalize_default_int(value, false) when is_integer(value), do: value
+  defp normalize_default_int(_value, _clamp?), do: 0
+end

--- a/lib/breeze/implicit/list.ex
+++ b/lib/breeze/implicit/list.ex
@@ -15,6 +15,7 @@ defmodule Breeze.Implicit.List do
   Child boxes should define a `value` attribute.
   """
 
+  alias Breeze.Implicit.Common
   alias Breeze.Viewport
 
   @type state :: %{
@@ -37,25 +38,32 @@ defmodule Breeze.Implicit.List do
       |> Enum.filter(&Map.has_key?(&1, :value))
       |> Enum.map(& &1.value)
 
-    loop = bool_option(root_attrs, :"list-loop", Map.get(last_state, :loop, true))
+    loop =
+      Common.bool_option(root_attrs, :"list-loop", Map.get(last_state, :loop, true),
+        numeric: true
+      )
 
     scroll_padding =
-      int_option(root_attrs, :"list-scroll-padding", Map.get(last_state, :scroll_padding, 0))
+      Common.int_option(
+        root_attrs,
+        :"list-scroll-padding",
+        Map.get(last_state, :scroll_padding, 0)
+      )
 
-    width = int_option(root_attrs, :"list-width", Map.get(last_state, :width, 0))
+    width = Common.int_option(root_attrs, :"list-width", Map.get(last_state, :width, 0))
 
     selected_index =
       values
       |> pick_selected_index(last_state, root_attrs)
-      |> normalize_selected_index(values)
+      |> Common.normalize_selected_index(values)
 
-    selected = if selected_index, do: Enum.at(values, selected_index), else: nil
+    selected = Common.selected_value(values, selected_index)
 
     %{
       values: values,
       selected: selected,
       selected_index: selected_index,
-      offset: normalize_int(Map.get(last_state, :offset, 0)),
+      offset: Common.normalize_int(Map.get(last_state, :offset, 0)),
       loop: loop,
       scroll_padding: scroll_padding,
       width: width
@@ -132,35 +140,30 @@ defmodule Breeze.Implicit.List do
 
   def handle_event(_, %{"mouse" => %{button: :wheel_down} = mouse, "element" => element}, state) do
     viewport = Viewport.from_dimensions(element)
-    offset = Viewport.clamp_scroll_y(state.offset + wheel_repeat(mouse), viewport)
+    offset = Viewport.clamp_scroll_y(state.offset + Common.wheel_repeat(mouse), viewport)
     {:noreply, %{state | offset: offset}}
   end
 
   def handle_event(_, %{"mouse" => %{button: :wheel_up} = mouse, "element" => element}, state) do
     viewport = Viewport.from_dimensions(element)
-    offset = Viewport.clamp_scroll_y(state.offset - wheel_repeat(mouse), viewport)
+    offset = Viewport.clamp_scroll_y(state.offset - Common.wheel_repeat(mouse), viewport)
     {:noreply, %{state | offset: offset}}
   end
 
   def handle_event(_, _, state), do: {:noreply, state}
 
   @spec handle_modifiers(:root | :child, keyword(), state()) :: keyword()
-  def handle_modifiers(:root, _flags, state), do: [scroll_y: state.offset]
+  def handle_modifiers(:root, _flags, state), do: Common.root_scroll_modifier(state)
 
-  def handle_modifiers(:child, flags, state) do
-    case Keyword.get(flags, :value) do
-      value when not is_nil(value) and state.selected == value -> [selected: true]
-      _ -> []
-    end
-  end
+  def handle_modifiers(:child, flags, state), do: Common.selected_modifier(flags, state)
 
   defp move_selection(%{values: []} = state, _delta, _element), do: state
 
   defp move_selection(state, delta, element) do
     index =
       state
-      |> next_index(delta)
-      |> normalize_selected_index(state.values)
+      |> Common.next_index(delta)
+      |> Common.normalize_selected_index(state.values)
 
     set_selection(state, index, element)
   end
@@ -169,9 +172,9 @@ defmodule Breeze.Implicit.List do
 
   defp set_selection(state, index, element) do
     values = state.values
-    index = normalize_selected_index(index, values)
+    index = Common.normalize_selected_index(index, values)
 
-    selected = if index, do: Enum.at(values, index), else: nil
+    selected = Common.selected_value(values, index)
 
     viewport = Viewport.from_dimensions(element)
 
@@ -190,32 +193,7 @@ defmodule Breeze.Implicit.List do
     %{state | selected_index: index, selected: selected, offset: offset}
   end
 
-  defp maybe_change(state) do
-    payload = %{
-      value: state.selected,
-      index: state.selected_index,
-      offset: state.offset
-    }
-
-    {{:change, payload}, state}
-  end
-
-  defp wheel_repeat(%{repeat: repeat}) when is_integer(repeat) and repeat > 0, do: repeat
-  defp wheel_repeat(_mouse), do: 1
-
-  defp next_index(%{selected_index: nil}, delta) when delta >= 0, do: 0
-  defp next_index(%{selected_index: nil, values: values}, _delta), do: max(length(values) - 1, 0)
-
-  defp next_index(%{selected_index: selected_index, values: values, loop: loop?}, delta) do
-    max_index = max(length(values) - 1, 0)
-    next = selected_index + delta
-
-    cond do
-      loop? && next > max_index -> 0
-      loop? && next < 0 -> max_index
-      true -> next
-    end
-  end
+  defp maybe_change(state), do: Common.change_reply(state)
 
   defp pick_selected_index(values, last_state, root_attrs) do
     selected = Map.get(last_state, :selected)
@@ -233,7 +211,7 @@ defmodule Breeze.Implicit.List do
 
       true ->
         case Map.fetch(root_attrs, :"list-initial-index") do
-          {:ok, value} -> normalize_int(value)
+          {:ok, value} -> Common.normalize_int(value)
           :error -> nil
         end
     end
@@ -276,47 +254,4 @@ defmodule Breeze.Implicit.List do
     end)
     |> elem(1)
   end
-
-  defp normalize_selected_index(_index, []), do: nil
-
-  defp normalize_selected_index(index, values) when is_integer(index) do
-    max_index = length(values) - 1
-
-    index
-    |> max(0)
-    |> min(max_index)
-  end
-
-  defp normalize_selected_index(_index, _values), do: nil
-
-  defp int_option(attrs, key, default) do
-    attrs
-    |> Map.get(key)
-    |> normalize_int(default)
-  end
-
-  defp bool_option(attrs, key, default) do
-    case Map.get(attrs, key) do
-      true -> true
-      false -> false
-      "true" -> true
-      "false" -> false
-      "1" -> true
-      "0" -> false
-      nil -> default
-      _ -> default
-    end
-  end
-
-  defp normalize_int(value, default \\ 0)
-  defp normalize_int(value, _default) when is_integer(value), do: max(value, 0)
-
-  defp normalize_int(value, default) when is_binary(value) do
-    case Integer.parse(value) do
-      {value, ""} -> max(value, 0)
-      _ -> max(default, 0)
-    end
-  end
-
-  defp normalize_int(_value, default), do: max(default, 0)
 end

--- a/lib/breeze/implicit/scroll.ex
+++ b/lib/breeze/implicit/scroll.ex
@@ -7,6 +7,7 @@ defmodule Breeze.Implicit.Scroll do
   Supports Up/Down/PageUp/PageDown/Home/End for vertical scrolling.
   """
 
+  alias Breeze.Implicit.Common
   alias Breeze.Viewport
 
   def init(children, last_state), do: init(children, %{}, last_state)
@@ -104,8 +105,7 @@ defmodule Breeze.Implicit.Scroll do
     max(div(height, 2), 1)
   end
 
-  defp wheel_repeat(%{repeat: repeat}) when is_integer(repeat) and repeat > 0, do: repeat
-  defp wheel_repeat(_mouse), do: 1
+  defp wheel_repeat(mouse), do: Common.wheel_repeat(mouse)
 
   defp effective_offset_y(state, nil), do: Map.get(state, :offset_y, 0)
 

--- a/lib/breeze/template.ex
+++ b/lib/breeze/template.ex
@@ -165,12 +165,19 @@ defmodule Breeze.Template do
     slot_assigns = normalize_assigns(slot_assigns)
 
     Enum.flat_map(slots, fn
+      %{__breeze_slot_raw__: {children, slot_ctx, let_pattern}} ->
+        nodes_to_tree(children, slot_ctx |> put_slot_vars(slot_assigns, let_pattern))
+
       %{__breeze_slot_raw__: {children, slot_ctx}} ->
         nodes_to_tree(children, %{slot_ctx | vars: Map.merge(slot_ctx.vars, slot_assigns)})
 
       _ ->
         []
     end)
+  end
+
+  defp expand_slot(%{__breeze_slot_raw__: {children, slot_ctx, let_pattern}}, slot_assigns, _ctx) do
+    nodes_to_tree(children, slot_ctx |> put_slot_vars(slot_assigns, let_pattern))
   end
 
   defp expand_slot(%{__breeze_slot_raw__: {children, slot_ctx}}, slot_assigns, _ctx) do
@@ -345,7 +352,7 @@ defmodule Breeze.Template do
             expand_for(directives[:for], ctx)
             |> Enum.flat_map(fn slot_ctx ->
               if render_if?(directives[:if], slot_ctx) do
-                [slot_entry(slot_attrs, slot_children, slot_ctx)]
+                [slot_entry(slot_attrs, slot_children, slot_ctx, directives[:let])]
               else
                 []
               end
@@ -366,18 +373,17 @@ defmodule Breeze.Template do
     end
   end
 
-  defp slot_entry(attrs, children, ctx) do
+  defp slot_entry(attrs, children, ctx, let_pattern \\ nil) do
     slot_attrs = eval_component_attrs(attrs, ctx) |> Map.new()
 
     render_fun = fn args ->
-      args = normalize_assigns(args)
-      slot_ctx = %{ctx | vars: Map.merge(ctx.vars, args)}
+      slot_ctx = put_slot_vars(ctx, args, let_pattern)
       render_nodes(children, slot_ctx)
     end
 
     slot_attrs
     |> Map.put(:__breeze_slot__, render_fun)
-    |> Map.put(:__breeze_slot_raw__, {children, ctx})
+    |> Map.put(:__breeze_slot_raw__, {children, ctx, let_pattern})
   end
 
   defp eval_html_attrs(attrs, ctx) do
@@ -579,6 +585,23 @@ defmodule Breeze.Template do
   defp normalize_assigns(assigns) when is_list(assigns), do: Map.new(assigns)
   defp normalize_assigns(_assigns), do: %{}
 
+  defp put_slot_vars(ctx, assigns, nil) do
+    %{ctx | vars: Map.merge(ctx.vars, normalize_assigns(assigns))}
+  end
+
+  defp put_slot_vars(ctx, assigns, let_pattern) do
+    pattern_expr =
+      case let_pattern do
+        {_pattern_string, pattern_expr} -> pattern_expr
+        pattern_expr -> pattern_expr
+      end
+
+    case bind_for_pattern(pattern_expr, assigns, ctx) do
+      {:ok, vars} -> %{ctx | vars: vars}
+      :error -> %{ctx | vars: ctx.vars}
+    end
+  end
+
   defp parse_nodes("", nil, _env, acc), do: {Enum.reverse(acc), ""}
 
   defp parse_nodes("", closing, _env, _acc) do
@@ -636,7 +659,7 @@ defmodule Breeze.Template do
     end
 
     {attrs, directives, self_closing?, rest} =
-      parse_attributes(rest, env, [], %{for: nil, if: nil})
+      parse_attributes(rest, env, [], %{for: nil, if: nil, let: nil})
 
     {name, attrs, directives, self_closing?, rest}
   end
@@ -678,6 +701,9 @@ defmodule Breeze.Template do
 
           {:directive, :for, expr} ->
             parse_attributes(rest, env, attrs, %{directives | for: expr})
+
+          {:directive, :let, expr} ->
+            parse_attributes(rest, env, attrs, %{directives | let: expr})
 
           _ ->
             parse_attributes(rest, env, [attr | attrs], directives)
@@ -733,12 +759,20 @@ defmodule Breeze.Template do
      {pattern, compile_for_pattern(pattern, env), compile_expr(enumerable, env)}}
   end
 
+  defp build_attribute(":let", {:dynamic, expr}, env) do
+    {:directive, :let, {String.trim(expr), compile_for_pattern(expr, env)}}
+  end
+
   defp build_attribute(":if", _other, _env) do
     raise "the :if directive requires an expression, e.g. :if={...}"
   end
 
   defp build_attribute(":for", _other, _env) do
     raise "the :for directive requires an expression, e.g. :for={x <- ...}"
+  end
+
+  defp build_attribute(":let", _other, _env) do
+    raise "the :let directive requires an expression, e.g. :let={item}"
   end
 
   defp build_attribute(name, {:dynamic, expr}, env) do

--- a/storybook/table.story.exs
+++ b/storybook/table.story.exs
@@ -1,0 +1,66 @@
+defmodule Breeze.Storybook.Stories.Blocks.TableStory do
+  use Breeze.Storybook.Story
+
+  def story do
+    %{
+      id: "table",
+      title: "Table",
+      description: "Keyboard-selectable data table with fixed columns and scrollable rows.",
+      notes: [
+        "Uses the built-in table implicit.",
+        "Arrow keys or j/k move the selected row.",
+        "The change event payload includes the selected row value, index, and scroll offset."
+      ],
+      source: "<.table id=\"cities\" selected=\"delhi\">...</.table>"
+    }
+  end
+
+  def mount(_opts, term) do
+    {:ok, assign(term, selected_city: "delhi")}
+  end
+
+  def render(assigns) do
+    rows = [
+      %{id: "tokyo", rank: "1", city: "Tokyo", country: "Japan", population: "37.2m"},
+      %{id: "delhi", rank: "2", city: "Delhi", country: "India", population: "32.0m"},
+      %{id: "shanghai", rank: "3", city: "Shanghai", country: "China", population: "28.5m"},
+      %{id: "dhaka", rank: "4", city: "Dhaka", country: "Bangladesh", population: "22.4m"},
+      %{id: "sao-paulo", rank: "5", city: "Sao Paulo", country: "Brazil", population: "22.4m"},
+      %{
+        id: "mexico-city",
+        rank: "6",
+        city: "Mexico City",
+        country: "Mexico",
+        population: "22.1m"
+      },
+      %{id: "cairo", rank: "7", city: "Cairo", country: "Egypt", population: "21.7m"},
+      %{id: "mumbai", rank: "8", city: "Mumbai", country: "India", population: "21.2m"},
+      %{id: "beijing", rank: "9", city: "Beijing", country: "China", population: "21.1m"},
+      %{id: "osaka", rank: "10", city: "Osaka", country: "Japan", population: "19.0m"}
+    ]
+
+    assigns = assign(assigns, rows: rows)
+
+    ~H"""
+    <.table
+      id="storybook-table"
+      rows={@rows}
+      selected={@selected_city}
+      br-change="storybook_table_changed"
+    >
+      <:col :let={city} label="#" width={4} align="right">{city.rank}</:col>
+      <:col :let={city} label="City" width={12}>{city.city}</:col>
+      <:col :let={city} label="Country" width={12} align="center">{city.country}</:col>
+      <:col :let={city} label="Population" width={10} align="right">
+        <box class="text-accent">{city.population}</box>
+      </:col>
+    </.table>
+    """
+  end
+
+  def handle_event("storybook_table_changed", %{value: value}, term) do
+    {:noreply, assign(term, selected_city: value)}
+  end
+
+  def handle_event(_, _, term), do: {:noreply, term}
+end

--- a/test/breeze/blocks_test.exs
+++ b/test/breeze/blocks_test.exs
@@ -174,6 +174,43 @@ defmodule Breeze.BlocksTest do
     def handle_info(_, term), do: {:noreply, term}
   end
 
+  defmodule TableExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def mount(_opts, term) do
+      {:ok, term |> focus("cities") |> assign(selected_city: "delhi")}
+    end
+
+    def render(assigns) do
+      rows = [
+        %{id: "tokyo", rank: "1", city: "Tokyo", country: "Japan", population: "37.2m"},
+        %{id: "delhi", rank: "2", city: "Delhi", country: "India", population: "32.0m"},
+        %{id: "shanghai", rank: "3", city: "Shanghai", country: "China", population: "28.5m"}
+      ]
+
+      assigns = assign(assigns, rows: rows)
+
+      ~H"""
+      <.table id="cities" rows={@rows} selected={@selected_city} br-change="city_changed">
+        <:col :let={city} label="#" width={4} align="right">{city.rank}</:col>
+        <:col :let={city} label="City" width={12}>{city.city}</:col>
+        <:col :let={city} label="Country" width={12} align="center">{city.country}</:col>
+        <:col :let={city} label="Pop." width={10} align={:right}>
+          <box class="text-muted">{city.population}</box>
+        </:col>
+      </.table>
+      """
+    end
+
+    def handle_event("city_changed", %{value: value}, term) do
+      {:noreply, assign(term, selected_city: value)}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
   describe "merge_class/2" do
     test "matches merge_style semantics" do
       assert Blocks.merge_class("border width-24 height-8", "width-32 bg-4") ==
@@ -338,5 +375,28 @@ defmodule Breeze.BlocksTest do
     refute box.content =~ ">Three"
     assert box.content =~ " One"
     assert box.content =~ " Two"
+  end
+
+  test "table renders headers, rows, and selectable cells" do
+    {:ok, pid} = ChildServer.start(view: TableExample, start_opts: [])
+
+    {:ok, acc, box} = ChildServer.render(pid, focused: "cities", implicit_state: %{})
+
+    assert acc.focusables == ["cities"]
+    assert box.content =~ "City"
+    assert box.content =~ "Tokyo"
+    assert box.content =~ "Delhi"
+    assert box.content =~ "India"
+    assert box.content =~ ~r/\e\[[0-9;]*48;5;4/
+  end
+
+  test "table emits change events from keyboard navigation" do
+    {:ok, pid} = ChildServer.start(view: TableExample, start_opts: [])
+
+    assert {:ok, _acc, _box} = ChildServer.render(pid, focused: "cities", implicit_state: %{})
+    assert {:noreply, "cities", true} = ChildServer.dispatch_input(pid, "ArrowDown")
+
+    term = :sys.get_state(pid)
+    assert term.assigns.selected_city == "shanghai"
   end
 end

--- a/test/breeze/html_formatter_test.exs
+++ b/test/breeze/html_formatter_test.exs
@@ -31,12 +31,15 @@ defmodule Breeze.HTMLFormatterTest do
              """
   end
 
-  test "keeps :for/:if directives and assign syntax" do
-    source = "<box :for={item <- @items} :if={@enabled}>{item.value}</box>"
+  test "keeps :for/:let/:if directives and assign syntax" do
+    source =
+      "<.table><:col :for={item <- @items} :let={row} :if={@enabled}>{row.value}</:col></.table>"
 
     assert HTMLFormatter.format(source, sigil: :H, opening_delimiter: "\"\"\"") ==
              """
-             <box :for={item <- @items} :if={@enabled}>{item.value}</box>
+             <.table>
+               <:col :for={item <- @items} :let={row} :if={@enabled}>{row.value}</:col>
+             </.table>
              """
   end
 

--- a/test/breeze/live_view_test.exs
+++ b/test/breeze/live_view_test.exs
@@ -165,6 +165,53 @@ defmodule Breeze.LiveViewTest do
     end
   end
 
+  defmodule ThemeLeafLiveChild do
+    use Breeze.View
+
+    def render(assigns) do
+      ~H"""
+      <box>Leaf</box>
+      """
+    end
+  end
+
+  defmodule ThemeBranchLiveChild do
+    use Breeze.View
+
+    def render(assigns) do
+      ~H"""
+      <box>
+        <live id="leaf" view={ThemeLeafLiveChild}>
+        </live>
+      </box>
+      """
+    end
+  end
+
+  defmodule ThemeSwitchingParent do
+    use Breeze.View
+
+    def mount(_opts, term) do
+      {:ok, focus(term, "switch")}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <box>
+        <box id="switch" focusable>Switch</box>
+        <live id="branch" view={ThemeBranchLiveChild}>
+        </live>
+      </box>
+      """
+    end
+
+    def handle_event(_, %{"key" => "t"}, term) do
+      {:noreply, put_theme(term, Breeze.Theme.builtin(:nebula))}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+  end
+
   defmodule HeaderedLiveChild do
     use Breeze.View
 
@@ -861,6 +908,32 @@ defmodule Breeze.LiveViewTest do
              ChildServer.render_snapshot(root_pid, terminal: terminal, live_view: live_view)
 
     assert %{focused: nil} = ChildServer.metadata(root_pid)
+  end
+
+  test "theme changes cascade to nested live children immediately" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+
+    {:ok, pid} =
+      ChildServer.start(
+        view: ThemeSwitchingParent,
+        terminal: terminal,
+        theme: Breeze.Theme.builtin(:gruvbox)
+      )
+
+    assert {:ok, _acc, _box} = ChildServer.render(pid, terminal: terminal)
+
+    branch = :sys.get_state(pid).children["branch"].pid
+    leaf = :sys.get_state(branch).children["leaf"].pid
+
+    assert ChildServer.metadata(pid).theme.name == "gruvbox-dark"
+    assert ChildServer.metadata(branch).theme.name == "gruvbox-dark"
+    assert ChildServer.metadata(leaf).theme.name == "gruvbox-dark"
+
+    assert {:noreply, "switch", true} = ChildServer.dispatch_event(pid, "switch", %{"key" => "t"})
+
+    assert ChildServer.metadata(pid).theme.name == "nebula"
+    assert ChildServer.metadata(branch).theme.name == "nebula"
+    assert ChildServer.metadata(leaf).theme.name == "nebula"
   end
 
   test "unfocused live children do not render their own local focus ring" do

--- a/test/breeze/template_test.exs
+++ b/test/breeze/template_test.exs
@@ -94,6 +94,29 @@ defmodule Breeze.TemplateTest do
     end
   end
 
+  defmodule SlotLetView do
+    use Breeze.View
+
+    attr :rows, :list, default: []
+    slot :col
+
+    def table(assigns) do
+      ~H"""
+      <box>
+        <box :for={row <- @rows}>{render_slot(@col, row)}</box>
+      </box>
+      """
+    end
+
+    def render(assigns) do
+      ~H"""
+      <.table rows={@rows}>
+        <:col :let={row}>{row.name}</:col>
+      </.table>
+      """
+    end
+  end
+
   defmodule PrivateComponentView do
     use Breeze.View
 
@@ -146,6 +169,11 @@ defmodule Breeze.TemplateTest do
     test "supports named slots, :for on slots, and render_slot assigns" do
       assert render(SlotView, %{labels: ["a", "b"]}) ==
                "<box><box>a:a!</box><box>b:b!</box></box>"
+    end
+
+    test "supports :let on slots" do
+      assert render(SlotLetView, %{rows: [%{name: "Ada"}, %{name: "Grace"}]}) ==
+               "<box><box>Ada</box><box>Grace</box></box>"
     end
 
     test "supports private function components" do


### PR DESCRIPTION
  Add a table block with column slots, inferred column widths,
  alignment, row values, keyboard selection, and change events through
  the shared list implicit.

  Support :let on slot entries so table columns can render row data, and
  preserve :let directives in the HTML formatter.