### PR TITLE
feat(Breeze.Inspector): adds render tree inspection

### DIFF
--- a/examples/remote_inspector.exs
+++ b/examples/remote_inspector.exs
@@ -4,5 +4,6 @@ Breeze.Example.run(
   view: Breeze.RemoteInspector.View,
   reload: true,
   mouse: true,
-  inspector: false
+  global_keybindings: Breeze.RemoteInspector.View.global_keybindings(),
+  inspector: true
 )

--- a/lib/breeze/blocks.ex
+++ b/lib/breeze/blocks.ex
@@ -27,15 +27,17 @@ defmodule Breeze.Blocks do
   attr :class, :string, default: nil
 
   def keybinding_bar(assigns) do
+    keybindings = Map.get(assigns, :keybindings) || []
+
     assigns =
       assign(assigns,
         parts:
-          Map.get(assigns, :keybindings, [])
+          keybindings
           |> Enum.with_index()
           |> Enum.flat_map(fn {%{key: key, label: label}, index} ->
             key = to_string(key)
             label = to_string(label || key)
-            separator? = index < length(Map.get(assigns, :keybindings, [])) - 1
+            separator? = index < length(keybindings) - 1
 
             [
               %{class: "text-accent bold", content: key},

--- a/lib/breeze/child_server.ex
+++ b/lib/breeze/child_server.ex
@@ -95,6 +95,7 @@ defmodule Breeze.ChildServer do
       theme: theme,
       theme_source: theme_input,
       apply_theme_defaults?: apply_theme_defaults?,
+      render_tree?: Keyword.get(opts, :render_tree?, false) == true,
       global_keybindings: global_keybindings,
       assigns: initial_assigns,
       external_assigns: external_assigns
@@ -449,6 +450,7 @@ defmodule Breeze.ChildServer do
       |> Keyword.put(:theme, theme)
       |> Keyword.put(:theme_source, term.theme_source || term.theme)
       |> Keyword.put(:apply_theme_defaults, term.apply_theme_defaults?)
+      |> Keyword.put(:render_tree?, Keyword.get(opts, :render_tree?, term.render_tree?))
 
     profile_scope = Keyword.get(opts, :profile_scope)
     profile_label = profile_label(term, opts)
@@ -1114,6 +1116,7 @@ defmodule Breeze.ChildServer do
         theme_source: term.theme_source,
         global_keybindings: term.global_keybindings,
         apply_theme_defaults?: term.apply_theme_defaults?,
+        render_tree?: term.render_tree?,
         invalidate: invalidate
       )
 
@@ -1135,6 +1138,7 @@ defmodule Breeze.ChildServer do
                  terminal: terminal,
                  theme: term.theme,
                  theme_source: term.theme_source || term.theme,
+                 render_tree?: Keyword.get(child_opts, :render_tree?, term.render_tree?),
                  live_prefix: full_prefix
                ) do
             {:ok, child_acc, child_box, _decorations} ->

--- a/lib/breeze/inspector.ex
+++ b/lib/breeze/inspector.ex
@@ -135,12 +135,43 @@ defmodule Breeze.Inspector do
         focusables: focusable_ids,
         focus_memory: Map.get(state, :focus_memory, %{})
       },
+      render_tree?: not is_nil(rendered_field(state, :render_tree, :rendered_render_tree)),
+      render_tree_kinds: render_tree_kinds(state),
       toggle_key: toggle_key(state),
       move_key: move_key(state),
       panel_position: panel_position(state),
       focused_entry: selected_snapshot(state, Map.get(state, :focused)),
       hovered: selected_snapshot(state, hovered_id),
       selected: selected_snapshot(state, selected_id)
+    }
+  end
+
+  def render_tree(state, opts \\ []) do
+    tree = rendered_field(state, :render_tree, :rendered_render_tree)
+    kind = normalize_render_tree_kind(Keyword.get(opts, :kind, :rendered))
+    tree_meta = render_tree_meta_for_kind(state, kind)
+
+    selected_id =
+      Keyword.get(opts, :selected_id) ||
+        inspector_field(state, :selected_id, :inspector_selected_id)
+
+    limit = opts |> Keyword.get(:limit, 600) |> normalize_render_tree_limit()
+
+    expanded =
+      tree
+      |> render_tree_expanded(tree_meta, Keyword.get(opts, :expanded, []), selected_id)
+      |> Enum.uniq()
+
+    {node, _remaining, truncated?} =
+      prune_render_tree(tree, tree_meta, MapSet.new(expanded), limit)
+
+    %{
+      kind: kind,
+      nodes: if(is_nil(node), do: [], else: [node]),
+      selected_id: selected_id,
+      expanded: expanded,
+      limit: limit,
+      truncated?: truncated?
     }
   end
 
@@ -306,6 +337,148 @@ defmodule Breeze.Inspector do
     end)
     |> Enum.map(fn {id, _flags} -> id end)
     |> Enum.sort()
+  end
+
+  defp normalize_render_tree_limit(limit) when is_integer(limit) and limit > 0 do
+    min(limit, 2_000)
+  end
+
+  defp normalize_render_tree_limit(_limit), do: 600
+
+  defp normalize_render_tree_kind(kind) when kind in [:code, "code"], do: :code
+  defp normalize_render_tree_kind(_kind), do: :rendered
+
+  defp render_tree_meta_for_kind(state, :code) do
+    rendered_field(state, :code_tree_meta, :rendered_code_tree_meta)
+  end
+
+  defp render_tree_meta_for_kind(state, _kind) do
+    rendered_field(state, :render_tree_meta, :rendered_render_tree_meta)
+  end
+
+  defp render_tree_kinds(state) do
+    if is_nil(rendered_field(state, :render_tree, :rendered_render_tree)) do
+      []
+    else
+      [:rendered, :code]
+    end
+  end
+
+  defp render_tree_expanded(nil, _tree_meta, _expanded, _selected_id), do: []
+
+  defp render_tree_expanded(tree, tree_meta, expanded, selected_id) do
+    explicit = List.wrap(expanded)
+
+    selected_path =
+      tree
+      |> render_tree_path(tree_meta, selected_id)
+      |> Enum.drop(-1)
+
+    expanded =
+      case explicit ++ selected_path do
+        [] -> expandable_tree_id(tree, tree_meta)
+        ids -> ids
+      end
+
+    Enum.filter(expanded, &is_binary/1)
+  end
+
+  defp expandable_tree_id(%{idx: idx, children: [_ | _]}, tree_meta) do
+    case Map.get(tree_meta, idx) do
+      %{id: id} when is_binary(id) -> [id]
+      _ -> []
+    end
+  end
+
+  defp expandable_tree_id(_tree, _tree_meta), do: []
+
+  defp render_tree_path(_tree, _tree_meta, selected_id) when not is_binary(selected_id), do: []
+
+  defp render_tree_path(%{idx: idx, children: children}, tree_meta, selected_id)
+       when is_list(children) do
+    id = tree_meta |> Map.get(idx, %{}) |> Map.get(:id)
+
+    if id == selected_id do
+      [selected_id]
+    else
+      render_tree_child_path(id, children, tree_meta, selected_id)
+    end
+  end
+
+  defp render_tree_path(_tree, _tree_meta, _selected_id), do: []
+
+  defp render_tree_child_path(id, children, tree_meta, selected_id) do
+    Enum.find_value(children, [], fn child ->
+      case render_tree_path(child, tree_meta, selected_id) do
+        [] -> nil
+        path -> [id | path]
+      end
+    end)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp prune_render_tree(nil, _tree_meta, _expanded, limit), do: {nil, limit, false}
+
+  defp prune_render_tree(_tree, _tree_meta, _expanded, remaining) when remaining <= 0,
+    do: {nil, remaining, true}
+
+  defp prune_render_tree(%{idx: idx, tag: tag} = tree, tree_meta, expanded, remaining) do
+    meta = render_tree_node_meta(idx, tag, tree_meta)
+    id = Map.get(meta, :id)
+    children = Map.get(tree, :children, [])
+    expandable? = children != []
+    remaining = remaining - 1
+
+    {children, remaining, truncated?} =
+      if MapSet.member?(expanded, id) do
+        prune_render_tree_children(children, tree_meta, expanded, remaining, [])
+      else
+        {[], remaining, false}
+      end
+
+    node = meta |> Map.put(:children, children) |> Map.put(:expandable?, expandable?)
+
+    {node, remaining, truncated?}
+  end
+
+  defp prune_render_tree(_tree, _tree_meta, _expanded, remaining), do: {nil, remaining, false}
+
+  defp render_tree_node_meta(idx, tag, tree_meta) do
+    Map.get(tree_meta, idx, %{
+      id: "__inspector__" <> Integer.to_string(idx),
+      actual_id: nil,
+      inspector_idx: idx,
+      label: "<#{tag}>",
+      label_parts: [%{text: "<#{tag}>", token: :tag}],
+      tag: to_string(tag),
+      flags: %{},
+      bounds: %{}
+    })
+  end
+
+  defp prune_render_tree_children([], _tree_meta, _expanded, remaining, acc) do
+    {Enum.reverse(acc), remaining, false}
+  end
+
+  defp prune_render_tree_children(_children, _tree_meta, _expanded, remaining, acc)
+       when remaining <= 0 do
+    {Enum.reverse(acc), remaining, true}
+  end
+
+  defp prune_render_tree_children([child | rest], tree_meta, expanded, remaining, acc) do
+    case prune_render_tree(child, tree_meta, expanded, remaining) do
+      {nil, remaining, true} ->
+        {Enum.reverse(acc), remaining, true}
+
+      {nil, remaining, false} ->
+        prune_render_tree_children(rest, tree_meta, expanded, remaining, acc)
+
+      {node, remaining, true} ->
+        {Enum.reverse([node | acc]), remaining, true}
+
+      {node, remaining, false} ->
+        prune_render_tree_children(rest, tree_meta, expanded, remaining, [node | acc])
+    end
   end
 
   defp active_trapped_scope_id(state, focusable_ids) do

--- a/lib/breeze/remote_inspector/view.ex
+++ b/lib/breeze/remote_inspector/view.ex
@@ -3,6 +3,18 @@ defmodule Breeze.RemoteInspector.View do
 
   use Breeze.View
   import Breeze.Blocks
+  alias BackBreeze.TextSpan
+
+  @render_tree_limit 600
+
+  def global_keybindings do
+    [
+      {"q", "Quit", &__MODULE__.quit/2},
+      {"F4", "Inspector"}
+    ]
+  end
+
+  def quit(_event, term), do: {:stop, term}
 
   def mount(_opts, term) do
     {:ok, _pid} = Breeze.RemoteInspector.ensure_server()
@@ -15,21 +27,32 @@ defmodule Breeze.RemoteInspector.View do
        latest_source: state.latest_source,
        active_source: state.latest_source,
        panel_tab: "overview",
+       render_tree_kind: "rendered",
+       render_tree_expanded: %{},
+       render_trees: %{},
        screen: term.terminal.size
-     )}
+     )
+     |> put_tree_keybindings()
+     |> refresh_active_render_tree()}
   end
 
   def render(assigns) do
     active = active_entry(assigns)
+    active_source = active_source(assigns)
+    render_tree_kind = render_tree_kind(assigns)
+    panel_tab = Map.get(assigns, :panel_tab, "overview")
+    breeze = assigns |> Map.get(:breeze, %{}) |> Map.put_new(:keybindings, [])
     now = System.system_time(:millisecond)
+    active_render_tree = active_render_tree(assigns, active_source, active, render_tree_kind)
 
     assigns =
       Map.merge(assigns, %{
         active: active,
+        active_source: active_source,
         now: now,
         screen_text: format_screen(assigns.screen),
         latest_source_text: format_source(assigns.latest_source),
-        source_entries: source_entries(assigns.snapshots, Map.get(assigns, :active_source)),
+        source_entries: source_entries(assigns.snapshots, active_source),
         active_source_text: if(active, do: format_source(active.source), else: "-"),
         active_server_text: if(active, do: format_server(active.snapshot), else: "-"),
         active_theme_text: if(active, do: format_theme(active.snapshot.theme), else: "-"),
@@ -69,83 +92,108 @@ defmodule Breeze.RemoteInspector.View do
         active_fragment_text: if(active, do: fragment_line(active.snapshot.selected), else: "-"),
         active_fragment_render:
           if(active, do: fragment_render_line(active.snapshot.selected, assigns.screen), else: ""),
-        panel_tab: Map.get(assigns, :panel_tab, "overview")
+        active_render_tree: active_render_tree,
+        active_render_tree_nodes: if(active, do: render_tree_nodes(active_render_tree), else: []),
+        active_render_tree_selected:
+          if(active, do: render_tree_selected(active_render_tree, active.snapshot), else: nil),
+        active_render_tree_expanded:
+          if(active, do: render_tree_expanded(active_render_tree), else: []),
+        render_tree_kind: render_tree_kind,
+        breeze: breeze,
+        panel_tab: panel_tab
       })
 
     ~H"""
-    <box class="width-screen height-screen bg padding-1">
-      <box class="inline width-full height-full overflow-hidden">
-        <.sidebar
-          active={@active}
-          screen_text={@screen_text}
-          snapshots={@snapshots}
-          latest_source_text={@latest_source_text}
-          active_selected_text={@active_selected_text}
-          active_hovered_text={@active_hovered_text}
-          active_focused_text={@active_focused_text}
-          active_focusables_text={@active_focusables_text}
-          active_component_module_text={@active_component_module_text}
-          active_component_function_text={@active_component_function_text}
-          source_entries={@source_entries}
-        />
-        <box class="width-full height-full padding-left-1 overflow-hidden">
-          <.tabs
-            id="remote-inspector-tabs"
-            selected={@panel_tab}
-            highlight="primary"
-            br-change="tab_changed"
-            class="width-full height-full border-rounded"
-            item_class="width-13"
-          >
-            <:tab value="overview" label="Overview">
-              <.overview_tab
-                scroll_id="remote-inspector-tabs-panel-overview"
-                active={@active}
-                active_source_text={@active_source_text}
-                active_theme_text={@active_theme_text}
-                active_status_text={@active_status_text}
-                active_counts_text={@active_counts_text}
-                active_layout_text={@active_layout_text}
-                active_box_text={@active_box_text}
-                active_component_text={@active_component_text}
-                active_class_text={@active_class_text}
-                active_style_input_text={@active_style_input_text}
-                active_color_text={@active_color_text}
-                show_fg_swatch={@show_fg_swatch?}
-                show_bg_swatch={@show_bg_swatch?}
-                fg_swatch_style={@fg_swatch_style}
-                bg_swatch_style={@bg_swatch_style}
-                active_fragment_text={@active_fragment_text}
-                active_fragment_render={@active_fragment_render}
-              />
-            </:tab>
-            <:tab value="layout" label="Element">
-              <.layout_tab
-                scroll_id="remote-inspector-tabs-panel-layout"
-                active={@active}
-                layout_data={@active_layout_data}
-                flag_rows={@active_flag_rows}
-                active_focus_text={@active_focus_text}
-                active_selected_focus_text={@active_selected_focus_text}
-              />
-            </:tab>
-            <:tab value="theme" label="Theme">
-              <.theme_tab
-                scroll_id="remote-inspector-tabs-panel-theme"
-                active={@active}
-                active_theme_text={@active_theme_text}
-                rows={@active_theme_rows}
-              />
-            </:tab>
-            <:tab value="implicit" label="Implicit">
-              <.implicit_tab
-                scroll_id="remote-inspector-tabs-panel-implicit"
-                active={@active}
-                active_implicit_text={@active_implicit_text}
-                active_implicit_detail_text={@active_implicit_detail_text}
-              />
-            </:tab>
-          </.tabs>
+    <box class="width-screen height-screen bg">
+      <box class="grid grid-cols-1 grid-rows-2 width-full height-full overflow-hidden">
+        <box class="inline width-full height-full overflow-hidden">
+          <.sidebar
+            active={@active}
+            screen_text={@screen_text}
+            snapshots={@snapshots}
+            latest_source_text={@latest_source_text}
+            active_selected_text={@active_selected_text}
+            active_hovered_text={@active_hovered_text}
+            active_focused_text={@active_focused_text}
+            active_focusables_text={@active_focusables_text}
+            active_component_module_text={@active_component_module_text}
+            active_component_function_text={@active_component_function_text}
+            source_entries={@source_entries}
+          />
+          <box class="width-full bg height-full padding-left-1 overflow-hidden">
+            <.tabs
+              id="remote-inspector-tabs"
+              selected={@panel_tab}
+              highlight="primary"
+              br-change="tab_changed"
+              class="width-full height-full border-rounded bg"
+              item_class="width-9"
+            >
+              <:tab value="tree" label="Tree">
+                <.tree_tab
+                  active={@active}
+                  nodes={@active_render_tree_nodes}
+                  selected={@active_render_tree_selected}
+                  expanded={@active_render_tree_expanded}
+                  kind={@render_tree_kind}
+                />
+              </:tab>
+              <:tab value="overview" label="Overview">
+                <.overview_tab
+                  scroll_id="remote-inspector-tabs-panel-overview"
+                  active={@active}
+                  active_source_text={@active_source_text}
+                  active_theme_text={@active_theme_text}
+                  active_status_text={@active_status_text}
+                  active_counts_text={@active_counts_text}
+                  active_layout_text={@active_layout_text}
+                  active_box_text={@active_box_text}
+                  active_component_text={@active_component_text}
+                  active_class_text={@active_class_text}
+                  active_style_input_text={@active_style_input_text}
+                  active_color_text={@active_color_text}
+                  show_fg_swatch={@show_fg_swatch?}
+                  show_bg_swatch={@show_bg_swatch?}
+                  fg_swatch_style={@fg_swatch_style}
+                  bg_swatch_style={@bg_swatch_style}
+                  active_fragment_text={@active_fragment_text}
+                  active_fragment_render={@active_fragment_render}
+                />
+              </:tab>
+              <:tab value="layout" label="Element">
+                <.layout_tab
+                  scroll_id="remote-inspector-tabs-panel-layout"
+                  active={@active}
+                  layout_data={@active_layout_data}
+                  flag_rows={@active_flag_rows}
+                  active_focus_text={@active_focus_text}
+                  active_selected_focus_text={@active_selected_focus_text}
+                />
+              </:tab>
+              <:tab value="theme" label="Theme">
+                <.theme_tab
+                  scroll_id="remote-inspector-tabs-panel-theme"
+                  active={@active}
+                  active_theme_text={@active_theme_text}
+                  rows={@active_theme_rows}
+                />
+              </:tab>
+              <:tab value="implicit" label="Implicit">
+                <.implicit_tab
+                  scroll_id="remote-inspector-tabs-panel-implicit"
+                  active={@active}
+                  active_implicit_text={@active_implicit_text}
+                  active_implicit_detail_text={@active_implicit_detail_text}
+                />
+              </:tab>
+            </.tabs>
+          </box>
+        </box>
+        <box class="height-1 width-full overflow-hidden bg-emphasize-12">
+          <.keybinding_bar
+            keybindings={@breeze.keybindings}
+            class="inline width-full height-1 overflow-hidden bg-emphasize-12 padding-left-1 padding-right-1"
+          />
         </box>
       </box>
     </box>
@@ -166,9 +214,8 @@ defmodule Breeze.RemoteInspector.View do
 
   def sidebar(assigns) do
     ~H"""
-    <box class="width-32 height-full border-rounded overflow-hidden bg-panel padding-right-1">
+    <box class="width-32 height-full border-rounded overflow-hidden bg padding-right-1">
       <box class="width-full bold text-primary">Remote Inspector</box>
-      <box class="width-full text-muted">Press q to quit.</box>
       <box class="width-full text-muted">screen={@screen_text}</box>
       <box class="width-full text-muted">sources={map_size(@snapshots)}</box>
       <box class="width-full text-muted">latest={@latest_source_text}</box>
@@ -234,6 +281,35 @@ defmodule Breeze.RemoteInspector.View do
           <box class="width-full">
           </box>
         </box>
+      </box>
+    </box>
+    """
+  end
+
+  attr :active, :any, required: true
+  attr :nodes, :list, required: true
+  attr :selected, :any, required: true
+  attr :expanded, :list, required: true
+  attr :kind, :string, required: true
+
+  def tree_tab(assigns) do
+    ~H"""
+    <box class="width-full height-full padding-top-1">
+      <box :if={!is_nil(@active)} class="width-full text-muted">tree={@kind}</box>
+      <.tree
+        :if={!is_nil(@active) and @nodes != []}
+        id="remote-inspector-render-tree"
+        nodes={@nodes}
+        selected={@selected}
+        expanded={@expanded}
+        collapsed_prefix="▸"
+        expanded_prefix="▾"
+        virtual
+        br-change="render_tree_changed"
+        class="width-full height-full bg"
+      />
+      <box :if={is_nil(@active) or @nodes == []} class="width-full text-muted">
+        Waiting for render tree...
       </box>
     </box>
     """
@@ -457,12 +533,16 @@ defmodule Breeze.RemoteInspector.View do
       ) do
     active_source = normalize_active_source(term.assigns.active_source, snapshots, latest_source)
 
-    {:noreply,
-     assign(term,
-       snapshots: snapshots,
-       latest_source: latest_source,
-       active_source: active_source
-     )}
+    term =
+      term
+      |> assign(
+        snapshots: snapshots,
+        latest_source: latest_source,
+        active_source: active_source
+      )
+      |> refresh_active_render_tree()
+
+    {:noreply, term}
   end
 
   def handle_info(:resize, term) do
@@ -470,20 +550,344 @@ defmodule Breeze.RemoteInspector.View do
   end
 
   def handle_event("tab_changed", %{value: value}, term) do
-    {:noreply, assign(term, panel_tab: value)}
+    {:noreply,
+     term
+     |> assign(panel_tab: value)
+     |> put_tree_keybindings()
+     |> refresh_active_render_tree(force: value == "tree")}
   end
 
   def handle_event("tab_changed", %{"value" => value}, term) do
-    {:noreply, assign(term, panel_tab: value)}
+    {:noreply,
+     term
+     |> assign(panel_tab: value)
+     |> put_tree_keybindings()
+     |> refresh_active_render_tree(force: value == "tree")}
   end
 
-  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
+  def handle_event("render_tree_changed", payload, term) do
+    selected = payload_value(payload, :value)
+    expanded = normalize_expanded(payload_value(payload, :expanded))
+    active_source = active_source(term.assigns)
+    active = active_entry(term.assigns)
+    kind = render_tree_kind(term.assigns)
+    current_tree = active_render_tree(term.assigns, active_source, active, kind)
+    selection_changed? = render_tree_selection_changed?(current_tree, active, selected)
+
+    expansion_changed? =
+      render_tree_expansion_changed?(term.assigns, active_source, kind, expanded)
+
+    if selection_changed? or expansion_changed? do
+      select_remote_element(active, selected)
+
+      render_tree_expanded =
+        if active_source && is_list(expanded) do
+          term.assigns
+          |> Map.get(:render_tree_expanded, %{})
+          |> Map.put(render_tree_cache_key(active_source, kind), expanded)
+        else
+          Map.get(term.assigns, :render_tree_expanded, %{})
+        end
+
+      term =
+        term
+        |> assign(render_tree_expanded: render_tree_expanded)
+        |> refresh_active_render_tree(selected_id: selected, force: true)
+
+      {:noreply, term}
+    else
+      {:noreply, term}
+    end
+  end
+
+  def handle_event(_, %{"key" => key}, term) when key in ["t", "T"] do
+    {:noreply, toggle_tree_panel(term)}
+  end
+
+  def handle_event(_, %{"key" => "q"}, term), do: quit(%{"key" => "q"}, term)
   def handle_event(_, _, term), do: {:noreply, term}
 
+  defp active_source(assigns),
+    do: Map.get(assigns, :active_source) || Map.get(assigns, :latest_source)
+
   defp active_entry(%{snapshots: snapshots, latest_source: latest_source} = assigns) do
-    active_source = Map.get(assigns, :active_source)
-    Map.get(snapshots, active_source || latest_source)
+    Map.get(snapshots, active_source(assigns) || latest_source)
   end
+
+  defp payload_value(payload, key) when is_map(payload) do
+    Map.get(payload, key) || Map.get(payload, Atom.to_string(key))
+  end
+
+  defp payload_value(_payload, _key), do: nil
+
+  defp normalize_expanded(nil), do: nil
+  defp normalize_expanded(expanded) when is_list(expanded), do: expanded
+  defp normalize_expanded(expanded), do: List.wrap(expanded)
+
+  defp put_tree_keybindings(term) do
+    put_local_keybindings(term, tree_keybindings(term.assigns))
+  end
+
+  defp tree_keybindings(%{panel_tab: "tree"} = assigns) do
+    [
+      {"t", tree_keybinding_label(render_tree_kind(assigns)),
+       fn _event, term ->
+         {:noreply, toggle_tree_panel(term)}
+       end}
+    ]
+  end
+
+  defp tree_keybindings(_assigns), do: []
+
+  defp tree_keybinding_label("code"), do: "Rendered tree"
+  defp tree_keybinding_label(_kind), do: "Code tree"
+
+  defp toggle_tree_panel(term) do
+    next_kind =
+      if Map.get(term.assigns, :panel_tab) == "tree" do
+        next_render_tree_kind(render_tree_kind(term.assigns))
+      else
+        render_tree_kind(term.assigns)
+      end
+
+    term
+    |> assign(panel_tab: "tree", render_tree_kind: next_kind)
+    |> put_tree_keybindings()
+    |> refresh_active_render_tree(force: true)
+  end
+
+  defp render_tree_kind(%{render_tree_kind: kind}), do: normalize_render_tree_kind(kind)
+  defp render_tree_kind(_assigns), do: "rendered"
+
+  defp normalize_render_tree_kind(kind) when kind in [:code, "code"], do: "code"
+  defp normalize_render_tree_kind(_kind), do: "rendered"
+
+  defp next_render_tree_kind("rendered"), do: "code"
+  defp next_render_tree_kind(_kind), do: "rendered"
+
+  defp render_tree_kind_atom("code"), do: :code
+  defp render_tree_kind_atom(_kind), do: :rendered
+
+  defp render_tree_cache_key(source, "rendered"), do: source
+  defp render_tree_cache_key(source, kind), do: {source, kind}
+
+  defp render_tree_selection_changed?(_tree, _active, selected) when not is_binary(selected),
+    do: false
+
+  defp render_tree_selection_changed?(tree, active, selected) do
+    current =
+      case tree do
+        %{selected_id: selected_id} -> selected_id
+        _ -> get_in(active || %{}, [:snapshot, :selected_id])
+      end
+
+    selected != current
+  end
+
+  defp render_tree_expansion_changed?(_assigns, _source, _kind, expanded)
+       when not is_list(expanded),
+       do: false
+
+  defp render_tree_expansion_changed?(assigns, source, kind, expanded) do
+    current =
+      assigns
+      |> Map.get(:render_tree_expanded, %{})
+      |> Map.get(render_tree_cache_key(source, kind), [])
+
+    expanded != current
+  end
+
+  defp select_remote_element(_active, selected) when not is_binary(selected), do: :ok
+
+  defp select_remote_element(%{snapshot: %{source: %{server_pid: pid}}}, selected)
+       when is_pid(pid) do
+    Breeze.Server.select_inspector(pid, selected)
+  end
+
+  defp select_remote_element(%{source: %{pid: pid}}, selected) when is_pid(pid) do
+    Breeze.Server.select_inspector(pid, selected)
+  end
+
+  defp select_remote_element(_active, _selected), do: :ok
+
+  defp refresh_active_render_tree(term, opts \\ []) do
+    if Keyword.get(opts, :force, false) or Map.get(term.assigns, :panel_tab) == "tree" do
+      active_source = active_source(term.assigns)
+      active = active_entry(term.assigns)
+      kind = render_tree_kind(term.assigns)
+
+      case fetch_render_tree(active, term.assigns, active_source, kind, opts) do
+        nil ->
+          term
+
+        tree ->
+          cache_key = render_tree_cache_key(active_source, kind)
+
+          render_trees =
+            term.assigns
+            |> Map.get(:render_trees, %{})
+            |> Map.put(cache_key, tree)
+
+          render_tree_expanded =
+            term.assigns
+            |> Map.get(:render_tree_expanded, %{})
+            |> Map.put(cache_key, Map.get(tree, :expanded, []))
+
+          assign(term, render_trees: render_trees, render_tree_expanded: render_tree_expanded)
+      end
+    else
+      term
+    end
+  end
+
+  defp fetch_render_tree(nil, _assigns, _source, _kind, _opts), do: nil
+  defp fetch_render_tree(_active, _assigns, nil, _kind, _opts), do: nil
+
+  defp fetch_render_tree(active, assigns, source, kind, opts) do
+    expanded =
+      opts[:expanded] ||
+        assigns
+        |> Map.get(:render_tree_expanded, %{})
+        |> Map.get(render_tree_cache_key(source, kind), [])
+
+    selected_id = opts[:selected_id] || active.snapshot.selected_id
+
+    case source_server_pid(active) do
+      pid when is_pid(pid) ->
+        Breeze.Server.inspector_render_tree(pid,
+          expanded: expanded,
+          selected_id: selected_id,
+          kind: render_tree_kind_atom(kind),
+          limit: @render_tree_limit
+        )
+
+      _ ->
+        snapshot_render_tree(active.snapshot, kind)
+    end
+  catch
+    :exit, _reason -> snapshot_render_tree(active.snapshot, kind)
+  end
+
+  defp source_server_pid(%{snapshot: %{source: %{server_pid: pid}}}) when is_pid(pid), do: pid
+  defp source_server_pid(%{source: %{pid: pid}}) when is_pid(pid), do: pid
+  defp source_server_pid(_active), do: nil
+
+  defp active_render_tree(assigns, source, active, kind) do
+    assigns
+    |> Map.get(:render_trees, %{})
+    |> Map.get(render_tree_cache_key(source, kind))
+    |> case do
+      nil -> if(active, do: snapshot_render_tree(active.snapshot, kind), else: nil)
+      tree -> tree
+    end
+  end
+
+  defp snapshot_render_tree(snapshot, kind)
+  defp snapshot_render_tree(_snapshot, "code"), do: nil
+
+  defp snapshot_render_tree(%{render_tree: tree, selected_id: selected_id}, _kind)
+       when is_map(tree) do
+    %{
+      nodes: [tree],
+      selected_id: selected_id,
+      expanded: default_render_tree_expanded(tree, selected_id),
+      limit: @render_tree_limit,
+      truncated?: false
+    }
+  end
+
+  defp snapshot_render_tree(_snapshot, _kind), do: nil
+
+  defp render_tree_nodes(%{nodes: nodes}) when is_list(nodes) do
+    Enum.map(nodes, &colorize_render_tree_node/1)
+  end
+
+  defp render_tree_nodes(_tree), do: []
+
+  defp colorize_render_tree_node(%{} = node) do
+    node
+    |> Map.update(:label, Map.get(node, :id, ""), fn label ->
+      case Map.get(node, :label_parts) do
+        parts when is_list(parts) -> render_tree_label_spans(parts)
+        _ -> label
+      end
+    end)
+    |> Map.update(:children, [], fn children ->
+      children
+      |> List.wrap()
+      |> Enum.map(&colorize_render_tree_node/1)
+    end)
+  end
+
+  defp colorize_render_tree_node(node), do: node
+
+  defp render_tree_label_spans(parts) do
+    parts
+    |> Enum.map(fn part ->
+      TextSpan.new(to_string(Map.get(part, :text, "")), render_tree_label_style(part))
+    end)
+    |> Enum.reject(&(&1.text == ""))
+  end
+
+  defp render_tree_label_style(%{token: :punctuation}), do: %{foreground_color: 8}
+  defp render_tree_label_style(%{token: :tag}), do: %{foreground_color: 14}
+  defp render_tree_label_style(%{token: :id}), do: %{foreground_color: 11}
+  defp render_tree_label_style(%{token: :anonymous_id}), do: %{foreground_color: 8}
+  defp render_tree_label_style(%{token: :class}), do: %{foreground_color: 10}
+  defp render_tree_label_style(%{token: :component}), do: %{foreground_color: 8}
+  defp render_tree_label_style(%{token: :separator}), do: %{}
+
+  defp render_tree_label_style(%{token: :swatch} = part) do
+    %{}
+    |> put_swatch_color(:foreground_color, Map.get(part, :foreground_color))
+    |> put_swatch_color(:background_color, Map.get(part, :background_color))
+  end
+
+  defp render_tree_label_style(_part), do: %{}
+
+  defp put_swatch_color(style, _key, nil), do: style
+  defp put_swatch_color(style, key, color), do: Map.put(style, key, color)
+
+  defp render_tree_selected(%{selected_id: selected_id}, _snapshot), do: selected_id
+  defp render_tree_selected(_tree, snapshot), do: Map.get(snapshot, :selected_id)
+
+  defp render_tree_expanded(%{expanded: expanded}) when is_list(expanded), do: expanded
+  defp render_tree_expanded(_tree), do: []
+
+  defp default_render_tree_expanded(nil, _selected_id), do: []
+
+  defp default_render_tree_expanded(tree, selected_id) do
+    case render_tree_path(tree, selected_id) do
+      [] ->
+        expandable_tree_id(tree)
+
+      path ->
+        expanded = Enum.drop(path, -1)
+
+        case expanded do
+          [] -> expandable_tree_id(tree)
+          _ -> expanded
+        end
+    end
+  end
+
+  defp expandable_tree_id(%{id: id, children: [_ | _]}), do: [id]
+  defp expandable_tree_id(_tree), do: []
+
+  defp render_tree_path(_tree, selected_id) when not is_binary(selected_id), do: []
+
+  defp render_tree_path(%{id: selected_id}, selected_id), do: [selected_id]
+
+  defp render_tree_path(%{id: id, children: children}, selected_id) when is_list(children) do
+    Enum.find_value(children, [], fn child ->
+      case render_tree_path(child, selected_id) do
+        [] -> nil
+        path -> [id | path]
+      end
+    end)
+  end
+
+  defp render_tree_path(_tree, _selected_id), do: []
 
   defp label(nil, fallback), do: fallback || "-"
 

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -25,12 +25,12 @@ defmodule Breeze.Renderer do
 
     rendered = mod.render(assigns)
 
-    [{_tag, _, root_children}] =
+    [{root_tag, _, root_children}] =
       rendered
       |> Breeze.Template.render_to_tree(assigns)
 
-    opts = maybe_attach_live_viewports(root_children, opts)
-    build_from_tree_nodes(root_children, opts)
+    opts = maybe_attach_live_viewports(root_tag, root_children, opts)
+    build_from_tree_nodes(root_tag, root_children, opts)
   end
 
   def render(mod, assigns, opts \\ []) do
@@ -53,16 +53,16 @@ defmodule Breeze.Renderer do
         mod.render(assigns)
       end)
 
-    [{_tag, _, root_children}] =
+    [{root_tag, _, root_children}] =
       profile(profile_scope, profile_label, :template_tree_us, fn ->
         Breeze.Template.render_to_tree(rendered, assigns)
       end)
 
-    opts = maybe_attach_live_viewports(root_children, opts)
+    opts = maybe_attach_live_viewports(root_tag, root_children, opts)
 
     {acc, box} =
       profile(profile_scope, profile_label, :build_tree_us, fn ->
-        build_from_tree_nodes(root_children, opts)
+        build_from_tree_nodes(root_tag, root_children, opts)
       end)
 
     %{box: box, dimensions: dimensions} =
@@ -100,7 +100,7 @@ defmodule Breeze.Renderer do
 
   defp terminal_context(_terminal), do: nil
 
-  defp build_from_tree_nodes(children, opts) do
+  defp build_from_tree_nodes(root_tag, children, opts) do
     {acc, box} =
       build_tree(
         children,
@@ -115,15 +115,98 @@ defmodule Breeze.Renderer do
           boxes: %{},
           ids: [],
           flags: [],
-          live_dimensions: %{}
+          live_dimensions: %{},
+          render_tree?: render_tree_enabled?(opts),
+          render_tree_nodes: %{},
+          render_tree_children: %{},
+          render_tree_root: 0
         },
-        opts
+        opts,
+        0,
+        root_tag
       )
 
     acc = %{acc | elements: Map.put(acc.elements, acc.id, acc.flags)}
     ids = Enum.reverse(acc.ids)
     focusables = Enum.reverse(acc.focusables) |> then(&Enum.filter(ids, fn id -> id in &1 end))
-    {%{acc | ids: ids, focusables: focusables}, box}
+    acc = %{acc | ids: ids, focusables: focusables}
+
+    acc =
+      if acc.render_tree? do
+        acc
+        |> Map.put(:render_tree, assemble_render_tree(acc))
+        |> Map.drop([:render_tree?, :render_tree_nodes, :render_tree_children, :render_tree_root])
+      else
+        Map.drop(acc, [
+          :render_tree?,
+          :render_tree_nodes,
+          :render_tree_children,
+          :render_tree_root
+        ])
+      end
+
+    {acc, box}
+  end
+
+  defp render_tree_enabled?(opts), do: Keyword.get(opts, :render_tree?, false) == true
+
+  defp put_render_tree_node(%{render_tree?: true} = acc, idx, tag) do
+    update_in(acc, [:render_tree_nodes], &Map.put(&1 || %{}, idx, %{idx: idx, tag: tag}))
+  end
+
+  defp put_render_tree_node(acc, _idx, _tag), do: acc
+
+  defp put_render_tree_child(%{render_tree?: true} = acc, parent_id, child_ref) do
+    update_in(acc, [:render_tree_children], fn children ->
+      Map.update(children || %{}, parent_id, [child_ref], &(&1 ++ [child_ref]))
+    end)
+  end
+
+  defp put_render_tree_child(acc, _parent_id, _child_ref), do: acc
+
+  defp assemble_render_tree(%{render_tree_root: root} = acc) do
+    assemble_render_tree(root, acc.render_tree_nodes, acc.render_tree_children)
+  end
+
+  defp assemble_render_tree(idx, nodes, children) do
+    case Map.get(nodes, idx) do
+      nil ->
+        nil
+
+      node ->
+        child_nodes =
+          children
+          |> Map.get(idx, [])
+          |> Enum.flat_map(fn
+            {:id, child_id} ->
+              case assemble_render_tree(child_id, nodes, children) do
+                nil -> []
+                child -> [child]
+              end
+
+            {:tree, child} when is_map(child) ->
+              [child]
+
+            _other ->
+              []
+          end)
+
+        Map.put(node, :children, child_nodes)
+    end
+  end
+
+  defp shift_render_tree(nil, _offset), do: nil
+
+  defp shift_render_tree(%{idx: idx} = node, offset) do
+    children =
+      node
+      |> Map.get(:children, [])
+      |> Enum.map(&shift_render_tree(&1, offset))
+      |> Enum.reject(&is_nil/1)
+
+    node
+    |> Map.put(:idx, idx + offset)
+    |> Map.put(:children, children)
   end
 
   defp build_tree(
@@ -133,11 +216,24 @@ defmodule Breeze.Renderer do
          style_state,
          flags,
          acc,
-         opts
+         opts,
+         current_id,
+         tag
        ) do
     acc = %{acc | flags: Keyword.put(acc.flags, :style_input, style)}
     flags = Keyword.put(flags, :style_input, style)
-    build_tree(rest, box, children, RenderStyle.put_style(style_state, style), flags, acc, opts)
+
+    build_tree(
+      rest,
+      box,
+      children,
+      RenderStyle.put_style(style_state, style),
+      flags,
+      acc,
+      opts,
+      current_id,
+      tag
+    )
   end
 
   defp build_tree(
@@ -147,11 +243,24 @@ defmodule Breeze.Renderer do
          style_state,
          flags,
          acc,
-         opts
+         opts,
+         current_id,
+         tag
        ) do
     acc = %{acc | flags: Keyword.put(acc.flags, :class, class)}
     flags = Keyword.put(flags, :class, class)
-    build_tree(rest, box, children, RenderStyle.put_class(style_state, class), flags, acc, opts)
+
+    build_tree(
+      rest,
+      box,
+      children,
+      RenderStyle.put_class(style_state, class),
+      flags,
+      acc,
+      opts,
+      current_id,
+      tag
+    )
   end
 
   defp build_tree(
@@ -161,11 +270,24 @@ defmodule Breeze.Renderer do
          style_state,
          flags,
          acc,
-         opts
+         opts,
+         current_id,
+         tag
        ) do
     ids = [box_id | acc.ids]
     acc = %{acc | ids: ids, flags: Keyword.put(acc.flags, :id, box_id)}
-    build_tree(rest, box, children, style_state, Keyword.put(flags, :id, box_id), acc, opts)
+
+    build_tree(
+      rest,
+      box,
+      children,
+      style_state,
+      Keyword.put(flags, :id, box_id),
+      acc,
+      opts,
+      current_id,
+      tag
+    )
   end
 
   defp build_tree(
@@ -175,7 +297,9 @@ defmodule Breeze.Renderer do
          style_state,
          flags,
          acc,
-         opts
+         opts,
+         current_id,
+         tag
        ) do
     mod =
       case mod do
@@ -184,7 +308,18 @@ defmodule Breeze.Renderer do
       end
 
     acc = %{acc | flags: Keyword.put(acc.flags, :implicit, mod)}
-    build_tree(rest, box, children, style_state, Keyword.put(flags, :implicit, mod), acc, opts)
+
+    build_tree(
+      rest,
+      box,
+      children,
+      style_state,
+      Keyword.put(flags, :implicit, mod),
+      acc,
+      opts,
+      current_id,
+      tag
+    )
   end
 
   defp build_tree(
@@ -194,7 +329,9 @@ defmodule Breeze.Renderer do
          style_state,
          flags,
          acc,
-         opts
+         opts,
+         current_id,
+         tag
        ) do
     acc = %{acc | flags: Keyword.put(acc.flags, :content, content)}
 
@@ -205,7 +342,9 @@ defmodule Breeze.Renderer do
       style_state,
       Keyword.put(flags, :content, content),
       acc,
-      opts
+      opts,
+      current_id,
+      tag
     )
   end
 
@@ -216,11 +355,24 @@ defmodule Breeze.Renderer do
          style_state,
          flags,
          acc,
-         opts
+         opts,
+         current_id,
+         tag
        ) do
     flag = String.to_atom(flag)
     acc = %{acc | flags: Keyword.put(acc.flags, flag, value)}
-    build_tree(rest, box, children, style_state, Keyword.put(flags, flag, value), acc, opts)
+
+    build_tree(
+      rest,
+      box,
+      children,
+      style_state,
+      Keyword.put(flags, flag, value),
+      acc,
+      opts,
+      current_id,
+      tag
+    )
   end
 
   defp build_tree(
@@ -230,45 +382,68 @@ defmodule Breeze.Renderer do
          style_state,
          flags,
          acc,
-         opts
+         opts,
+         current_id,
+         tag
        ) do
     attr = String.to_atom(attr)
     acc = %{acc | flags: Keyword.put(acc.flags, attr, true)}
-    build_tree(rest, box, children, style_state, Keyword.put(flags, attr, true), acc, opts)
+
+    build_tree(
+      rest,
+      box,
+      children,
+      style_state,
+      Keyword.put(flags, attr, true),
+      acc,
+      opts,
+      current_id,
+      tag
+    )
   end
 
-  defp build_tree([content | rest], box, children, style_state, flags, acc, opts)
+  defp build_tree([content | rest], box, children, style_state, flags, acc, opts, current_id, tag)
        when is_binary(content) do
     box = %{box | content: String.trim_trailing(content, "\n  ")}
-    build_tree(rest, box, children, style_state, flags, acc, opts)
+    build_tree(rest, box, children, style_state, flags, acc, opts, current_id, tag)
   end
 
-  defp build_tree([content | rest], box, children, style_state, flags, acc, opts)
+  defp build_tree([content | rest], box, children, style_state, flags, acc, opts, current_id, tag)
        when is_map(content) do
     if virtual_text_surface?(content) do
       box = %{box | content: content}
-      build_tree(rest, box, children, style_state, flags, acc, opts)
+      build_tree(rest, box, children, style_state, flags, acc, opts, current_id, tag)
     else
       children = children ++ [content]
-      build_tree(rest, box, children, style_state, flags, acc, opts)
+      build_tree(rest, box, children, style_state, flags, acc, opts, current_id, tag)
     end
   end
 
-  defp build_tree([content | rest], box, children, style_state, flags, acc, opts)
+  defp build_tree([content | rest], box, children, style_state, flags, acc, opts, current_id, tag)
        when is_list(content) do
     if text_span_list?(content) do
       box = %{box | content: content}
-      build_tree(rest, box, children, style_state, flags, acc, opts)
+      build_tree(rest, box, children, style_state, flags, acc, opts, current_id, tag)
     else
       children = children ++ [content]
-      build_tree(rest, box, children, style_state, flags, acc, opts)
+      build_tree(rest, box, children, style_state, flags, acc, opts, current_id, tag)
     end
   end
 
-  defp build_tree([{:live, attrs} | rest], box, children, style_state, flags, acc, opts) do
+  defp build_tree(
+         [{:live, attrs} | rest],
+         box,
+         children,
+         style_state,
+         flags,
+         acc,
+         opts,
+         current_id,
+         tag
+       ) do
     {acc, child} =
       if Keyword.get(opts, :live_placeholder, false) do
-        build_live_placeholder(attrs, flags, acc, opts)
+        build_live_placeholder(attrs, flags, acc, opts, current_id)
       else
         case Keyword.get(opts, :live_view) do
           fun when is_function(fun, 2) ->
@@ -284,12 +459,14 @@ defmodule Breeze.Renderer do
 
             case fun.(attrs, child_opts) do
               {:rendered, prefix, child_acc, child_box} ->
-                {merge_live_acc(acc, namespace_live_acc(child_acc, prefix, child_opts)),
-                 child_box}
+                child_acc = namespace_live_acc(child_acc, prefix, child_opts)
+
+                {merge_live_acc(acc, child_acc, current_id), child_box}
 
               {:rendered, prefix, child_acc, child_box, child_dimensions} ->
-                {merge_live_acc(acc, namespace_live_acc(child_acc, prefix, child_opts)),
-                 child_box}
+                child_acc = namespace_live_acc(child_acc, prefix, child_opts)
+
+                {merge_live_acc(acc, child_acc, current_id), child_box}
                 |> then(fn {merged_acc, rendered_box} ->
                   {
                     %{
@@ -313,10 +490,21 @@ defmodule Breeze.Renderer do
       end
 
     children = if child, do: [child | children], else: children
-    build_tree(rest, box, children, style_state, flags, acc, opts)
+    build_tree(rest, box, children, style_state, flags, acc, opts, current_id, tag)
   end
 
-  defp build_tree([{:box, _, nodes} | rest], box, children, style_state, flags, acc, opts) do
+  defp build_tree(
+         [{child_tag, _, nodes} | rest],
+         box,
+         children,
+         style_state,
+         flags,
+         acc,
+         opts,
+         current_id,
+         tag
+       )
+       when is_atom(child_tag) do
     child_flags =
       []
       |> inherit_implicit_owner(flags)
@@ -325,20 +513,34 @@ defmodule Breeze.Renderer do
       |> inherit_focus_within_path(flags)
       |> inherit_selected_with_owner(opts)
 
-    acc = %{
-      acc
-      | flags: child_flags,
-        id: acc.id + 1,
-        elements: Map.put(acc.elements, acc.id, acc.flags)
-    }
+    child_id = acc.id + 1
+
+    acc =
+      %{
+        acc
+        | flags: child_flags,
+          id: child_id,
+          elements: Map.put(acc.elements, acc.id, acc.flags)
+      }
+      |> put_render_tree_child(current_id, {:id, child_id})
 
     {acc, child} =
-      build_tree(nodes, %BackBreeze.Box{}, [], RenderStyle.empty(), child_flags, acc, opts)
+      build_tree(
+        nodes,
+        %BackBreeze.Box{},
+        [],
+        RenderStyle.empty(),
+        child_flags,
+        acc,
+        opts,
+        child_id,
+        child_tag
+      )
 
-    build_tree(rest, box, [child | children], style_state, flags, acc, opts)
+    build_tree(rest, box, [child | children], style_state, flags, acc, opts, current_id, tag)
   end
 
-  defp build_tree([], box, children, style_state, flags, acc, opts) do
+  defp build_tree([], box, children, style_state, flags, acc, opts, current_id, tag) do
     render_opts = opts
     %{focusables: focusables} = acc
     implicit_state = Keyword.get(opts, :implicit_state, %{})
@@ -477,7 +679,11 @@ defmodule Breeze.Renderer do
         if root_id, do: Map.put(boxes, root_id, stored_box), else: boxes
       end)
 
-    acc = %{acc | focusables: focusables, boxes: boxes}
+    acc =
+      acc
+      |> Map.put(:focusables, focusables)
+      |> Map.put(:boxes, boxes)
+      |> put_render_tree_node(current_id, tag)
 
     {acc, final_box}
   end
@@ -604,16 +810,20 @@ defmodule Breeze.Renderer do
     max(intrinsic_content_width(content), child_width)
   end
 
-  defp merge_live_acc(acc, child_acc) do
+  defp merge_live_acc(acc, child_acc, parent_id) do
     child_offset = acc.id + 1
     child_last_id = max_key(child_acc.elements)
+
+    child_tree =
+      if Map.get(acc, :render_tree?, false),
+        do: shift_render_tree(Map.get(child_acc, :render_tree), child_offset)
 
     elements =
       Enum.reduce(child_acc.elements, acc.elements, fn {id, flags}, elements ->
         Map.put(elements, child_offset + id, flags)
       end)
 
-    %{
+    acc = %{
       acc
       | id: child_offset + child_last_id + 1,
         elements: elements,
@@ -622,15 +832,20 @@ defmodule Breeze.Renderer do
         focusables: Enum.reverse(child_acc.focusables) ++ acc.focusables,
         live_dimensions: Map.get(acc, :live_dimensions, %{})
     }
+
+    case child_tree do
+      nil -> acc
+      tree -> put_render_tree_child(acc, parent_id, {:tree, tree})
+    end
   end
 
-  defp maybe_attach_live_viewports(root_children, opts) do
+  defp maybe_attach_live_viewports(root_tag, root_children, opts) do
     case Keyword.get(opts, :live_view) do
       fun when is_function(fun, 2) ->
         placeholder_opts = Keyword.put(opts, :live_placeholder, true)
 
         {placeholder_acc, placeholder_box} =
-          build_from_tree_nodes(root_children, placeholder_opts)
+          build_from_tree_nodes(root_tag, root_children, placeholder_opts)
 
         %{dimensions: dimensions} =
           BackBreeze.Box.render_with_dimensions(placeholder_box, placeholder_opts)
@@ -654,22 +869,36 @@ defmodule Breeze.Renderer do
     end
   end
 
-  defp build_live_placeholder(attrs, flags, acc, opts) do
+  defp build_live_placeholder(attrs, flags, acc, opts, current_id) do
     live_flags =
       [__live_placeholder__: true]
       |> inherit_implicit_owner(flags)
       |> inherit_focus_scope_path(flags)
 
-    acc = %{
-      acc
-      | flags: live_flags,
-        id: acc.id + 1,
-        elements: Map.put(acc.elements, acc.id, acc.flags)
-    }
+    child_id = acc.id + 1
+
+    acc =
+      %{
+        acc
+        | flags: live_flags,
+          id: child_id,
+          elements: Map.put(acc.elements, acc.id, acc.flags)
+      }
+      |> put_render_tree_child(current_id, {:id, child_id})
 
     nodes = live_placeholder_nodes(attrs, opts)
 
-    build_tree(nodes, %BackBreeze.Box{}, [], RenderStyle.empty(), live_flags, acc, opts)
+    build_tree(
+      nodes,
+      %BackBreeze.Box{},
+      [],
+      RenderStyle.empty(),
+      live_flags,
+      acc,
+      opts,
+      child_id,
+      :box
+    )
   end
 
   defp live_placeholder_nodes(attrs, opts) do

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -126,6 +126,12 @@ defmodule Breeze.Server do
     GenServer.call(pid, :inspector_snapshot)
   end
 
+  @doc false
+  @spec inspector_render_tree(pid(), keyword()) :: map()
+  def inspector_render_tree(pid, opts \\ []) do
+    GenServer.call(pid, {:inspector_render_tree, opts})
+  end
+
   @spec subscribe_debug(pid(), pid()) :: :ok
   def subscribe_debug(pid, subscriber) do
     GenServer.cast(pid, {:subscribe_debug, subscriber})
@@ -134,6 +140,12 @@ defmodule Breeze.Server do
   @spec subscribe_inspector(pid(), pid()) :: :ok
   def subscribe_inspector(pid, subscriber) do
     GenServer.cast(pid, {:subscribe_inspector, subscriber})
+  end
+
+  @doc false
+  @spec select_inspector(pid(), String.t()) :: :ok
+  def select_inspector(pid, id) when is_pid(pid) and is_binary(id) do
+    GenServer.cast(pid, {:select_inspector, id})
   end
 
   @impl true
@@ -150,6 +162,7 @@ defmodule Breeze.Server do
     theme = Breeze.Theme.new(Keyword.get(opts, :theme), terminal: terminal)
     theme_source = Keyword.get(opts, :theme)
     apply_theme_defaults? = Breeze.Theme.defaults_enabled?(Keyword.get(opts, :theme))
+    inspector_enabled? = inspector_enabled?(Keyword.get(opts, :inspector, false))
 
     session = self()
 
@@ -162,6 +175,7 @@ defmodule Breeze.Server do
         theme_source: theme_source,
         apply_theme_defaults?: apply_theme_defaults?,
         process_flags: Keyword.get(opts, :child_process_flags, []),
+        render_tree?: inspector_enabled?,
         server: self(),
         global_keybindings: Keyword.get(opts, :global_keybindings, []),
         invalidate: fn
@@ -229,6 +243,10 @@ defmodule Breeze.Server do
     {:reply, Breeze.Inspector.snapshot(state), state}
   end
 
+  def handle_call({:inspector_render_tree, opts}, _from, state) do
+    {:reply, Breeze.Inspector.render_tree(state, opts), state}
+  end
+
   def handle_call(:focused_implicit_meta, _from, state) do
     {:reply, focused_implicit_meta(state), state}
   end
@@ -258,6 +276,20 @@ defmodule Breeze.Server do
       )
 
     {:noreply, Inspector.push_snapshot_now(state)}
+  end
+
+  def handle_cast({:select_inspector, id}, state) when is_binary(id) do
+    state =
+      if Breeze.Inspector.enabled?(state) do
+        state
+        |> update_inspector(selected_id: id, hovered_id: id)
+        |> Breeze.Inspector.sync_selected_id()
+        |> maybe_render_base(:remote_inspector_select)
+      else
+        state
+      end
+
+    {:noreply, state}
   end
 
   @impl true
@@ -441,6 +473,8 @@ defmodule Breeze.Server do
 
   defp update_inspector(state, updates),
     do: %{state | inspector_state: struct!(state.inspector_state, updates)}
+
+  defp inspector_enabled?(config), do: config not in [false, nil]
 
   defp update_rendered(state, updates), do: %{state | rendered: struct!(state.rendered, updates)}
 
@@ -861,6 +895,7 @@ defmodule Breeze.Server do
       implicit_state: %{},
       terminal: state.terminal,
       theme: state.theme,
+      render_tree?: Breeze.Inspector.enabled?(state),
       render_tracking_ref: tracking_ref,
       profile_scope: profile_scope,
       profile_label: inspect(root_view_module(state)),
@@ -990,6 +1025,7 @@ defmodule Breeze.Server do
              terminal: ctx.terminal,
              theme: state.theme,
              live_prefix: ctx.full_id,
+             render_tree?: Breeze.Inspector.enabled?(state),
              render_tracking_ref: tracking_ref,
              profile_scope: profile_scope,
              profile_label: "#{ctx.full_id} #{inspect(child.view)}",
@@ -1104,6 +1140,7 @@ defmodule Breeze.Server do
              terminal: ctx.terminal,
              theme: ctx.state.theme,
              live_prefix: ctx.child_id,
+             render_tree?: Breeze.Inspector.enabled?(ctx.state),
              render_tracking_ref: ctx.tracking_ref,
              profile_scope: ctx.profile_scope,
              profile_label: "#{ctx.child_id} #{inspect(ctx.view)}",
@@ -1836,6 +1873,7 @@ defmodule Breeze.Server do
              theme: state.theme,
              process_flags: state.child_process_flags || [],
              server: self(),
+             render_tree?: Breeze.Inspector.enabled?(state),
              global_keybindings: state.global_keybindings || [],
              invalidate: fn -> send(session, :child_invalidated) end
            )
@@ -2118,6 +2156,7 @@ defmodule Breeze.Server do
         terminal: terminal,
         theme: theme,
         process_flags: state.child_process_flags || [],
+        render_tree?: Breeze.Inspector.enabled?(state),
         invalidate: invalidate
       )
 

--- a/lib/breeze/server/inspector.ex
+++ b/lib/breeze/server/inspector.ex
@@ -25,7 +25,14 @@ defmodule Breeze.Server.Inspector do
   def merge_render_data(%{inspector_state: %{config: false}} = state, _acc, _metadata), do: state
 
   def merge_render_data(state, acc, metadata) do
-    %{viewports: viewports, bounds: bounds, flags: flags, boxes: boxes} = nodes(acc)
+    %{
+      viewports: viewports,
+      bounds: bounds,
+      flags: flags,
+      boxes: boxes,
+      tree_meta: tree_meta,
+      code_tree_meta: code_tree_meta
+    } = nodes(acc, state.theme)
 
     state
     |> update_rendered(
@@ -33,6 +40,9 @@ defmodule Breeze.Server.Inspector do
       mouse_targets: bounds,
       flags: flags,
       boxes: Map.merge(state.rendered.boxes, boxes),
+      render_tree: Map.get(acc, :render_tree),
+      render_tree_meta: tree_meta,
+      code_tree_meta: code_tree_meta,
       focus_meta: Map.get(metadata, :focus_meta, %{}),
       implicit_state: Map.get(metadata, :implicit_state, %{}),
       implicit_meta: Map.get(metadata, :implicit_meta, %{})
@@ -57,36 +67,431 @@ defmodule Breeze.Server.Inspector do
 
   defp update_rendered(state, updates), do: %{state | rendered: struct!(state.rendered, updates)}
 
-  defp nodes(acc) do
+  defp nodes(acc, theme) do
     source_boxes = Map.get(acc, :boxes, %{})
 
     acc.elements
     |> Enum.sort()
     |> Enum.zip(acc.dimensions)
-    |> Enum.reduce(%{viewports: %{}, bounds: %{}, flags: %{}, boxes: %{}}, fn {{idx, flags}, dims},
-                                                                              node_acc ->
-      key = node_key(idx, flags)
-      viewport = Breeze.Viewport.from_dimensions(dims)
+    |> Enum.reduce(
+      %{viewports: %{}, bounds: %{}, flags: %{}, boxes: %{}, tree_meta: %{}, code_tree_meta: %{}},
+      fn {{idx, flags}, dims}, node_acc ->
+        key = node_key(idx, flags)
+        box = node_box(source_boxes, idx, flags)
+        viewport = Breeze.Viewport.from_dimensions(dims)
 
-      width = max((viewport.width || 0) - 1, 0)
-      height = max(viewport.height - 1, 0)
-      normalized_flags = Keyword.put(flags, :__inspector_idx__, idx)
+        width = max((viewport.width || 0) - 1, 0)
+        height = max(viewport.height - 1, 0)
+        normalized_flags = Keyword.put(flags, :__inspector_idx__, idx)
 
-      bounds = %{
+        bounds = %{
+          left: viewport.left,
+          top: viewport.top,
+          right: viewport.left + width,
+          bottom: viewport.top + height
+        }
+
+        %{
+          viewports: Map.put(node_acc.viewports, key, viewport),
+          bounds: Map.put(node_acc.bounds, key, bounds),
+          flags: Map.put(node_acc.flags, key, normalized_flags),
+          boxes: put_node_box(node_acc.boxes, key, box),
+          tree_meta:
+            Map.put(
+              node_acc.tree_meta,
+              idx,
+              render_tree_meta(idx, key, normalized_flags, viewport, bounds, box, theme)
+            ),
+          code_tree_meta:
+            Map.put(
+              node_acc.code_tree_meta,
+              idx,
+              code_tree_meta(idx, key, normalized_flags, box, theme)
+            )
+        }
+      end
+    )
+  end
+
+  defp render_tree_meta(idx, key, flags, viewport, bounds, box, theme) do
+    tag = "box"
+
+    %{
+      id: key,
+      actual_id: Keyword.get(flags, :id),
+      inspector_idx: idx,
+      label: render_tree_label(tag, idx, key, flags, box, theme),
+      label_parts: render_tree_label_parts(tag, idx, key, flags, box, theme),
+      tag: tag,
+      component: Keyword.get(flags, :"breeze-component"),
+      class: Keyword.get(flags, :class),
+      style_input: Keyword.get(flags, :style_input),
+      implicit: Keyword.get(flags, :implicit),
+      focusable?: Keyword.get(flags, :focusable, false),
+      focused?: Keyword.get(flags, :focused, false),
+      selected?: Keyword.get(flags, :selected, false),
+      bounds: bounds,
+      layout: %{
         left: viewport.left,
         top: viewport.top,
-        right: viewport.left + width,
-        bottom: viewport.top + height
+        width: viewport.width || 0,
+        height: viewport.height
       }
+    }
+  end
 
-      %{
-        viewports: Map.put(node_acc.viewports, key, viewport),
-        bounds: Map.put(node_acc.bounds, key, bounds),
-        flags: Map.put(node_acc.flags, key, normalized_flags),
-        boxes: put_node_box(node_acc.boxes, key, source_boxes, idx, flags)
-      }
+  defp code_tree_meta(idx, key, flags, box, theme) do
+    tag = code_tree_tag(flags)
+
+    %{
+      id: key,
+      actual_id: Keyword.get(flags, :id),
+      inspector_idx: idx,
+      label: code_tree_label(tag, idx, key, flags, box, theme),
+      label_parts: code_tree_label_parts(tag, idx, key, flags, box, theme),
+      tag: tag,
+      component: Keyword.get(flags, :"breeze-component"),
+      class: Keyword.get(flags, :class),
+      style_input: Keyword.get(flags, :style_input),
+      implicit: Keyword.get(flags, :implicit),
+      focusable?: Keyword.get(flags, :focusable, false),
+      focused?: Keyword.get(flags, :focused, false),
+      selected?: Keyword.get(flags, :selected, false),
+      tree_kind: :code
+    }
+  end
+
+  defp code_tree_tag(flags) do
+    case Keyword.get(flags, :"breeze-component") do
+      component when is_binary(component) -> component
+      _ -> "box"
+    end
+  end
+
+  defp render_tree_label(tag, idx, key, flags, box, theme) do
+    tag
+    |> render_tree_label_parts(idx, key, flags, box, theme)
+    |> Enum.map(& &1.text)
+    |> IO.iodata_to_binary()
+  end
+
+  defp code_tree_label(tag, idx, key, flags, box, theme) do
+    tag
+    |> code_tree_label_parts(idx, key, flags, box, theme)
+    |> Enum.map(& &1.text)
+    |> IO.iodata_to_binary()
+  end
+
+  defp render_tree_label_parts(tag, idx, key, flags, box, theme) do
+    id = Keyword.get(flags, :id)
+    component = Keyword.get(flags, :"breeze-component")
+
+    [
+      %{text: "<", token: :punctuation},
+      %{text: tag, token: :tag},
+      render_tree_id_part(id, key, idx),
+      render_tree_class_parts(Keyword.get(flags, :class), box, flags, theme),
+      render_tree_style_input_swatch_parts(box, flags, theme),
+      %{text: ">", token: :punctuation},
+      render_tree_component_part(component)
+    ]
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp code_tree_label_parts(tag, idx, key, flags, box, theme) do
+    [
+      %{text: "<", token: :punctuation},
+      %{text: tag, token: :tag},
+      render_tree_id_part(Keyword.get(flags, :id), key, idx),
+      render_tree_class_parts(Keyword.get(flags, :class), box, flags, theme),
+      render_tree_style_input_swatch_parts(box, flags, theme),
+      %{text: ">", token: :punctuation}
+    ]
+    |> List.flatten()
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp render_tree_id_part(id, _key, _idx) when is_binary(id) do
+    %{text: "#" <> id, token: :id}
+  end
+
+  defp render_tree_id_part(_id, _key, idx) do
+    %{text: " anon#" <> Integer.to_string(idx), token: :anonymous_id}
+  end
+
+  defp render_tree_class_parts(class, %BackBreeze.Box{} = box, flags, theme)
+       when is_binary(class) do
+    style = normalize_style_map(box.style)
+
+    class
+    |> String.split()
+    |> Enum.take(3)
+    |> Enum.flat_map(fn token ->
+      [
+        %{text: "." <> token, token: :class},
+        render_tree_class_swatch_part(token, flags, style, theme)
+      ]
+      |> Enum.reject(&is_nil/1)
     end)
   end
+
+  defp render_tree_class_parts(_class, _box, _flags, _theme), do: []
+
+  defp render_tree_component_part(component) when is_binary(component) do
+    %{text: " " <> component, token: :component}
+  end
+
+  defp render_tree_component_part(_component), do: nil
+
+  defp render_tree_style_input_swatch_parts(%BackBreeze.Box{} = box, flags, theme) do
+    intents =
+      MapSet.new()
+      |> collect_class_color_intents(Keyword.get(flags, :style_input), flags, theme)
+      |> collect_style_map_color_intents(Keyword.get(flags, :style_input))
+
+    style = normalize_style_map(box.style)
+    fg = if MapSet.member?(intents, :foreground), do: Map.get(style, :foreground_color)
+    bg = if MapSet.member?(intents, :background), do: Map.get(style, :background_color)
+
+    cond do
+      recognized_color?(fg) and recognized_color?(bg) ->
+        [
+          %{text: " ", token: :separator},
+          swatch_part(:foreground, fg),
+          swatch_part(:background, bg)
+        ]
+
+      recognized_color?(fg) ->
+        [%{text: " ", token: :separator}, swatch_part(:foreground, fg)]
+
+      recognized_color?(bg) ->
+        [%{text: " ", token: :separator}, swatch_part(:background, bg)]
+
+      true ->
+        []
+    end
+  end
+
+  defp render_tree_style_input_swatch_parts(_box, _flags, _theme), do: []
+
+  defp render_tree_class_swatch_part(token, flags, style, theme) do
+    with {active?, active_token} <- style_token_state(token, flags),
+         role when role in [:foreground, :background] <- color_token_role(active_token),
+         color when not is_nil(color) <- swatch_color(active_token, role, style, theme, active?),
+         true <- recognized_color?(color) do
+      swatch_part(role, color)
+    else
+      _ -> nil
+    end
+  end
+
+  defp swatch_part(:foreground, color) do
+    %{
+      text: "●",
+      token: :swatch,
+      role: :foreground,
+      foreground_color: color,
+      background_color: nil
+    }
+  end
+
+  defp swatch_part(:background, color) do
+    %{
+      text: "●",
+      token: :swatch,
+      role: :background,
+      foreground_color: color,
+      background_color: nil
+    }
+  end
+
+  defp color_for_role(style, :foreground), do: Map.get(style, :foreground_color)
+  defp color_for_role(style, :background), do: Map.get(style, :background_color)
+
+  defp swatch_color(token, role, style, theme, true) do
+    resolve_token_color(token, role, theme) || color_for_role(style, role)
+  end
+
+  defp swatch_color(token, role, _style, theme, false) do
+    resolve_token_color(token, role, theme)
+  end
+
+  defp resolve_token_color("text", :foreground, theme),
+    do: Breeze.Theme.resolve_color(theme, :text)
+
+  defp resolve_token_color("text-" <> color, :foreground, theme),
+    do: Breeze.Theme.resolve_color(theme, color)
+
+  defp resolve_token_color("placeholder-text", :foreground, theme),
+    do: Breeze.Theme.resolve_color(theme, :text)
+
+  defp resolve_token_color("placeholder-text-" <> color, :foreground, theme),
+    do: Breeze.Theme.resolve_color(theme, color)
+
+  defp resolve_token_color("bg", :background, theme),
+    do: Breeze.Theme.resolve_color(theme, :background)
+
+  defp resolve_token_color("bg-" <> color, :background, theme),
+    do: Breeze.Theme.resolve_color(theme, color)
+
+  defp resolve_token_color(_token, _role, _theme), do: nil
+
+  defp color_token_role("text"), do: :foreground
+  defp color_token_role("text-" <> _color), do: :foreground
+  defp color_token_role("mute-text-" <> _value), do: :foreground
+  defp color_token_role("emphasize-text-" <> _value), do: :foreground
+  defp color_token_role("placeholder-text"), do: :foreground
+  defp color_token_role("placeholder-text-" <> _color), do: :foreground
+  defp color_token_role("bg"), do: :background
+  defp color_token_role("bg-" <> _color), do: :background
+  defp color_token_role("mute-bg-" <> _value), do: :background
+  defp color_token_role("emphasize-bg-" <> _value), do: :background
+  defp color_token_role(_token), do: nil
+
+  defp collect_class_color_intents(intents, value, flags, theme) do
+    value
+    |> class_tokens()
+    |> Enum.reduce(intents, fn token, intents ->
+      case style_token_state(token, flags) do
+        {_active?, token} -> collect_color_token_intent(intents, token, theme)
+        nil -> intents
+      end
+    end)
+  end
+
+  defp collect_color_token_intent(intents, token, theme) do
+    case color_token_role(token) do
+      :foreground ->
+        if recognized_color?(resolve_token_color(token, :foreground, theme)),
+          do: MapSet.put(intents, :foreground),
+          else: intents
+
+      :background ->
+        if recognized_color?(resolve_token_color(token, :background, theme)),
+          do: MapSet.put(intents, :background),
+          else: intents
+
+      nil ->
+        intents
+    end
+  end
+
+  defp collect_style_map_color_intents(intents, value) when is_map(value) do
+    Enum.reduce(value, intents, fn {key, _value}, intents ->
+      case normalize_color_style_key(key) do
+        key when key in [:foreground_color, :text] -> MapSet.put(intents, :foreground)
+        key when key in [:background_color, :bg] -> MapSet.put(intents, :background)
+        _key -> intents
+      end
+    end)
+  end
+
+  defp collect_style_map_color_intents(intents, value) when is_list(value) do
+    if Keyword.keyword?(value) do
+      collect_style_map_color_intents(intents, Map.new(value))
+    else
+      Enum.reduce(value, intents, &collect_style_map_color_intents(&2, &1))
+    end
+  end
+
+  defp collect_style_map_color_intents(intents, _value), do: intents
+
+  defp normalize_color_style_key(key) when is_atom(key), do: key
+
+  defp normalize_color_style_key(key) when is_binary(key) do
+    case key |> String.trim() |> String.replace("-", "_") do
+      "foreground_color" -> :foreground_color
+      "background_color" -> :background_color
+      "text" -> :text
+      "bg" -> :bg
+      _key -> key
+    end
+  end
+
+  defp normalize_color_style_key(key), do: key
+
+  defp class_tokens(value) when is_list(value) do
+    if Keyword.keyword?(value) do
+      class_tokens(Map.new(value))
+    else
+      value
+      |> Enum.reverse()
+      |> Enum.flat_map(&class_tokens/1)
+    end
+  end
+
+  defp class_tokens(value) do
+    value
+    |> class_segments()
+    |> Enum.flat_map(&String.split(&1, " ", trim: true))
+  end
+
+  defp class_segments(nil), do: []
+  defp class_segments(false), do: []
+  defp class_segments(value) when is_binary(value), do: [String.trim(value)]
+  defp class_segments(value) when is_atom(value), do: [Atom.to_string(value)]
+  defp class_segments(value) when is_list(value), do: Enum.flat_map(value, &class_segments/1)
+  defp class_segments(value) when is_integer(value), do: [Integer.to_string(value)]
+  defp class_segments(value) when is_float(value), do: [Float.to_string(value)]
+
+  defp class_segments(value) when is_map(value) do
+    value
+    |> Enum.flat_map(fn
+      {key, true} ->
+        class_segments(key)
+
+      {_key, truthy} when truthy in [false, nil] ->
+        []
+
+      {key, nested_value} ->
+        case class_segments(nested_value) do
+          [] -> []
+          nested_segments -> [Enum.join(class_segments(key) ++ nested_segments, "-")]
+        end
+    end)
+  end
+
+  defp class_segments(_value), do: []
+
+  defp style_token_state(token, flags) do
+    token
+    |> String.split(":")
+    |> Enum.reduce_while({true, nil, false}, fn
+      "focus", {active?, _token, placeholder?} ->
+        {:cont, {active? and Keyword.get(flags, :focused, false), nil, placeholder?}}
+
+      "selected", {active?, _token, placeholder?} ->
+        {:cont, {active? and Keyword.get(flags, :selected, false), nil, placeholder?}}
+
+      "placeholder", {active?, _token, _placeholder?} ->
+        placeholder_active? =
+          Keyword.get(flags, :placeholder, false) or
+            Keyword.get(flags, :__live_placeholder__, false)
+
+        {:cont, {active? and placeholder_active?, nil, true}}
+
+      token, {active?, _token, placeholder?} ->
+        {:halt, {active?, token, placeholder?}}
+    end)
+    |> case do
+      {_active?, nil, _placeholder?} -> nil
+      {active?, token, true} -> {active?, "placeholder-" <> token}
+      {active?, token, false} -> {active?, token}
+    end
+  end
+
+  defp normalize_style_map(%{__struct__: _struct} = style), do: Map.from_struct(style)
+  defp normalize_style_map(style) when is_map(style), do: style
+  defp normalize_style_map(_style), do: %{}
+
+  defp recognized_color?(color) when is_integer(color), do: color >= 0
+
+  defp recognized_color?({r, g, b})
+       when r in 0..255 and g in 0..255 and b in 0..255,
+       do: true
+
+  defp recognized_color?(_color), do: false
 
   defp node_key(idx, flags) do
     case Keyword.get(flags, :id) do
@@ -95,13 +500,14 @@ defmodule Breeze.Server.Inspector do
     end
   end
 
-  defp put_node_box(boxes, key, source_boxes, idx, flags) do
+  defp node_box(source_boxes, idx, flags) do
+    Map.get(source_boxes, Keyword.get(flags, :id)) || Map.get(source_boxes, idx)
+  end
+
+  defp put_node_box(boxes, key, box) do
     case Map.get(boxes, key) do
       nil ->
-        case Map.get(source_boxes, idx) || Map.get(source_boxes, Keyword.get(flags, :id)) do
-          nil -> boxes
-          box -> Map.put(boxes, key, box)
-        end
+        if is_nil(box), do: boxes, else: Map.put(boxes, key, box)
 
       _box ->
         boxes

--- a/lib/breeze/server/state.ex
+++ b/lib/breeze/server/state.ex
@@ -52,6 +52,9 @@ defmodule Breeze.Server.State.Rendered do
 
   defstruct boxes: %{},
             elements: %{},
+            render_tree: nil,
+            render_tree_meta: %{},
+            code_tree_meta: %{},
             viewports: %{},
             mouse_targets: %{},
             flags: %{},

--- a/lib/breeze/term.ex
+++ b/lib/breeze/term.ex
@@ -32,6 +32,7 @@ defmodule Breeze.Term do
     children: %{},
     frame_delay_ms: 16,
     render_timer: nil,
+    render_tree?: false,
     apply_theme_defaults?: false
   ]
 end

--- a/lib/mix/tasks/breeze.inspector.ex
+++ b/lib/mix/tasks/breeze.inspector.ex
@@ -28,8 +28,10 @@ defmodule Mix.Tasks.Breeze.Inspector do
     [
       view: Breeze.RemoteInspector.View,
       reload: true,
+      theme: :system,
       mouse: true,
-      inspector: false
+      global_keybindings: Breeze.RemoteInspector.View.global_keybindings(),
+      inspector: true
     ]
   end
 

--- a/test/breeze/inspector_test.exs
+++ b/test/breeze/inspector_test.exs
@@ -2,7 +2,50 @@ defmodule Breeze.InspectorTest do
   use ExUnit.Case, async: true
 
   alias Breeze.Inspector
+  alias Breeze.Server.State
   alias Breeze.Viewport
+
+  defmodule RenderTreeView do
+    use Breeze.View
+
+    def render(assigns) do
+      ~H"""
+      <box id="root" class="panel">
+        <box id="field" focusable class="input text-primary bg-panel">Field</box>
+        <box id="variant" class="selected:text-primary selected:bg-panel">Variant</box>
+        <box id="nested" class="label">
+          <box id="leaf" class="text-primary bg-panel">Leaf</box>
+        </box>
+      </box>
+      """
+    end
+  end
+
+  defmodule ComponentTreeView do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box id="root">
+        <.input id="url" input-value="abc"/>
+        <box id="plain">Plain</box>
+      </box>
+      """
+    end
+  end
+
+  defmodule StyleMapTreeView do
+    use Breeze.View
+
+    def render(assigns) do
+      ~H"""
+      <box id="root" style={%{foreground_color: {235, 219, 178}, background_color: {40, 40, 40}}}>
+        Styled
+      </box>
+      """
+    end
+  end
 
   test "toggle uses configured keys and clears hover state while re-syncing selection" do
     state =
@@ -66,6 +109,281 @@ defmodule Breeze.InspectorTest do
 
     assert snapshot.selected_id == "field"
     assert snapshot.selected.actual_id == "field"
+  end
+
+  test "renderer only builds render tree data when requested" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+
+    {acc, _box} =
+      Breeze.Renderer.render(RenderTreeView, %{},
+        terminal: terminal,
+        theme: true,
+        theme_source: true
+      )
+
+    refute Map.has_key?(acc, :render_tree)
+
+    {acc, _box} =
+      Breeze.Renderer.render(RenderTreeView, %{},
+        terminal: terminal,
+        theme: true,
+        theme_source: true,
+        render_tree?: true
+      )
+
+    assert is_map(acc.render_tree)
+  end
+
+  test "render tree handles style maps with tuple colors" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+    theme = Breeze.Theme.default(terminal: terminal)
+
+    {acc, _box} =
+      Breeze.Renderer.render(StyleMapTreeView, %{},
+        terminal: terminal,
+        theme: theme,
+        theme_source: theme,
+        render_tree?: true
+      )
+
+    state =
+      %Breeze.Server{
+        terminal: terminal,
+        view: StyleMapTreeView,
+        theme: theme,
+        inspector_state: %State.Inspector{config: true, selected_id: "root"},
+        rendered: %State.Rendered{}
+      }
+      |> Breeze.Server.Inspector.merge_render_data(acc, %{})
+
+    tree = Inspector.render_tree(state, expanded: ["root"], selected_id: "root", limit: 10)
+
+    assert [%{id: "root", label_parts: label_parts}] = tree.nodes
+
+    assert %{
+             text: "●",
+             token: :swatch,
+             role: :foreground,
+             foreground_color: {235, 219, 178},
+             background_color: nil
+           } in label_parts
+
+    assert %{
+             text: "●",
+             token: :swatch,
+             role: :background,
+             foreground_color: {40, 40, 40},
+             background_color: nil
+           } in label_parts
+  end
+
+  test "snapshot advertises render tree availability and queries a bounded tree window" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+
+    theme =
+      Breeze.Theme.new(%{
+        name: "tree-test",
+        defaults: %{foreground_color: {9, 9, 9}, background_color: {0, 0, 0}},
+        palette: %{primary: {1, 2, 3}, panel: {4, 5, 6}},
+        extras: %{}
+      })
+
+    {acc, _box} =
+      Breeze.Renderer.render(RenderTreeView, %{},
+        terminal: terminal,
+        theme: theme,
+        theme_source: true,
+        render_tree?: true
+      )
+
+    state =
+      %Breeze.Server{
+        terminal: terminal,
+        view: RenderTreeView,
+        theme: theme,
+        inspector_state: %State.Inspector{config: true, selected_id: "leaf"},
+        rendered: %State.Rendered{}
+      }
+      |> Breeze.Server.Inspector.merge_render_data(acc, %{})
+
+    snapshot = Inspector.snapshot(state)
+
+    assert snapshot.selected_id == "leaf"
+    assert snapshot.render_tree?
+    refute Map.has_key?(snapshot, :render_tree)
+
+    tree = Inspector.render_tree(state, expanded: ["root"], selected_id: "leaf", limit: 10)
+
+    assert [
+             %{
+               id: "root",
+               label: root_label,
+               children: [
+                 %{id: "field", label: field_label, label_parts: field_label_parts, children: []},
+                 %{
+                   id: "variant",
+                   label: variant_label,
+                   label_parts: variant_label_parts,
+                   children: []
+                 },
+                 %{
+                   id: "nested",
+                   children: [
+                     %{
+                       id: "leaf",
+                       label: leaf_label,
+                       label_parts: leaf_label_parts,
+                       children: []
+                     }
+                   ]
+                 }
+               ]
+             }
+           ] = tree.nodes
+
+    assert root_label =~ "<box#root.panel>"
+    assert field_label =~ "#field"
+    assert field_label =~ ".input"
+    assert field_label =~ ".input.text-primary●.bg-panel●>"
+
+    assert %{
+             text: "●",
+             token: :swatch,
+             role: :foreground,
+             foreground_color: {1, 2, 3},
+             background_color: nil
+           } in field_label_parts
+
+    assert %{
+             text: "●",
+             token: :swatch,
+             role: :background,
+             foreground_color: {4, 5, 6},
+             background_color: nil
+           } in field_label_parts
+
+    assert variant_label =~ ".selected:text-primary●.selected:bg-panel●>"
+
+    assert %{
+             text: "●",
+             token: :swatch,
+             role: :foreground,
+             foreground_color: {1, 2, 3},
+             background_color: nil
+           } in variant_label_parts
+
+    assert %{
+             text: "●",
+             token: :swatch,
+             role: :background,
+             foreground_color: {4, 5, 6},
+             background_color: nil
+           } in variant_label_parts
+
+    assert leaf_label =~ ".text-primary●.bg-panel●>"
+
+    assert %{
+             text: "●",
+             token: :swatch,
+             role: :foreground,
+             foreground_color: {1, 2, 3},
+             background_color: nil
+           } in leaf_label_parts
+
+    assert %{
+             text: "●",
+             token: :swatch,
+             role: :background,
+             foreground_color: {4, 5, 6},
+             background_color: nil
+           } in leaf_label_parts
+
+    assert %{label_parts: [%{text: "<", token: :punctuation}, %{text: "box", token: :tag} | _]} =
+             hd(tree.nodes)
+
+    refute Enum.any?(hd(tree.nodes).label_parts, &match?(%{token: :swatch}, &1))
+
+    assert "nested" in tree.expanded
+
+    tree = Inspector.render_tree(state, expanded: ["root"], selected_id: "field", limit: 10)
+
+    assert [
+             %{
+               children: [
+                 %{id: "field"},
+                 %{id: "variant"},
+                 %{id: "nested", expandable?: true, children: []}
+               ]
+             }
+           ] = tree.nodes
+  end
+
+  test "render tree can expose a code tree view with component labels" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+    theme = Breeze.Theme.default(terminal: terminal)
+
+    {acc, _box} =
+      Breeze.Renderer.render(ComponentTreeView, %{},
+        terminal: terminal,
+        theme: theme,
+        theme_source: theme,
+        render_tree?: true
+      )
+
+    state =
+      %Breeze.Server{
+        terminal: terminal,
+        view: ComponentTreeView,
+        theme: theme,
+        inspector_state: %State.Inspector{config: true, selected_id: "url"},
+        rendered: %State.Rendered{}
+      }
+      |> Breeze.Server.Inspector.merge_render_data(acc, %{})
+
+    snapshot = Inspector.snapshot(state)
+
+    assert snapshot.render_tree?
+    assert snapshot.render_tree_kinds == [:rendered, :code]
+
+    rendered_tree =
+      Inspector.render_tree(state, expanded: ["root"], selected_id: "url", limit: 10)
+
+    code_tree =
+      Inspector.render_tree(state, kind: :code, expanded: ["root"], selected_id: "url", limit: 10)
+
+    assert rendered_tree.kind == :rendered
+    assert code_tree.kind == :code
+
+    assert [
+             %{
+               id: "root",
+               children: [
+                 %{id: "url", label: rendered_label, label_parts: rendered_label_parts},
+                 %{id: "plain"}
+               ]
+             }
+           ] = rendered_tree.nodes
+
+    assert [
+             %{
+               id: "root",
+               children: [
+                 %{id: "url", label: code_label, label_parts: code_label_parts, tree_kind: :code},
+                 %{id: "plain", label: plain_label}
+               ],
+               tree_kind: :code
+             }
+           ] = code_tree.nodes
+
+    assert rendered_label =~ "<box#url"
+    assert rendered_label =~ "Breeze.Blocks.input"
+    assert code_label =~ "<Breeze.Blocks.input#url"
+    assert plain_label =~ "<box#plain"
+
+    assert %{text: "box", token: :tag} in rendered_label_parts
+    assert %{text: " Breeze.Blocks.input", token: :component} in rendered_label_parts
+    assert %{text: "Breeze.Blocks.input", token: :tag} in code_label_parts
+    refute Enum.any?(code_label_parts, &match?(%{token: :component}, &1))
   end
 
   test "select_at cycles overlapping targets from inner to outer elements" do

--- a/test/breeze/remote_inspector_test.exs
+++ b/test/breeze/remote_inspector_test.exs
@@ -32,6 +32,43 @@ defmodule Breeze.RemoteInspectorTest do
     end
   end
 
+  defmodule SelectCaptureServer do
+    use GenServer
+
+    def start_link(parent) do
+      GenServer.start_link(__MODULE__, parent)
+    end
+
+    def init(parent), do: {:ok, parent}
+
+    def handle_cast({:select_inspector, id}, parent) do
+      send(parent, {:selected_inspector, id})
+      {:noreply, parent}
+    end
+
+    def handle_call({:inspector_render_tree, opts}, _from, parent) do
+      send(parent, {:inspector_render_tree, opts})
+      kind = Keyword.get(opts, :kind, :rendered)
+      child_label = if kind == :code, do: "<Breeze.Blocks.input#child>", else: "<box#child>"
+
+      {:reply,
+       %{
+         kind: kind,
+         nodes: [
+           %{
+             id: "root",
+             label: "<box#root>",
+             children: [%{id: "child", label: child_label, children: []}]
+           }
+         ],
+         selected_id: Keyword.get(opts, :selected_id),
+         expanded: Keyword.get(opts, :expanded, []),
+         limit: Keyword.get(opts, :limit),
+         truncated?: false
+       }, parent}
+    end
+  end
+
   test "remote inspector view renders rich snapshot details" do
     theme =
       Breeze.Theme.new(%{
@@ -50,6 +87,42 @@ defmodule Breeze.RemoteInspectorTest do
       last_interaction_at: 456,
       theme: theme,
       source: %{node: :app@host, server_pid: self(), view_pid: self()},
+      render_tree: %{
+        id: "root",
+        label: "<box#root.panel>",
+        children: [
+          %{
+            id: "url",
+            label: "<box#url.input> Breeze.Blocks.input",
+            label_parts: [
+              %{text: "<", token: :punctuation},
+              %{text: "box", token: :tag},
+              %{text: "#url", token: :id},
+              %{text: ".input", token: :class},
+              %{text: ".text-primary", token: :class},
+              %{
+                text: "●",
+                token: :swatch,
+                role: :foreground,
+                foreground_color: {1, 2, 3},
+                background_color: nil
+              },
+              %{text: ".bg-panel", token: :class},
+              %{
+                text: "●",
+                token: :swatch,
+                role: :background,
+                foreground_color: {4, 5, 6},
+                background_color: nil
+              },
+              %{text: ">", token: :punctuation},
+              %{text: " Breeze.Blocks.input", token: :component}
+            ],
+            children: []
+          },
+          %{id: "method", label: "<box#method>", children: []}
+        ]
+      },
       counts: %{elements: 12, focusables: 3, mouse_targets: 9, children: 1},
       focus: %{active_scope: "modal", focusables: ["url"], focus_memory: %{__root__: "url"}},
       selected_id: "url",
@@ -153,6 +226,25 @@ defmodule Breeze.RemoteInspectorTest do
         terminal: %Termite.Terminal{size: %{width: 80, height: 40}}
       )
 
+    tree_output =
+      Breeze.Renderer.render_to_string(
+        Breeze.RemoteInspector.View,
+        %{
+          snapshots: %{
+            {:app@host, "#PID<0.1.0>"} => %{
+              source: %{node: :app@host, pid: self()},
+              snapshot: snapshot,
+              updated_at: 1_000
+            }
+          },
+          latest_source: {:app@host, "#PID<0.1.0>"},
+          panel_tab: "tree",
+          screen: %{width: 140, height: 32}
+        },
+        theme: true,
+        terminal: %Termite.Terminal{size: %{width: 140, height: 40}}
+      )
+
     assert output =~ "Remote Inspector"
     assert output =~ "theme=demo mode=custom dark=true"
     assert output =~ "counts=elements=12 focusables=3"
@@ -185,12 +277,28 @@ defmodule Breeze.RemoteInspectorTest do
     assert theme_output =~ "foreground_color #010203"
     assert theme_output =~ "border_color"
     assert theme_output =~ "7"
+    assert tree_output =~ "Tree"
+    assert tree_output =~ "<box#root.panel>"
+
+    stripped_tree_output = Regex.replace(~r/\e\[[0-9;]*m/, tree_output, "")
+
+    assert stripped_tree_output =~ "<box#url.input.text-primary●.bg-panel●> Breeze.Blocks.input"
+    assert tree_output =~ "●"
+    assert tree_output =~ "38;2;1;2;3"
+    assert tree_output =~ "38;2;4;5;6"
   end
 
   test "remote inspector tab changes accept implicit tab payloads" do
     term = %Breeze.Term{
       view: Breeze.RemoteInspector.View,
-      assigns: %{panel_tab: "overview"}
+      assigns: %{
+        panel_tab: "overview",
+        snapshots: %{},
+        latest_source: nil,
+        active_source: nil,
+        render_tree_expanded: %{},
+        render_trees: %{}
+      }
     }
 
     assert {:noreply, %{assigns: %{panel_tab: "layout"}}} =
@@ -200,12 +308,184 @@ defmodule Breeze.RemoteInspectorTest do
                term
              )
 
+    assert {:noreply, %{assigns: %{panel_tab: "tree"}, local_keybindings: tree_keybindings}} =
+             Breeze.RemoteInspector.View.handle_event(
+               "tab_changed",
+               %{value: "tree"},
+               term
+             )
+
+    assert [%{key: "t", label: "Code tree"}] = Breeze.Keybindings.visible(tree_keybindings)
+
     assert {:noreply, %{assigns: %{panel_tab: "focus"}}} =
              Breeze.RemoteInspector.View.handle_event(
                "tab_changed",
                %{"value" => "focus"},
                term
              )
+
+    assert {:noreply, %{assigns: %{panel_tab: "layout"}, local_keybindings: []}} =
+             Breeze.RemoteInspector.View.handle_event(
+               "tab_changed",
+               %{"value" => "layout"},
+               %{term | local_keybindings: tree_keybindings}
+             )
+  end
+
+  test "remote inspector render tree selection updates expansion and delegates selection" do
+    {:ok, source_pid} = SelectCaptureServer.start_link(self())
+
+    on_exit(fn ->
+      if Process.alive?(source_pid), do: GenServer.stop(source_pid)
+    end)
+
+    key = {:app@host, inspect(source_pid)}
+
+    term = %Breeze.Term{
+      view: Breeze.RemoteInspector.View,
+      assigns: %{
+        snapshots: %{
+          key => %{
+            source: %{node: :app@host, pid: source_pid},
+            snapshot: %{
+              source: %{node: :app@host, server_pid: source_pid, view_pid: source_pid},
+              selected_id: "root",
+              render_tree: %{
+                id: "root",
+                label: "<box#root>",
+                children: [%{id: "child", label: "<box#child>", children: []}]
+              }
+            },
+            updated_at: 1,
+            alive?: true
+          }
+        },
+        latest_source: key,
+        active_source: key,
+        render_tree_expanded: %{},
+        render_trees: %{}
+      }
+    }
+
+    assert {:noreply, term} =
+             Breeze.RemoteInspector.View.handle_event(
+               "render_tree_changed",
+               %{value: "child", expanded: ["root"]},
+               term
+             )
+
+    assert term.assigns.render_tree_expanded[key] == ["root"]
+    assert term.assigns.render_trees[key].selected_id == "child"
+    assert_receive {:selected_inspector, "child"}, 500
+    assert_receive {:inspector_render_tree, opts}, 500
+    assert Keyword.get(opts, :selected_id) == "child"
+    assert Keyword.get(opts, :expanded) == ["root"]
+    assert Keyword.get(opts, :kind) == :rendered
+  end
+
+  test "remote inspector t key toggles the tree between rendered and code modes" do
+    {:ok, source_pid} = SelectCaptureServer.start_link(self())
+
+    on_exit(fn ->
+      if Process.alive?(source_pid), do: GenServer.stop(source_pid)
+    end)
+
+    key = {:app@host, inspect(source_pid)}
+
+    term = %Breeze.Term{
+      view: Breeze.RemoteInspector.View,
+      assigns: %{
+        snapshots: %{
+          key => %{
+            source: %{node: :app@host, pid: source_pid},
+            snapshot: %{
+              source: %{node: :app@host, server_pid: source_pid, view_pid: source_pid},
+              selected_id: "child",
+              render_tree?: true
+            },
+            updated_at: 1,
+            alive?: true
+          }
+        },
+        latest_source: key,
+        active_source: key,
+        panel_tab: "tree",
+        render_tree_kind: "rendered",
+        render_tree_expanded: %{key => ["root"]},
+        render_trees: %{}
+      }
+    }
+
+    assert {:noreply, term} =
+             Breeze.RemoteInspector.View.handle_event(:ignored, %{"key" => "t"}, term)
+
+    assert term.assigns.panel_tab == "tree"
+    assert term.assigns.render_tree_kind == "code"
+
+    assert %{kind: :code, selected_id: "child", nodes: [%{children: [child]}]} =
+             term.assigns.render_trees[{key, "code"}]
+
+    assert child.label == "<Breeze.Blocks.input#child>"
+
+    assert_receive {:inspector_render_tree, opts}, 500
+    assert Keyword.get(opts, :kind) == :code
+    assert Keyword.get(opts, :selected_id) == "child"
+  end
+
+  test "remote inspector render tree scroll changes stay local" do
+    {:ok, source_pid} = SelectCaptureServer.start_link(self())
+
+    on_exit(fn ->
+      if Process.alive?(source_pid), do: GenServer.stop(source_pid)
+    end)
+
+    key = {:app@host, inspect(source_pid)}
+
+    term = %Breeze.Term{
+      view: Breeze.RemoteInspector.View,
+      assigns: %{
+        snapshots: %{
+          key => %{
+            source: %{node: :app@host, pid: source_pid},
+            snapshot: %{
+              source: %{node: :app@host, server_pid: source_pid, view_pid: source_pid},
+              selected_id: "child",
+              render_tree?: true
+            },
+            updated_at: 1,
+            alive?: true
+          }
+        },
+        latest_source: key,
+        active_source: key,
+        render_tree_expanded: %{key => ["root"]},
+        render_trees: %{
+          key => %{
+            nodes: [
+              %{
+                id: "root",
+                label: "<box#root>",
+                children: [%{id: "child", label: "<box#child>", children: []}]
+              }
+            ],
+            selected_id: "child",
+            expanded: ["root"],
+            limit: 600,
+            truncated?: false
+          }
+        }
+      }
+    }
+
+    assert {:noreply, ^term} =
+             Breeze.RemoteInspector.View.handle_event(
+               "render_tree_changed",
+               %{value: "child", expanded: ["root"], offset: 12},
+               term
+             )
+
+    refute_receive {:selected_inspector, _id}, 50
+    refute_receive {:inspector_render_tree, _opts}, 50
   end
 
   test "remote inspector follows the newest live source after a disconnect and reconnect" do

--- a/test/mix/tasks/breeze_inspector_task_test.exs
+++ b/test/mix/tasks/breeze_inspector_task_test.exs
@@ -1,12 +1,14 @@
 defmodule Mix.Tasks.BreezeInspectorTaskTest do
   use ExUnit.Case, async: true
 
-  test "run opts enable reload and disable nested inspector" do
+  test "run opts enable reload and remote inspector self-inspection" do
     assert Mix.Tasks.Breeze.Inspector.run_opts() == [
              view: Breeze.RemoteInspector.View,
              reload: true,
+             theme: :system,
              mouse: true,
-             inspector: false
+             global_keybindings: Breeze.RemoteInspector.View.global_keybindings(),
+             inspector: true
            ]
   end
 


### PR DESCRIPTION
Adds a Tree tab to the remote inspector for browsing rendered and code render trees, tracks tree selection and expansion locally, and delegates remote element selection through the inspector server API. Also records render tree metadata during rendering and expands inspector coverage.