### PR TITLE
feat(Breeze.Inspector): try to start distributed erlang on launch

### DIFF
--- a/examples/remote_inspector.exs
+++ b/examples/remote_inspector.exs
@@ -1,3 +1,4 @@
+_ = Breeze.RemoteInspector.ensure_inspector_distribution()
 {:ok, _pid} = Breeze.RemoteInspector.ensure_server()
 
 Breeze.Example.run(

--- a/lib/breeze/remote_inspector.ex
+++ b/lib/breeze/remote_inspector.ex
@@ -31,6 +31,52 @@ defmodule Breeze.RemoteInspector do
     end
   end
 
+  def ensure_app_distribution(opts \\ []) do
+    opts
+    |> Keyword.put_new_lazy(:name, fn -> default_distribution_name(:app, opts) end)
+    |> ensure_distribution()
+  end
+
+  def ensure_inspector_distribution(opts \\ []) do
+    opts
+    |> Keyword.put_new(:name, :inspector)
+    |> ensure_distribution()
+  end
+
+  def ensure_distribution(opts) when is_list(opts) do
+    if Node.alive?() do
+      :ok
+    else
+      name = opts |> Keyword.fetch!(:name) |> normalize_distribution_name()
+      type = Keyword.get(opts, :type, Keyword.get(opts, :name_type, :shortnames))
+      key = {__MODULE__, :distribution_attempt, name, type}
+
+      case Process.get(key) do
+        nil ->
+          result = start_distribution(name, type)
+          unless result == :ok, do: Process.put(key, result)
+          result
+
+        result ->
+          result
+      end
+    end
+  end
+
+  def default_distribution_name(role, opts \\ [])
+
+  def default_distribution_name(:inspector, _opts), do: :inspector
+
+  def default_distribution_name(:app, opts) do
+    opts
+    |> Keyword.get(:view)
+    |> application_for_module()
+    |> case do
+      app when is_atom(app) and not is_nil(app) -> app
+      _ -> :app
+    end
+  end
+
   def register_app(pid) when is_pid(pid) do
     ensure_registry_started()
     :pg.join(@app_group, pid)
@@ -61,6 +107,8 @@ defmodule Breeze.RemoteInspector do
   def publish(%{enabled?: false}), do: :ok
 
   def publish(snapshot) when is_map(snapshot) do
+    _ = ensure_app_distribution(view: Map.get(snapshot, :root_view))
+
     case ensure_remote_server_pid() do
       pid when is_pid(pid) ->
         Server.publish(pid, self(), snapshot)
@@ -122,6 +170,22 @@ defmodule Breeze.RemoteInspector do
   end
 
   defp default_inspector_node(_current_node), do: nil
+
+  defp application_for_module(module) when is_atom(module),
+    do: Application.get_application(module)
+
+  defp application_for_module(_module), do: nil
+
+  defp normalize_distribution_name(name) when is_atom(name), do: name
+  defp normalize_distribution_name(name) when is_binary(name), do: String.to_atom(name)
+
+  defp start_distribution(name, type) do
+    case Node.start(name, type) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+      {:error, _reason} = error -> error
+    end
+  end
 
   def ensure_registry_started do
     case Process.whereis(:pg) do

--- a/lib/breeze/remote_inspector/view.ex
+++ b/lib/breeze/remote_inspector/view.ex
@@ -17,6 +17,7 @@ defmodule Breeze.RemoteInspector.View do
   def quit(_event, term), do: {:stop, term}
 
   def mount(_opts, term) do
+    _ = Breeze.RemoteInspector.ensure_inspector_distribution()
     {:ok, _pid} = Breeze.RemoteInspector.ensure_server()
     :ok = Breeze.RemoteInspector.subscribe(self())
     state = Breeze.RemoteInspector.snapshot()

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -164,6 +164,10 @@ defmodule Breeze.Server do
     apply_theme_defaults? = Breeze.Theme.defaults_enabled?(Keyword.get(opts, :theme))
     inspector_enabled? = inspector_enabled?(Keyword.get(opts, :inspector, false))
 
+    if inspector_enabled? do
+      _ = Breeze.RemoteInspector.ensure_app_distribution(view: view)
+    end
+
     session = self()
 
     {:ok, view_pid} =

--- a/lib/mix/tasks/breeze.inspector.ex
+++ b/lib/mix/tasks/breeze.inspector.ex
@@ -8,11 +8,7 @@ defmodule Mix.Tasks.Breeze.Inspector do
   def run(args) do
     Mix.Task.run("app.start")
 
-    unless Node.alive?() do
-      Mix.raise(
-        "breeze.inspector requires distributed Erlang. Start with --sname or --name, for example: elixir --sname inspector -S mix breeze.inspector"
-      )
-    end
+    ensure_distribution!()
 
     {opts, positional, _invalid} = OptionParser.parse(args, strict: @switches)
     maybe_connect_target(Keyword.get(opts, :connect) || List.first(positional))
@@ -46,6 +42,23 @@ defmodule Mix.Tasks.Breeze.Inspector do
     String.to_atom(target)
   end
 
+  def distribution_error_message(reason) do
+    if distribution_epmd_unavailable?(reason) do
+      """
+      breeze.inspector could not start distributed Erlang because epmd appears to be unavailable.
+
+      Start epmd, then run `mix breeze.inspector` again:
+
+          epmd -daemon
+
+      You may also need to restart your application so it can start distributed Erlang.
+      """
+      |> String.trim()
+    else
+      "breeze.inspector could not start distributed Erlang as inspector: #{inspect(reason)}"
+    end
+  end
+
   defp maybe_connect_target(nil), do: :ok
 
   defp maybe_connect_target(target) do
@@ -63,6 +76,36 @@ defmodule Mix.Tasks.Breeze.Inspector do
         Mix.raise("Connection to #{node_name} was ignored")
     end
   end
+
+  defp ensure_distribution! do
+    case Breeze.RemoteInspector.ensure_inspector_distribution() do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Mix.raise(distribution_error_message(reason))
+    end
+  end
+
+  defp distribution_epmd_unavailable?(reason) do
+    term_contains?(reason, :nodistribution)
+  end
+
+  defp term_contains?(term, value) when term == value, do: true
+
+  defp term_contains?(term, value) when is_tuple(term),
+    do: term |> Tuple.to_list() |> Enum.any?(&term_contains?(&1, value))
+
+  defp term_contains?(term, value) when is_list(term),
+    do: Enum.any?(term, &term_contains?(&1, value))
+
+  defp term_contains?(term, value) when is_map(term) do
+    Enum.any?(term, fn {key, item} ->
+      term_contains?(key, value) or term_contains?(item, value)
+    end)
+  end
+
+  defp term_contains?(_term, _value), do: false
 
   defp current_host do
     case String.split(to_string(node()), "@", parts: 2) do

--- a/test/breeze/remote_inspector_test.exs
+++ b/test/breeze/remote_inspector_test.exs
@@ -550,6 +550,15 @@ defmodule Breeze.RemoteInspectorTest do
     refute Breeze.RemoteInspector.available?()
   end
 
+  test "distribution names default for apps and the remote inspector" do
+    assert Breeze.RemoteInspector.default_distribution_name(:inspector) == :inspector
+    assert Breeze.RemoteInspector.default_distribution_name(:app, []) == :app
+
+    assert Breeze.RemoteInspector.default_distribution_name(:app,
+             view: Breeze.RemoteInspector.View
+           ) == :breeze
+  end
+
   test "publishing to the local server updates subscribers" do
     {:ok, pid} = Breeze.RemoteInspector.ensure_server()
     :ok = Breeze.RemoteInspector.subscribe(self())

--- a/test/mix/tasks/breeze_inspector_task_test.exs
+++ b/test/mix/tasks/breeze_inspector_task_test.exs
@@ -12,6 +12,35 @@ defmodule Mix.Tasks.BreezeInspectorTaskTest do
            ]
   end
 
+  test "distribution error message prompts user to start epmd for nodistribution" do
+    reason =
+      {{:shutdown, {:failed_to_start_child, :net_kernel, {:EXIT, :nodistribution}}},
+       {:child, :undefined, :net_sup_dynamic,
+        {:erl_distribution, :start_link,
+         [
+           %{
+             name: :inspector,
+             supervisor: :net_sup_dynamic,
+             net_tickintensity: 4,
+             net_ticktime: 60,
+             name_domain: :shortnames,
+             clean_halt: false
+           }
+         ]}, :permanent, false, 1000, :supervisor, [:erl_distribution]}}
+
+    message = Mix.Tasks.Breeze.Inspector.distribution_error_message(reason)
+
+    assert message =~ "epmd appears to be unavailable"
+    assert message =~ "epmd -daemon"
+    assert message =~ "mix breeze.inspector"
+    assert message =~ "restart your application"
+  end
+
+  test "distribution error message preserves unexpected reasons" do
+    assert Mix.Tasks.Breeze.Inspector.distribution_error_message(:some_other_reason) ==
+             "breeze.inspector could not start distributed Erlang as inspector: :some_other_reason"
+  end
+
   test "normalize_connect_target keeps explicit host" do
     assert Mix.Tasks.Breeze.Inspector.normalize_connect_target("app@host.example") ==
              :"app@host.example"


### PR DESCRIPTION
When launching the remote inspector, we attempt to start distributed erlang using short names. This allows running an application with `mix` and running `mix breeze.inspector` without explicitly setting names on the nodes.