### PR TITLE
fix(Breeze.ChildServer): route preview mouse events through live children

### DIFF
--- a/examples/list_view.exs
+++ b/examples/list_view.exs
@@ -34,6 +34,7 @@ end
 Breeze.Example.run(
   [
     view: ListViewDemo,
+    mouse: true,
     global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
   ],
   keep_alive: :infinity

--- a/examples/mouse.exs
+++ b/examples/mouse.exs
@@ -1,71 +1,151 @@
 defmodule MouseExample do
   use Breeze.View
 
+  @max_events 16
+
   def mount(_opts, term) do
     term =
       term
-      |> assign(clicks: 0, last_mouse: "none")
+      |> assign(
+        clicks: 0,
+        wheel_up: 0,
+        wheel_down: 0,
+        event_seq: 0,
+        last_event_at: nil,
+        events: []
+      )
       |> focus("left-panel")
 
     {:ok, term}
   end
 
   def render(assigns) do
+    assigns =
+      assign(assigns,
+        last_mouse:
+          case List.first(assigns.events) do
+            nil -> "none"
+            event -> event.summary
+          end
+      )
+
     ~H"""
-    <box style="width-screen height-screen">
+    <box style="width-screen height-screen padding-left-1 padding-top-1">
       <box style="bold">Mouse example</box>
-      <box>Left click either panel to focus it. Press q to quit.</box>
+      <box>Left click either panel to focus it. Scroll over a panel to inspect wheel events.</box>
+      <box>Press c to clear, q to quit.</box>
       <box>Last mouse event: {@last_mouse}</box>
-      <box>Click count: {@clicks}</box>
+      <box>Clicks: {@clicks}  Wheel up: {@wheel_up}  Wheel down: {@wheel_down}</box>
       <box>
       </box>
       <box style="inline">
         <box id="left-panel" focusable style="border-rounded width-24 height-6 focus:border-4">
           <box style="bold">Left panel</box>
           <box>Expected target: left-panel</box>
+          <box>Wheel here</box>
         </box>
         <box>
         </box>
         <box id="right-panel" focusable style="border-rounded width-24 height-6 focus:border-4">
           <box style="bold">Right panel</box>
           <box>Expected target: right-panel</box>
+          <box>Wheel here</box>
         </box>
+      </box>
+      <box>
+      </box>
+      <box style="bold">Recent events</box>
+      <box style="text-muted">
+        #    dt   button/action       x,y      row,col  target       repeat  modifiers
+      </box>
+      <box :for={event <- @events} style="inline width-full overflow-hidden">
+        <box style="width-5">{event.seq}</box>
+        <box style="width-5">{event.dt}</box>
+        <box style="width-20">{event.button_action}</box>
+        <box style="width-9">{event.xy}</box>
+        <box style="width-9">{event.row_col}</box>
+        <box style="width-13">{event.target}</box>
+        <box style="width-8">{event.repeat}</box>
+        <box>{event.modifiers}</box>
       </box>
     </box>
     """
   end
 
-  def handle_event(
-        _,
-        %{"mouse" => %{button: :left, action: :press} = mouse, "target" => target},
-        term
-      ) do
-    summary =
-      "#{mouse.button}/#{mouse.action} x=#{mouse.x} y=#{mouse.y} target=#{target}"
-
+  def handle_event(_, %{"key" => "c"}, term) do
     {:noreply,
      assign(term,
-       clicks: term.assigns.clicks + 1,
-       last_mouse: summary
+       clicks: 0,
+       wheel_up: 0,
+       wheel_down: 0,
+       event_seq: 0,
+       last_event_at: nil,
+       events: []
      )}
   end
 
-  def handle_event(_, %{"mouse" => mouse, "target" => target}, term) do
-    summary = "#{mouse.button}/#{mouse.action} x=#{mouse.x} y=#{mouse.y} target=#{target}"
-    {:noreply, assign(term, last_mouse: summary)}
-  end
+  def handle_event(_, %{"mouse" => mouse} = event, term),
+    do: {:noreply, record_mouse_event(term, event, mouse)}
 
-  def handle_event(_, %{"mouse" => mouse}, term) do
-    summary = "#{mouse.button}/#{mouse.action} x=#{mouse.x} y=#{mouse.y} target=none"
-    {:noreply, assign(term, last_mouse: summary)}
-  end
+  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
 
   def handle_event(_, _, term), do: {:noreply, term}
+
+  defp record_mouse_event(term, event, mouse) do
+    now = System.monotonic_time(:millisecond)
+    dt = event_delta(term.assigns.last_event_at, now)
+    seq = term.assigns.event_seq + 1
+    target = Map.get(event, "target", "none")
+    repeat = Map.get(mouse, :repeat, 1)
+
+    entry = %{
+      seq: pad(seq, 4),
+      dt: pad(dt, 4),
+      button_action: "#{mouse.button}/#{mouse.action}",
+      xy: "#{mouse.x},#{mouse.y}",
+      row_col: "#{Map.get(event, "row", "-")},#{Map.get(event, "col", "-")}",
+      target: target,
+      repeat: to_string(repeat),
+      modifiers: mouse.modifiers |> Enum.map_join("+", &to_string/1) |> blank_dash(),
+      summary:
+        "##{seq} +#{dt}ms #{mouse.button}/#{mouse.action} x=#{mouse.x} y=#{mouse.y} target=#{target} repeat=#{repeat}"
+    }
+
+    term
+    |> update_mouse_counts(mouse)
+    |> assign(
+      event_seq: seq,
+      last_event_at: now,
+      events: Enum.take([entry | term.assigns.events], @max_events)
+    )
+  end
+
+  defp update_mouse_counts(term, %{button: :left, action: :press}) do
+    assign(term, clicks: term.assigns.clicks + 1)
+  end
+
+  defp update_mouse_counts(term, %{button: :wheel_up}) do
+    assign(term, wheel_up: term.assigns.wheel_up + 1)
+  end
+
+  defp update_mouse_counts(term, %{button: :wheel_down}) do
+    assign(term, wheel_down: term.assigns.wheel_down + 1)
+  end
+
+  defp update_mouse_counts(term, _mouse), do: term
+
+  defp event_delta(nil, _now), do: 0
+  defp event_delta(last, now), do: max(now - last, 0)
+
+  defp pad(value, width), do: value |> to_string() |> String.pad_leading(width)
+
+  defp blank_dash(""), do: "-"
+  defp blank_dash(value), do: value
 end
 
 Breeze.Example.run(
   view: MouseExample,
   hide_cursor: true,
   mouse: true,
-  global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+  global_keybindings: [{"q", "Quit", fn _event, term -> {:stop, term} end}]
 )

--- a/examples/storybook.exs
+++ b/examples/storybook.exs
@@ -8,6 +8,7 @@ Breeze.Example.run(
     start_opts: [directory: "storybook"],
     theme: Breeze.Theme.builtin(:gruvbox),
     hide_cursor: true,
+    mouse: true,
     reload: true,
     inspector: true,
     global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]

--- a/lib/breeze/child_server.ex
+++ b/lib/breeze/child_server.ex
@@ -780,31 +780,47 @@ defmodule Breeze.ChildServer do
     end
   end
 
-  defp process_input(%{"mouse" => mouse} = event, term, _opts) do
+  defp process_input(%{"mouse" => mouse} = event, term, opts) do
     case mouse_target(term, mouse) do
       nil ->
         handle_view_event(term.view, :ignore_me, event, term)
 
       target ->
-        term =
-          if focus_mouse_target?(target, mouse, term) do
-            %{term | focused: target}
-          else
-            term
-          end
+        event = put_mouse_target_fields(term, target, event)
+        live_children = Keyword.get(opts, :live_children, term.children)
 
-        event =
-          event
-          |> Map.put("target", target)
-          |> Map.put("row", mouse_row(term, target, mouse))
-          |> Map.put("col", mouse_col(term, target, mouse))
+        case dispatch_live_mouse_target(term, target, event, live_children) do
+          {:ok, reply} ->
+            reply
 
-        handle_event(:ignore_me, event, term, target)
+          :bubble ->
+            normalize_result(term.view.handle_event(:ignore_me, event, term), term)
+
+          :not_live ->
+            dispatch_mouse_target(event, mouse, target, term)
+        end
     end
   end
 
   defp process_input(key, term, opts) do
     dispatch_key_input(key, term, opts)
+  end
+
+  defp dispatch_mouse_target(event, mouse, target, term) do
+    term =
+      case mouse_focus_target(target, mouse, term) do
+        nil -> term
+        focused -> %{term | focused: focused}
+      end
+
+    handle_event(:ignore_me, event, term, target)
+  end
+
+  defp put_mouse_target_fields(term, target, %{"mouse" => mouse} = event) do
+    event
+    |> Map.put("target", target)
+    |> Map.put("row", mouse_row(term, target, mouse))
+    |> Map.put("col", mouse_col(term, target, mouse))
   end
 
   defp dispatch_key_input(key, term, opts) do
@@ -1232,6 +1248,93 @@ defmodule Breeze.ChildServer do
   defp namespace_child_focus(nil, _child_id), do: nil
   defp namespace_child_focus(focused, child_id), do: child_id <> "::" <> focused
 
+  defp dispatch_live_mouse_target(term, target, event, live_children) do
+    case live_child_for_target(live_children, target) do
+      nil ->
+        :not_live
+
+      {child_id, %{pid: pid}} when is_pid(pid) ->
+        reply =
+          pid
+          |> Breeze.ChildServer.dispatch_input(
+            translate_mouse_event_for_child(term, child_id, event)
+          )
+          |> namespace_mouse_child_reply(child_id, term.focused, live_mouse_focus_event?(event))
+
+        case reply do
+          {:noreply, _focused, true} -> {:ok, reply}
+          {:stop, _focused, _consumed} -> {:ok, reply}
+          _ -> :bubble
+        end
+    end
+  end
+
+  defp live_child_for_target(children, target) when is_map(children) and is_binary(target) do
+    children
+    |> Enum.filter(fn {id, _child} ->
+      target == id or String.starts_with?(target, id <> "::")
+    end)
+    |> Enum.max_by(fn {id, _child} -> String.length(id) end, fn -> nil end)
+  end
+
+  defp live_child_for_target(_children, _target), do: nil
+
+  defp namespace_mouse_child_reply({kind, focused}, child_id, current_focused, focus_event?)
+       when kind in [:noreply, :stop] do
+    {kind, mouse_child_focus(focused, child_id, current_focused, focus_event?)}
+  end
+
+  defp namespace_mouse_child_reply(
+         {kind, focused, consumed},
+         child_id,
+         current_focused,
+         focus_event?
+       )
+       when kind in [:noreply, :stop] do
+    {kind, mouse_child_focus(focused, child_id, current_focused, focus_event?), consumed}
+  end
+
+  defp mouse_child_focus(focused, child_id, current_focused, true),
+    do: namespace_child_focus(focused, child_id) || current_focused
+
+  defp mouse_child_focus(_focused, _child_id, current_focused, false), do: current_focused
+
+  defp live_mouse_focus_event?(%{"mouse" => %{button: :left, action: :press}}), do: true
+  defp live_mouse_focus_event?(_event), do: false
+
+  defp translate_mouse_event_for_child(term, child_id, %{"mouse" => mouse} = event) do
+    case live_child_origin(term, child_id) do
+      %{left: left, top: top} ->
+        mouse =
+          mouse
+          |> Map.put(:x, max(mouse.x - left, 1))
+          |> Map.put(:y, max(mouse.y - top, 1))
+
+        event
+        |> Map.put("mouse", mouse)
+        |> Map.drop(["target", "row", "col"])
+
+      nil ->
+        Map.drop(event, ["target", "row", "col"])
+    end
+  end
+
+  defp live_child_origin(term, child_id) do
+    cond do
+      match?(%Breeze.Viewport{}, Map.get(term.elements, child_id)) ->
+        Map.fetch!(term.elements, child_id)
+
+      match?(%Breeze.Viewport{}, Map.get(term.retained_elements, child_id)) ->
+        Map.fetch!(term.retained_elements, child_id)
+
+      is_map(Map.get(term.mouse_targets, child_id)) ->
+        Map.take(Map.fetch!(term.mouse_targets, child_id), [:left, :top])
+
+      true ->
+        nil
+    end
+  end
+
   defp strip_live_prefix(nil, _live_id), do: nil
 
   defp strip_live_prefix(id, live_id) do
@@ -1597,6 +1700,7 @@ defmodule Breeze.ChildServer do
     y = y - 1
 
     term.mouse_targets
+    |> Enum.map(fn {id, bounds} -> {id, mouse_target_bounds(term, bounds)} end)
     |> Enum.filter(fn {_id, bounds} ->
       is_integer(bounds[:left]) and is_integer(bounds[:right]) and is_integer(bounds[:top]) and
         is_integer(bounds[:bottom]) and x >= bounds.left and x <= bounds.right and
@@ -1612,6 +1716,63 @@ defmodule Breeze.ChildServer do
       nil -> nil
     end
   end
+
+  defp mouse_target_bounds(term, bounds) when is_map(bounds) do
+    bounds
+    |> expand_full_mouse_axis(
+      :width,
+      :content_width,
+      :viewport_width,
+      :left,
+      :right,
+      term_width(term)
+    )
+    |> expand_full_mouse_axis(
+      :height,
+      :content_height,
+      :viewport_height,
+      :top,
+      :bottom,
+      term_height(term)
+    )
+  end
+
+  defp mouse_target_bounds(_term, bounds), do: bounds
+
+  defp expand_full_mouse_axis(
+         bounds,
+         axis,
+         content_axis,
+         viewport_axis,
+         start_axis,
+         end_axis,
+         size
+       ) do
+    start = Map.get(bounds, start_axis)
+
+    if full_mouse_dimension?(bounds, axis, content_axis, viewport_axis) and is_integer(size) and
+         is_integer(start) do
+      extent = max(size - start, 0)
+
+      bounds
+      |> Map.put(axis, extent)
+      |> Map.put(end_axis, start + max(extent - 1, 0))
+    else
+      bounds
+    end
+  end
+
+  defp full_mouse_dimension?(bounds, axis, content_axis, viewport_axis) do
+    Map.get(bounds, axis) in [:full, :screen] or
+      Map.get(bounds, content_axis) in [:full, :screen] or
+      Map.get(bounds, viewport_axis) in [:full, :screen]
+  end
+
+  defp term_width(%{terminal: %Termite.Terminal{size: %{width: width}}}), do: width
+  defp term_width(_term), do: nil
+
+  defp term_height(%{terminal: %Termite.Terminal{size: %{height: height}}}), do: height
+  defp term_height(_term), do: nil
 
   defp mouse_row(term, target, %{y: y}) do
     bounds = Map.fetch!(term.mouse_targets, target)
@@ -1633,11 +1794,20 @@ defmodule Breeze.ChildServer do
 
   defp border_inset(_, _side), do: 0
 
-  defp focus_mouse_target?(target, %{button: :left, action: :press}, term) do
-    target in term.focusables
+  defp mouse_focus_target(target, %{button: :left, action: :press}, term) do
+    cond do
+      target in term.focusables ->
+        target
+
+      owner = get_in(term.focus_meta, [target, :implicit_owner]) ->
+        if owner in term.focusables, do: owner
+
+      true ->
+        nil
+    end
   end
 
-  defp focus_mouse_target?(_target, _mouse, _term), do: false
+  defp mouse_focus_target(_target, _mouse, _term), do: nil
 
   defp profile_label(term, opts) do
     case Keyword.get(opts, :live_prefix) do

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -794,7 +794,9 @@ defmodule Breeze.Server do
     state
     |> touch_interaction()
     |> safe_apply_input_reply(fn state ->
-      Breeze.ChildServer.dispatch_input(state.view_pid, %{"mouse" => event})
+      Breeze.ChildServer.dispatch_input(state.view_pid, %{"mouse" => event},
+        live_children: state.children
+      )
     end)
   end
 

--- a/test/breeze/child_server_test.exs
+++ b/test/breeze/child_server_test.exs
@@ -64,6 +64,24 @@ defmodule Breeze.ChildServerTest do
     def handle_event(_, _, term), do: {:noreply, term}
   end
 
+  defmodule FullWidthMouseTargetView do
+    use Breeze.View
+
+    def mount(_opts, term), do: {:ok, assign(term, last_target: "none")}
+
+    def render(assigns) do
+      ~H"""
+      <box id="full" focusable style="width-full height-3 border">{@last_target}</box>
+      """
+    end
+
+    def handle_event(_, %{"target" => target}, term) do
+      {:noreply, assign(term, last_target: target)}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+  end
+
   defmodule KeybindingView do
     use Breeze.View
 
@@ -158,6 +176,21 @@ defmodule Breeze.ChildServerTest do
 
     assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, terminal: terminal)
     assert box.content =~ "right"
+  end
+
+  test "mouse targets with full width use the rendered terminal width" do
+    terminal = %Termite.Terminal{size: %{width: 20, height: 5}}
+    {:ok, pid} = Breeze.ChildServer.start(view: FullWidthMouseTargetView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
+
+    assert {:noreply, "full", true} =
+             Breeze.ChildServer.dispatch_input(pid, %{
+               "mouse" => %{button: :left, action: :press, x: 12, y: 2, modifiers: []}
+             })
+
+    assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, terminal: terminal)
+    assert box.content =~ "full"
   end
 
   test "metadata exposes active keybindings and local handlers dispatch before handle_event/3" do

--- a/test/breeze/implicit/tabs_test.exs
+++ b/test/breeze/implicit/tabs_test.exs
@@ -177,7 +177,7 @@ defmodule Breeze.Implicit.TabsTest do
       x = div(bounds.left + bounds.right, 2) + 1
       y = div(bounds.top + bounds.bottom, 2) + 1
 
-      assert {_status, _focused, _changed} =
+      assert {_status, "tabs", _changed} =
                Breeze.ChildServer.dispatch_input(pid, %{
                  "mouse" => %{button: :left, action: :press, x: x, y: y, modifiers: []}
                })
@@ -189,6 +189,7 @@ defmodule Breeze.Implicit.TabsTest do
                Breeze.ChildServer.metadata(pid)
 
       assert state.selected == "details"
+      assert Breeze.ChildServer.metadata(pid).focused == "tabs"
     end
   end
 end

--- a/test/breeze_storybook/view_test.exs
+++ b/test/breeze_storybook/view_test.exs
@@ -520,6 +520,77 @@ defmodule Breeze.Storybook.ViewTest do
     assert plain_content =~ " Muted  Accent "
   end
 
+  test "list story mouse wheel scrolls the preview list without changing selection" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+    {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
+
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
+    select_story!(pid, "list")
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
+
+    child = :sys.get_state(pid).children["storybook-preview"].pid
+
+    {Breeze.Implicit.List, before_list} =
+      :sys.get_state(child).implicit_state["storybook-list-muted"]
+
+    preview_bounds = Breeze.ChildServer.layout_snapshot(pid).mouse_targets["storybook-preview"]
+
+    assert {:noreply, "storybook-nav", true} =
+             Breeze.ChildServer.dispatch_input(pid, %{
+               "mouse" => %{
+                 button: :wheel_down,
+                 action: :press,
+                 x: preview_bounds.left + div(preview_bounds.width, 2) + 1,
+                 y: preview_bounds.top + 3,
+                 modifiers: []
+               }
+             })
+
+    {Breeze.Implicit.List, after_list} =
+      :sys.get_state(child).implicit_state["storybook-list-muted"]
+
+    {Breeze.Implicit.List, nav} = :sys.get_state(pid).implicit_state["storybook-nav"]
+
+    assert after_list.offset == before_list.offset + 1
+    assert after_list.selected == before_list.selected
+    assert after_list.selected_index == before_list.selected_index
+    assert nav.selected == "list"
+    assert :sys.get_state(pid).assigns.current_story_id == "list"
+    assert Breeze.ChildServer.metadata(pid).focused == "storybook-nav"
+  end
+
+  test "table story mouse wheel scrolls the preview table without changing selection" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+    {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
+
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
+    select_story!(pid, "table")
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
+
+    child = :sys.get_state(pid).children["storybook-preview"].pid
+    {Breeze.Implicit.List, before_table} = :sys.get_state(child).implicit_state["storybook-table"]
+    preview_bounds = Breeze.ChildServer.layout_snapshot(pid).mouse_targets["storybook-preview"]
+
+    assert {:noreply, "storybook-nav", true} =
+             Breeze.ChildServer.dispatch_input(pid, %{
+               "mouse" => %{
+                 button: :wheel_down,
+                 action: :press,
+                 x: preview_bounds.left + div(preview_bounds.width, 2) + 1,
+                 y: preview_bounds.top + 4,
+                 modifiers: []
+               }
+             })
+
+    {Breeze.Implicit.List, after_table} = :sys.get_state(child).implicit_state["storybook-table"]
+
+    assert after_table.offset == before_table.offset + 1
+    assert after_table.selected == before_table.selected
+    assert after_table.selected_index == before_table.selected_index
+    assert :sys.get_state(child).assigns.selected_city == "delhi"
+    assert :sys.get_state(pid).assigns.current_story_id == "table"
+  end
+
   test "Ctrl+Up and Ctrl+Down navigate stories regardless of current focus" do
     terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
     {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
@@ -741,6 +812,58 @@ defmodule Breeze.Storybook.ViewTest do
              Enum.to_list((viewport.top + 1)..(viewport.top + viewport.height))
   end
 
+  test "storybook server routes mouse clicks to tabs inside the preview" do
+    {terminal, pid} = start_storybook_server!("tabs.story.exs", mouse: true)
+    reader = terminal.reader
+
+    {preview_pid, viewport} = wait_for_preview_child(pid, "tabs")
+
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(preview_pid, terminal: terminal)
+    assert :sys.get_state(preview_pid).assigns.selected_tab == "headers"
+
+    body =
+      Breeze.ChildServer.layout_snapshot(preview_pid).mouse_targets["storybook-tabs-tab-body"]
+
+    send_mouse(pid, reader, 0, viewport.left + body.left + 1, viewport.top + body.top + 1)
+
+    wait_until(fn ->
+      :sys.get_state(preview_pid).assigns.selected_tab == "body"
+    end)
+
+    assert :sys.get_state(pid).focused == "storybook-preview::storybook-tabs"
+  end
+
+  test "storybook server routes mouse wheel to scrollable preview stories" do
+    for {file, story_id, implicit_id, state_key} <- [
+          {"list.story.exs", "list", "storybook-list-muted", :offset},
+          {"scroll.story.exs", "scroll", "storybook-scroll", :offset_y},
+          {"table.story.exs", "table", "storybook-table", :offset}
+        ] do
+      {terminal, pid} = start_storybook_server!(file, mouse: true)
+      reader = terminal.reader
+
+      {preview_pid, viewport} = wait_for_preview_child(pid, story_id)
+
+      assert {:ok, _acc, _box} = Breeze.ChildServer.render(preview_pid, terminal: terminal)
+
+      {_, before_state} = :sys.get_state(preview_pid).implicit_state[implicit_id]
+      target = Breeze.ChildServer.layout_snapshot(preview_pid).mouse_targets[implicit_id]
+
+      send_mouse(
+        pid,
+        reader,
+        65,
+        viewport.left + min(target.left + 2, target.right) + 1,
+        viewport.top + min(target.top + 1, target.bottom) + 1
+      )
+
+      wait_until(fn ->
+        {_, after_state} = :sys.get_state(preview_pid).implicit_state[implicit_id]
+        Map.fetch!(after_state, state_key) > Map.fetch!(before_state, state_key)
+      end)
+    end
+  end
+
   test "storybook preview child patches clear the full viewport height when the list selection changes" do
     {terminal, pid} = start_storybook_server!("list.story.exs")
 
@@ -830,19 +953,25 @@ defmodule Breeze.Storybook.ViewTest do
     end
   end
 
-  defp start_storybook_server!(file) do
+  defp start_storybook_server!(file, opts \\ []) do
     terminal = Termite.Terminal.start(adapter: RecordingAdapter, owner: self())
 
     {:ok, pid} =
-      Breeze.Server.start_app_link(
+      [
         view: Breeze.Storybook.View,
         terminal: terminal,
         start_opts: [directory: "storybook", file: file]
-      )
+      ]
+      |> Keyword.merge(opts)
+      |> Breeze.Server.start_app_link()
 
     on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid, :normal) end)
 
     {terminal, pid}
+  end
+
+  defp send_mouse(pid, reader, code, x, y) do
+    send(pid, {reader, {:data, "\e[<#{code};#{x};#{y}M"}})
   end
 
   defp wait_for_preview_child(pid, story_id) do


### PR DESCRIPTION
Forward mouse events from the server into matching live child views with translated coordinates, so Storybook preview controls respond to clicks and wheel events. Make mouse clicks focus the owning implicit control, which lets clicked tabs keep keyboard focus for follow-up arrow navigation. Enable mouse in the Storybook and list examples, expand the mouse example diagnostics, and add regression coverage for preview scrolling, tab clicks, and tab focus.