### PR TITLE
feat(input): support focused implicit key capture

### DIFF
--- a/lib/breeze/child_server.ex
+++ b/lib/breeze/child_server.ex
@@ -679,46 +679,26 @@ defmodule Breeze.ChildServer do
   defp normalize_result({:noreply, next_term}, _term), do: {:noreply, next_term}
   defp normalize_result({:stop, next_term}, _term), do: {:stop, next_term}
 
-  defp process_input(%{"key" => "\t"} = event, term, opts) do
-    if truthy_modifier?(Map.get(event, "shiftKey")) do
-      process_input("ShiftTab", term, opts)
+  defp process_input(%{"key" => key} = event, term, opts) when key in ["\t", "Tab"] do
+    event
+    |> Breeze.InputCapture.normalize_focus_key()
+    |> process_input(term, opts)
+  end
+
+  defp process_input("\t", term, opts) do
+    if focused_implicit_captures_key?("\t", term) do
+      dispatch_key_input("\t", term, opts)
     else
-      process_input("\t", term, opts)
+      focus_next(term)
     end
   end
 
-  defp process_input("\t", term, _opts) do
-    focusables = Breeze.Focus.active_focusables(term.focusables, term.focus_meta)
-    index = Enum.find_index(focusables, &(&1 == term.focused))
-    trapped_scope = Breeze.Focus.trapped_scope?(term.focusables, term.focus_meta)
-
-    focused =
-      cond do
-        focusables == [] -> nil
-        trapped_scope && is_integer(index) -> Enum.at(focusables, index + 1) || hd(focusables)
-        is_integer(index) -> Enum.at(focusables, index + 1)
-        true -> hd(focusables)
-      end
-
-    {:noreply, %{term | focused: focused, allow_unfocused?: is_nil(focused)}}
-  end
-
-  defp process_input("ShiftTab", term, _opts) do
-    focusables = Breeze.Focus.active_focusables(term.focusables, term.focus_meta)
-    index = Enum.find_index(focusables, &(&1 == term.focused))
-    trapped_scope = Breeze.Focus.trapped_scope?(term.focusables, term.focus_meta)
-
-    focused =
-      cond do
-        focusables == [] -> nil
-        trapped_scope && index == 0 -> List.last(focusables)
-        trapped_scope && is_integer(index) -> Enum.at(focusables, index - 1)
-        index == 0 -> nil
-        index == nil -> List.last(focusables)
-        true -> Enum.at(focusables, index - 1)
-      end
-
-    {:noreply, %{term | focused: focused, allow_unfocused?: is_nil(focused)}}
+  defp process_input("ShiftTab", term, opts) do
+    if focused_implicit_captures_key?("ShiftTab", term) do
+      dispatch_key_input("ShiftTab", term, opts)
+    else
+      focus_previous(term)
+    end
   end
 
   defp process_input(%{"mouse" => mouse} = event, term, _opts) do
@@ -745,17 +725,60 @@ defmodule Breeze.ChildServer do
   end
 
   defp process_input(key, term, opts) do
+    dispatch_key_input(key, term, opts)
+  end
+
+  defp dispatch_key_input(key, term, opts) do
     event = normalize_key_event(key)
 
     steps =
-      if printable_key?(event) do
-        [:hierarchy, :focused_implicit, :local, :global, :view_direct]
-      else
-        [:global, :hierarchy, :local, :view]
+      cond do
+        focused_implicit_captures_key?(event, term) ->
+          [:hierarchy, :focused_implicit, :local, :global, :view_direct]
+
+        printable_key?(event) ->
+          [:hierarchy, :focused_implicit, :local, :global, :view_direct]
+
+        true ->
+          [:global, :hierarchy, :local, :view]
       end
       |> maybe_skip_global(Keyword.get(opts, :skip_global, false))
 
     dispatch_input_steps(steps, event, key, term)
+  end
+
+  defp focus_next(term) do
+    focusables = Breeze.Focus.active_focusables(term.focusables, term.focus_meta)
+    index = Enum.find_index(focusables, &(&1 == term.focused))
+    trapped_scope = Breeze.Focus.trapped_scope?(term.focusables, term.focus_meta)
+
+    focused =
+      cond do
+        focusables == [] -> nil
+        trapped_scope && is_integer(index) -> Enum.at(focusables, index + 1) || hd(focusables)
+        is_integer(index) -> Enum.at(focusables, index + 1)
+        true -> hd(focusables)
+      end
+
+    {:noreply, %{term | focused: focused, allow_unfocused?: is_nil(focused)}}
+  end
+
+  defp focus_previous(term) do
+    focusables = Breeze.Focus.active_focusables(term.focusables, term.focus_meta)
+    index = Enum.find_index(focusables, &(&1 == term.focused))
+    trapped_scope = Breeze.Focus.trapped_scope?(term.focusables, term.focus_meta)
+
+    focused =
+      cond do
+        focusables == [] -> nil
+        trapped_scope && index == 0 -> List.last(focusables)
+        trapped_scope && is_integer(index) -> Enum.at(focusables, index - 1)
+        index == 0 -> nil
+        index == nil -> List.last(focusables)
+        true -> Enum.at(focusables, index - 1)
+      end
+
+    {:noreply, %{term | focused: focused, allow_unfocused?: is_nil(focused)}}
   end
 
   defp maybe_skip_global(steps, true), do: List.delete(steps, :global)
@@ -871,6 +894,12 @@ defmodule Breeze.ChildServer do
       true ->
         :continue
     end
+  end
+
+  defp focused_implicit_captures_key?(event, term) do
+    term
+    |> focused_implicit_meta(term.focused)
+    |> Breeze.InputCapture.captures_key?(event)
   end
 
   defp printable_key?(%{"key" => key} = event) when is_binary(key) do

--- a/lib/breeze/input_capture.ex
+++ b/lib/breeze/input_capture.ex
@@ -1,0 +1,123 @@
+defmodule Breeze.InputCapture do
+  @moduledoc false
+
+  @non_text_keys ["\n", "\r", "\t", "\v", "\f"]
+  @modifier_keys ["ctrlKey", "altKey", "metaKey"]
+  @control_character_pattern ~r/[\x00-\x1F\x7F]/u
+
+  def captures_key?(meta, key) when is_map(meta) do
+    cond do
+      Map.get(meta, :captures_keys) == true -> true
+      captures_listed_key?(meta, key) -> true
+      captures_printable_key?(meta, key) -> true
+      captures_text_editing_key?(meta, key) -> true
+      captures_control_key?(meta, key) -> true
+      captures_focus_key?(meta, key) -> true
+      :otherwise -> false
+    end
+  end
+
+  def captures_key?(_meta, _key), do: false
+
+  def captures_listed_key?(meta, key) when is_map(meta) do
+    case Map.get(meta, :captures_keys) do
+      keys when is_list(keys) -> key_name(key) in keys
+      _ -> false
+    end
+  end
+
+  def captures_listed_key?(_meta, _key), do: false
+
+  def captures_printable_key?(%{captures_printable_keys: true}, key), do: printable_key?(key)
+
+  def captures_printable_key?(_meta, _key), do: false
+
+  def captures_text_editing_key?(%{captures_printable_keys: true}, key),
+    do: text_editing_key?(key)
+
+  def captures_text_editing_key?(_meta, _key), do: false
+
+  def printable_key?(%{"__batched_printable__" => true, "key" => key}) when is_binary(key) do
+    printable_text?(key)
+  end
+
+  def printable_key?(%{"key" => key} = event) when is_binary(key) do
+    if modified_input?(event), do: false, else: printable_key?(key)
+  end
+
+  def printable_key?(<<_codepoint::utf8>> = key), do: printable_text?(key)
+  def printable_key?(key) when is_binary(key), do: false
+
+  def printable_key?(_key), do: false
+
+  def captures_control_key?(%{captures_control_keys: true}, key), do: control_key?(key)
+
+  def captures_control_key?(_meta, _key), do: false
+
+  def control_key?(%{"ctrlKey" => value}) when value in [true, "true"], do: true
+  def control_key?(%{"key" => key}), do: control_key?(key)
+
+  def control_key?(<<codepoint>>) when codepoint in [?\b, ?\t, ?\r], do: false
+  def control_key?(<<codepoint>>) when codepoint in 1..26, do: true
+  def control_key?(key) when is_binary(key), do: false
+
+  def control_key?(_key), do: false
+
+  def captures_focus_key?(%{captures_focus_keys: true}, key), do: focus_key?(key)
+
+  def captures_focus_key?(_meta, _key), do: false
+
+  def focus_key?(%{"key" => key}) when key in ["\t", "Tab", "ShiftTab"], do: true
+  def focus_key?(key), do: normalize_focus_key(key) in ["\t", "ShiftTab"]
+
+  def normalize_focus_key(%{"key" => key} = event) when key in ["\t", "Tab"] do
+    if truthy?(Map.get(event, "shiftKey")) do
+      "ShiftTab"
+    else
+      "\t"
+    end
+  end
+
+  def normalize_focus_key(%{"key" => "ShiftTab"}), do: "ShiftTab"
+
+  def normalize_focus_key(key), do: key
+
+  defp key_name(%{"key" => key}), do: key
+  defp key_name(key), do: key
+
+  defp text_editing_key?(%{"ctrlKey" => value, "key" => "Backspace"})
+       when value in [true, "true"],
+       do: true
+
+  defp text_editing_key?(%{"ctrlKey" => value, "key" => "w"}) when value in [true, "true"],
+    do: true
+
+  defp text_editing_key?(key) when key in ["\x08", "\x17"], do: true
+  defp text_editing_key?(_key), do: false
+
+  defp printable_text?(""), do: false
+
+  defp printable_text?(key) do
+    if String.printable?(key),
+      do: Enum.all?(String.graphemes(key), &printable_grapheme?/1),
+      else: false
+  end
+
+  defp printable_grapheme?(grapheme) do
+    cond do
+      grapheme in @non_text_keys -> false
+      String.match?(grapheme, @control_character_pattern) -> false
+      :otherwise -> true
+    end
+  end
+
+  defp modified_input?(event) do
+    Enum.any?(@modifier_keys, fn key ->
+      event
+      |> Map.get(key)
+      |> truthy?()
+    end)
+  end
+
+  defp truthy?(value), do: value in [true, "true"]
+end

--- a/lib/breeze/input_router.ex
+++ b/lib/breeze/input_router.ex
@@ -4,6 +4,7 @@ defmodule Breeze.InputRouter do
   use GenServer
 
   alias Breeze.InputRouter.{IExShellProxy, SilentGroupLeader, TerminalStart}
+  alias Breeze.InputCapture
 
   defstruct [
     :terminal,
@@ -132,13 +133,14 @@ defmodule Breeze.InputRouter do
   defp stop_global_key?(key, state),
     do:
       Breeze.GlobalKeybindings.stop_action?(normalize_key_event(key), state) and
-        not focused_implicit_captures_printable_key?(key, state)
+        not focused_implicit_captures_key?(key, state)
 
   defp route_reader_data(reader, data, state) do
     decoded = decode_input(data)
 
     cond do
-      forced_stop_input?(data, decoded) ->
+      forced_stop_input?(data, decoded) and
+          not focused_implicit_captures_decoded_input?(decoded, state) ->
         stop(state)
 
       stop_decoded_input?(decoded, state) ->
@@ -171,31 +173,18 @@ defmodule Breeze.InputRouter do
 
   defp forced_stop_input?(_data, _decoded), do: false
 
-  defp focused_implicit_captures_printable_key?(key, state) do
-    printable_key?(key) and
-      match?(
-        %{captures_printable_keys: true},
-        Breeze.Server.focused_implicit_metadata(state.server_pid)
-      )
+  defp focused_implicit_captures_decoded_input?({:key, key}, state),
+    do: focused_implicit_captures_key?(key, state)
+
+  defp focused_implicit_captures_decoded_input?(_decoded, _state), do: false
+
+  defp focused_implicit_captures_key?(key, state) do
+    state.server_pid
+    |> Breeze.Server.focused_implicit_metadata()
+    |> InputCapture.captures_key?(key)
   catch
     :exit, _reason -> false
   end
-
-  defp printable_key?(%{"key" => key} = event) when is_binary(key) do
-    not truthy_modifier?(Map.get(event, "ctrlKey")) and
-      not truthy_modifier?(Map.get(event, "altKey")) and
-      not truthy_modifier?(Map.get(event, "metaKey")) and
-      printable_key?(key)
-  end
-
-  defp printable_key?(key) when is_binary(key) do
-    String.length(key) == 1 and key not in ["\n", "\r", "\t", "\v", "\f"] and
-      String.printable?(key) and not String.match?(key, ~r/[\x00-\x1F\x7F]/u)
-  end
-
-  defp printable_key?(_key), do: false
-
-  defp truthy_modifier?(value), do: value in [true, "true"]
 
   defp maybe_start_theme_probe(%{theme_probe: probe} = state, _theme) when is_map(probe),
     do: state

--- a/lib/breeze/key_decoder.ex
+++ b/lib/breeze/key_decoder.ex
@@ -62,8 +62,6 @@ defmodule Breeze.KeyDecoder do
   defp convert_csi("4~"), do: "End"
   defp convert_csi("5~"), do: "PageUp"
   defp convert_csi("6~"), do: "PageDown"
-  defp convert_csi("8;5u"), do: %{"ctrlKey" => true, "key" => "Backspace"}
-  defp convert_csi("127;5u"), do: %{"ctrlKey" => true, "key" => "w"}
 
   defp convert_csi(sequence) do
     case decode_modified_csi(sequence) do
@@ -183,10 +181,13 @@ defmodule Breeze.KeyDecoder do
   defp decode_tilde_key(21), do: "F10"
   defp decode_tilde_key(23), do: "F11"
   defp decode_tilde_key(24), do: "F12"
+  defp decode_tilde_key(127), do: "Backspace"
   defp decode_tilde_key(_codepoint), do: nil
 
+  defp decode_csi_u_key(8), do: "Backspace"
   defp decode_csi_u_key(9), do: "\t"
   defp decode_csi_u_key(13), do: "Enter"
+  defp decode_csi_u_key(127), do: "Backspace"
   defp decode_csi_u_key(codepoint) when codepoint in 57376..57398, do: "F#{codepoint - 57363}"
 
   defp decode_csi_u_key(codepoint) when codepoint in 32..0x10FFFF do

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -575,6 +575,7 @@ defmodule Breeze.Server do
       stop_global_key?(key, state) -> :global_stop
       Inspector.toggle_key?(key, state) -> :inspector_toggle
       Inspector.move_key?(key, state) -> :inspector_move
+      focused_implicit_captures_key?(state, key) -> :hierarchy
       tab_input?(key) -> :tab
       true -> :hierarchy
     end
@@ -634,11 +635,13 @@ defmodule Breeze.Server do
   defp truthy_input_modifier?(value), do: value in [true, "true"]
 
   defp batchable_printable_input?(key, state) do
-    Input.raw_printable_key?(key) and focused_implicit_captures_printable_key?(state, key)
+    Breeze.InputCapture.printable_key?(key) and
+      focused_implicit_captures_printable_key?(state, key)
   end
 
   defp stop_global_key?(key, state) do
-    Breeze.GlobalKeybindings.stop_action?(%{"key" => key}, state)
+    Breeze.GlobalKeybindings.stop_action?(%{"key" => key}, state) and
+      not focused_implicit_captures_key?(state, key)
   end
 
   defp focused_implicit?(%{focused: nil}), do: false
@@ -654,16 +657,12 @@ defmodule Breeze.Server do
   end
 
   defp focused_implicit_captures_printable_key?(state, key) do
-    printable_input?(key) and
-      match?(%{captures_printable_keys: true}, focused_implicit_meta(state))
+    Breeze.InputCapture.captures_printable_key?(focused_implicit_meta(state), key)
   end
 
-  defp printable_input?(%{"__batched_printable__" => true, "key" => key}) when is_binary(key) do
-    String.printable?(key)
+  defp focused_implicit_captures_key?(state, key) do
+    Breeze.InputCapture.captures_key?(focused_implicit_meta(state), key)
   end
-
-  defp printable_input?(key) when is_binary(key), do: Input.raw_printable_key?(key)
-  defp printable_input?(_key), do: false
 
   defp focused_child_or_root_metadata(state) do
     case focused_child_chain(state) do
@@ -2142,7 +2141,7 @@ defmodule Breeze.Server do
       end
 
     root_global_reply =
-      if printable_input?(key) do
+      if Breeze.InputCapture.printable_key?(key) or focused_implicit_captures_key?(state, key) do
         nil
       else
         case safe_call(fn ->
@@ -2190,7 +2189,7 @@ defmodule Breeze.Server do
                if state.focused, do: Breeze.ChildServer.set_focus(state.view_pid, state.focused)
 
                Breeze.ChildServer.dispatch_input(state.view_pid, key,
-                 skip_global: focused_implicit_captures_printable_key?(state, key)
+                 skip_global: focused_implicit_captures_key?(state, key)
                )
              end) do
           {:ok, reply} -> reply

--- a/test/breeze/input_capture_test.exs
+++ b/test/breeze/input_capture_test.exs
@@ -1,0 +1,45 @@
+defmodule Breeze.InputCaptureTest do
+  use ExUnit.Case, async: true
+
+  alias Breeze.InputCapture
+
+  test "captures explicitly listed keys" do
+    meta = %{captures_keys: ["PageUp", "PageDown"]}
+
+    assert InputCapture.captures_key?(meta, %{"key" => "PageUp"})
+    assert InputCapture.captures_key?(meta, "PageDown")
+    refute InputCapture.captures_key?(meta, %{"key" => "F10"})
+    refute InputCapture.captures_key?(meta, "ArrowDown")
+  end
+
+  test "captures printable keys when enabled" do
+    meta = %{captures_printable_keys: true}
+
+    assert InputCapture.captures_key?(meta, %{"key" => "a"})
+    assert InputCapture.captures_key?(meta, "é")
+    assert InputCapture.captures_key?(meta, %{"__batched_printable__" => true, "key" => "abc"})
+    assert InputCapture.captures_key?(meta, %{"key" => "Backspace", "ctrlKey" => true})
+    assert InputCapture.captures_key?(meta, %{"key" => "w", "ctrlKey" => true})
+    assert InputCapture.captures_key?(meta, "\x08")
+    assert InputCapture.captures_key?(meta, "\x17")
+    refute InputCapture.captures_key?(meta, %{"key" => "a", "ctrlKey" => true})
+    refute InputCapture.captures_key?(meta, "\t")
+  end
+
+  test "captures control keys when enabled" do
+    meta = %{captures_control_keys: true}
+
+    assert InputCapture.captures_key?(meta, %{"key" => "c", "ctrlKey" => true})
+    assert InputCapture.captures_key?(meta, <<3>>)
+    refute InputCapture.captures_key?(meta, "\t")
+  end
+
+  test "captures focus keys when enabled" do
+    meta = %{captures_focus_keys: true}
+
+    assert InputCapture.captures_key?(meta, %{"key" => "Tab"})
+    assert InputCapture.captures_key?(meta, %{"key" => "Tab", "shiftKey" => true})
+    assert InputCapture.captures_key?(meta, "ShiftTab")
+    refute InputCapture.captures_key?(meta, "ArrowDown")
+  end
+end

--- a/test/breeze/input_router_test.exs
+++ b/test/breeze/input_router_test.exs
@@ -114,6 +114,52 @@ defmodule Breeze.InputRouterTest do
     def handle_info(_, term), do: {:noreply, term}
   end
 
+  defmodule CapturingImplicit do
+    def init(_children, _attrs, state) do
+      {:ok, state,
+       active_when_focused: true,
+       captures_printable_keys: true,
+       captures_control_keys: true,
+       captures_focus_keys: true}
+    end
+
+    def handle_event(_, event, state), do: {{:change, event}, state}
+    def handle_modifiers(_, _, _), do: []
+    def animate(_, box, _, _, _), do: box
+  end
+
+  defmodule FocusedCaptureView do
+    use Breeze.View
+
+    def mount(opts, term) do
+      {:ok, term |> focus("capture") |> assign(parent: Keyword.fetch!(opts, :parent))}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <box>
+        <box
+          id="capture"
+          focusable
+          implicit={Breeze.InputRouterTest.CapturingImplicit}
+          br-change="captured"
+        >
+          capture
+        </box>
+        <box id="other" focusable>other</box>
+      </box>
+      """
+    end
+
+    def handle_event("captured", event, term) do
+      send(term.assigns.parent, {:captured, event})
+      {:noreply, term}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
   defmodule FocusCycleView do
     use Breeze.View
 
@@ -221,6 +267,72 @@ defmodule Breeze.InputRouterTest do
 
     assert_receive :halted
     assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+  end
+
+  test "ctrl-c is forwarded when a focused implicit captures control keys" do
+    parent = self()
+
+    {:ok, pid} =
+      Breeze.InputRouter.start_link(
+        view: FocusedCaptureView,
+        start_opts: [parent: parent],
+        hide_cursor: false,
+        terminal_opts: [adapter: FakeAdapter],
+        halt_fun: fn -> send(parent, :halted) end
+      )
+
+    state = :sys.get_state(pid)
+    reader = state.reader
+    server_pid = state.server_pid
+
+    wait_until(fn ->
+      match?(
+        %{captures_control_keys: true},
+        Breeze.Server.focused_implicit_metadata(server_pid)
+      )
+    end)
+
+    send(pid, {reader, {:data, "\x03"}})
+
+    assert_receive {:captured, %{"ctrlKey" => true, "key" => "c"}}
+    refute_receive :halted, 50
+
+    Process.exit(pid, :normal)
+  end
+
+  test "tab and shift-tab are forwarded when a focused implicit captures focus keys" do
+    parent = self()
+
+    {:ok, pid} =
+      Breeze.InputRouter.start_link(
+        view: FocusedCaptureView,
+        start_opts: [parent: parent],
+        hide_cursor: false,
+        terminal_opts: [adapter: FakeAdapter],
+        halt_fun: fn -> send(parent, :halted) end
+      )
+
+    state = :sys.get_state(pid)
+    reader = state.reader
+    server_pid = state.server_pid
+
+    wait_until(fn ->
+      match?(
+        %{captures_focus_keys: true},
+        Breeze.Server.focused_implicit_metadata(server_pid)
+      )
+    end)
+
+    send(pid, {reader, {:data, "\t"}})
+    assert_receive {:captured, %{"key" => "\t"}}
+
+    send(pid, {reader, {:data, "\e[9;2u"}})
+    assert_receive {:captured, %{"key" => "ShiftTab"}}
+
+    refute_receive :halted, 50
+    assert :sys.get_state(server_pid).focused == "capture"
+
+    Process.exit(pid, :normal)
   end
 
   defp assert_ctrl_c_halts(sequence) do

--- a/test/breeze/key_decoder_test.exs
+++ b/test/breeze/key_decoder_test.exs
@@ -49,8 +49,17 @@ defmodule Breeze.KeyDecoderTest do
   end
 
   test "decodes common ctrl-backspace sequences as structured key events" do
-    assert Breeze.KeyDecoder.decode("\e[8;5u") == %{"ctrlKey" => true, "key" => "Backspace"}
-    assert Breeze.KeyDecoder.decode("\e[127;5u") == %{"ctrlKey" => true, "key" => "w"}
+    for sequence <- [
+          "\b",
+          "\e[8;5u",
+          "\e[127;5u",
+          "\e[27;5;8u",
+          "\e[27;5;127u",
+          "\e[27;5;127~",
+          "\e[127;5~"
+        ] do
+      assert Breeze.KeyDecoder.decode(sequence) == %{"ctrlKey" => true, "key" => "Backspace"}
+    end
   end
 
   test "decodes ctrl-j and ctrl-k CSI-u sequences as structured key events" do

--- a/test/examples/posting_test.exs
+++ b/test/examples/posting_test.exs
@@ -226,6 +226,47 @@ defmodule PostingTest do
     Process.exit(pid, :normal)
   end
 
+  test "server forwards ctrl-backspace variants to the focused posting input" do
+    for raw_key <- [
+          "\b",
+          "\e[8;5u",
+          "\e[127;5u",
+          "\e[27;5;8u",
+          "\e[27;5;127u",
+          "\e[27;5;127~",
+          "\e[127;5~"
+        ] do
+      terminal = Termite.Terminal.start(adapter: FakeAdapter)
+
+      {:ok, pid} =
+        Breeze.Server.start_link(
+          view: Posting,
+          alt_screen: false,
+          enhanced_keyboard: false,
+          hide_cursor: false,
+          terminal: terminal,
+          halt_fun: fn -> :ok end,
+          global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+        )
+
+      state = :sys.get_state(pid)
+      reader = state.reader
+      server_pid = state.server_pid
+
+      send(pid, {reader, {:data, raw_key}})
+
+      wait_until(fn ->
+        state = :sys.get_state(server_pid)
+        term = :sys.get_state(state.view_pid)
+
+        not state.input.flush_scheduled? and :queue.is_empty(state.input.queued_input) and
+          term.assigns.url == ""
+      end)
+
+      GenServer.stop(pid, :normal)
+    end
+  end
+
   test "posting keeps repeated wide characters contiguous in the url row" do
     terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
     {:ok, pid} = Breeze.ChildServer.start(view: Posting, terminal: terminal)


### PR DESCRIPTION
Route printable, control, focus, and explicitly listed keys through the focused implicit when its metadata declares capture support. This lets terminal-like controls opt into handling keys such as Ctrl-C, Tab, ShiftTab, PageUp, and PageDown while preserving default global shortcuts and focus traversal for controls that do not capture them.