### PR TITLE
feat(Breeze.Flash): add stackable flash messages

### DIFF
--- a/examples/flash.exs
+++ b/examples/flash.exs
@@ -1,0 +1,208 @@
+defmodule FlashExample do
+  use Breeze.View
+  import Breeze.Blocks
+
+  @messages %{
+    "success" => %{
+      kind: :success,
+      title: "Saved",
+      message: "Draft synced to disk",
+      highlight: "success"
+    },
+    "info" => %{
+      kind: :info,
+      title: "Queued",
+      message: "Background job started",
+      highlight: "#6bc2ff"
+    },
+    "warning" => %{
+      kind: :warning,
+      title: "Check Input",
+      message: "Missing optional metadata",
+      highlight: {250, 189, 47}
+    },
+    "error" => %{
+      kind: :error,
+      title: "Publish Failed",
+      message: "Remote rejected the release please try again later",
+      highlight: "error"
+    }
+  }
+
+  @actions [
+    {"success", "Success", "1"},
+    {"info", "Info", "2"},
+    {"warning", "Warning", "3"},
+    {"error", "Error", "4"}
+  ]
+
+  @placements ["bottom-right", "bottom-left", "top-right", "top-left"]
+  @variants ["default", "square", "rounded"]
+
+  def mount(_opts, term) do
+    {:ok,
+     term
+     |> switch_theme(:gruvbox)
+     |> focus("success")
+     |> put_local_keybindings(base_keybindings())
+     |> clear_flash()
+     |> assign(
+       next_id: 1,
+       last_id: nil,
+       placement: "bottom-right",
+       variant: "default"
+     )}
+  end
+
+  def render(assigns) do
+    assigns =
+      assign(assigns,
+        actions: @actions,
+        flash_count: length(Breeze.Flash.entries(assigns.breeze.flash)),
+        queued_count: length(Breeze.Flash.queued_entries(assigns.breeze.flash)),
+        placement_label: String.replace(assigns.placement, "-", " "),
+        variant_label: assigns.variant
+      )
+
+    ~H"""
+    <box class="grid grid-cols-1 grid-rows-2 width-screen height-screen bg">
+      <box class="width-full height-full padding-left-2 padding-top-1">
+        <box class="bold">Flash Messages</box>
+        <box class="text-muted">Enter adds the focused message. 1-4 add directly.</box>
+        <box class="text-muted">c clears all, x clears latest, e clears errors.</box>
+        <box class="text-muted">p moves the stack, v changes variant.</box>
+        <box class="text-muted">F3 cycles theme. Max three show; queued messages wait.</box>
+        <box>
+        </box>
+        <box class="grid grid-cols-4 gap-x-1 width-72">
+          <box
+            :for={{id, label, key} <- @actions}
+            id={id}
+            focusable
+            class="border-rounded width-17 height-4 focus:border-primary"
+          >
+            <box class="bold text-center">{label}</box>
+            <box class="text-center text-muted">{key}</box>
+          </box>
+        </box>
+        <box>
+        </box>
+        <box class="border-rounded width-50 height-10">
+          <box class="bold">State</box>
+          <box>Visible: {@flash_count}</box>
+          <box>Queued: {@queued_count}</box>
+          <box>Latest id: {inspect(@last_id)}</box>
+          <box>Placement: {@placement_label}</box>
+          <box>Variant: {@variant_label}</box>
+          <box>Theme: {@breeze.theme.name}</box>
+        </box>
+        <.flash_group
+          flash={@breeze.flash}
+          placement={@placement}
+          variant={@variant}
+          width={36}
+          offset={1}
+        />
+      </box>
+      <box class="height-1 width-full bg-panel overflow-hidden">
+        <.keybinding_bar
+          keybindings={@breeze.keybindings}
+          class="inline width-full overflow-hidden padding-left-1"
+        />
+      </box>
+    </box>
+    """
+  end
+
+  def handle_event(_, %{"key" => key}, term) when key in ["1", "2", "3", "4"] do
+    action =
+      @actions
+      |> Enum.find(fn {_id, _label, action_key} -> action_key == key end)
+      |> elem(0)
+
+    {:noreply, push_flash(term, action)}
+  end
+
+  def handle_event(_, %{"key" => "Enter"}, %{focused: focused} = term) do
+    if Map.has_key?(@messages, focused) do
+      {:noreply, push_flash(term, focused)}
+    else
+      {:noreply, term}
+    end
+  end
+
+  def handle_event(_, %{"key" => "c"}, term),
+    do: {:noreply, clear_flash(assign(term, last_id: nil))}
+
+  def handle_event(_, %{"key" => "e"}, term), do: {:noreply, clear_flash(term, :error)}
+
+  def handle_event(_, %{"key" => "x"}, %{assigns: %{last_id: id}} = term) when not is_nil(id) do
+    {:noreply, term |> clear_flash(id) |> assign(last_id: nil)}
+  end
+
+  def handle_event(_, %{"key" => "p"}, term) do
+    {:noreply, assign(term, placement: next_placement(term.assigns.placement))}
+  end
+
+  def handle_event(_, %{"key" => "v"}, term) do
+    {:noreply, assign(term, variant: next_variant(term.assigns.variant))}
+  end
+
+  def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
+  def handle_event(_, _, term), do: {:noreply, term}
+  def handle_info(_, term), do: {:noreply, term}
+
+  defp push_flash(term, action) do
+    message = Map.fetch!(@messages, action)
+    id = "flash-#{term.assigns.next_id}"
+
+    term
+    |> put_flash(message.kind, message.message,
+      id: id,
+      title: "#{message.title} ##{term.assigns.next_id}",
+      highlight: message.highlight,
+      max: 3,
+      duration: 5_000
+    )
+    |> assign(next_id: term.assigns.next_id + 1, last_id: id)
+  end
+
+  defp next_placement(current) do
+    index = Enum.find_index(@placements, &(&1 == current)) || 0
+    Enum.at(@placements, rem(index + 1, length(@placements)))
+  end
+
+  defp next_variant(current) do
+    index = Enum.find_index(@variants, &(&1 == current)) || 0
+    Enum.at(@variants, rem(index + 1, length(@variants)))
+  end
+
+  defp base_keybindings do
+    [
+      {"Enter", "Add"},
+      {"1-4", "Push"},
+      {"c", "All"},
+      {"x", "Last"},
+      {"e", "Err"},
+      {"p", "Place"},
+      {"v", "Shape"},
+      {"F3", "Theme"},
+      {"q", "Quit"}
+    ]
+  end
+end
+
+Breeze.Example.run(
+  [
+    view: FlashExample,
+    theme: Breeze.Theme.builtin(:gruvbox),
+    hide_cursor: true,
+    mouse: false,
+    reload: true,
+    global_keybindings: [
+      {"F3", "Theme", &Breeze.View.cycle_theme/2},
+      {"q", "Quit", fn _event, term -> {:stop, term} end}
+    ]
+  ],
+  keep_alive: :infinity
+)

--- a/lib/breeze/blocks.ex
+++ b/lib/breeze/blocks.ex
@@ -1426,6 +1426,326 @@ defmodule Breeze.Blocks do
   defp maybe_append_dimension(class, :width, width), do: "#{class} width-#{width}"
   defp maybe_append_dimension(class, :height, height), do: "#{class} height-#{height}"
 
+  attr :id, :string, default: nil
+  attr :flash, :any, default: []
+  attr :variant, :string, default: "default", values: ["default", "square", "rounded"]
+  attr :placement, :string, default: "bottom-right"
+  attr :width, :integer, default: 40
+  attr :offset, :integer, default: 1
+  attr :gap, :integer, default: 1
+  attr :layer, :integer, default: 60
+  attr :class, :string, default: nil
+  attr :style, :any, default: nil
+  attr :rest, :global
+
+  def flash_group(assigns) do
+    width = max(Map.get(assigns, :width, 40), 8)
+    gap = max(Map.get(assigns, :gap, 1), 0)
+    variant = flash_variant(Map.get(assigns, :variant, "default"))
+    gap = flash_variant_gap(gap, variant)
+    flash_entries = Breeze.Flash.entries(Map.get(assigns, :flash))
+
+    assigns =
+      assigns
+      |> assign(
+        flash_entries: flash_group_entries(flash_entries, assigns, gap, variant),
+        variant: variant,
+        width: width,
+        class:
+          merge_class(
+            flash_group_class(assigns, width),
+            class_override(assigns)
+          )
+      )
+
+    ~H"""
+    <box
+      :if={@flash_entries != []}
+      id={@id}
+      class={@class}
+      style={Breeze.Blocks.inline_style(assigns)}
+      {@rest}
+    >
+      <.flash
+        :for={flash <- @flash_entries}
+        id={flash.id}
+        kind={flash.kind}
+        title={Map.get(flash, :title)}
+        message={flash.message}
+        highlight={Map.get(flash, :highlight)}
+        variant={@variant}
+        width={@width}
+        class={flash.class}
+      />
+    </box>
+    """
+  end
+
+  defp flash_group_entries([], _assigns, _gap, _variant), do: []
+
+  defp flash_group_entries(entries, assigns, gap, variant) do
+    offset = max(Map.get(assigns, :offset, 1) || 0, 0)
+    layer = Map.get(assigns, :layer, 60)
+    item_offset = flash_item_initial_offset(Map.get(assigns, :placement, "bottom-right"), offset)
+
+    entries_with_heights = Enum.map(entries, &{&1, flash_entry_height(&1, variant)})
+    offsets = flash_item_offsets(entries_with_heights, item_offset, gap)
+
+    entries_with_heights
+    |> Enum.zip(offsets)
+    |> Enum.with_index()
+    |> Enum.map(fn {{{entry, _height}, item_offset}, index} ->
+      Map.put(
+        entry,
+        :class,
+        flash_item_class(item_offset, layer + index)
+      )
+    end)
+  end
+
+  defp flash_item_offsets(entries_with_heights, offset, gap) do
+    {offsets, _next_offset} =
+      Enum.reduce(entries_with_heights, {[], offset}, fn {_entry, height},
+                                                         {offsets, next_offset} ->
+        {[next_offset | offsets], next_offset + height + gap}
+      end)
+
+    Enum.reverse(offsets)
+  end
+
+  defp flash_item_initial_offset(placement, offset) do
+    case normalize_flash_placement(placement) do
+      placement when placement in [:top_left, :top_right] -> 0
+      _placement -> offset
+    end
+  end
+
+  defp flash_entry_height(entry, variant) do
+    padding = if variant == :square, do: 4, else: 2
+
+    flash_content_line_count(Map.get(entry, :title), Map.get(entry, :message)) + padding
+  end
+
+  defp flash_variant(variant) when variant in [:square, "square"], do: :square
+  defp flash_variant(variant) when variant in [:rounded, "rounded"], do: :rounded
+  defp flash_variant(_variant), do: :default
+
+  defp flash_variant_gap(gap, :square), do: max(gap - 1, 0)
+  defp flash_variant_gap(gap, _variant), do: gap
+
+  defp flash_item_class(offset, layer) do
+    "absolute left-0 top-#{offset} layer-#{layer}"
+  end
+
+  attr :id, :string, default: nil
+  attr :kind, :any, default: :info
+  attr :title, :string, default: nil
+  attr :message, :string, default: nil
+  attr :highlight, :any, default: nil
+  attr :variant, :any, default: :default
+  attr :width, :integer, default: 40
+  attr :class, :string, default: nil
+
+  defp flash(assigns) do
+    case flash_variant(Map.get(assigns, :variant, :default)) do
+      :square -> render_square_flash(assigns)
+      variant -> render_compact_flash(assigns, variant)
+    end
+  end
+
+  defp render_compact_flash(assigns, variant) do
+    kind = Map.get(assigns, :kind, :info)
+    highlight = Map.get(assigns, :highlight) || flash_color(kind)
+    highlight_width = 1
+    width = max(Map.get(assigns, :width, 40), highlight_width + 4)
+    body_width = max(width - highlight_width - 2, 1)
+    message = Map.get(assigns, :message) || ""
+    highlight_height = flash_content_line_count(Map.get(assigns, :title), message)
+    highlight_content = flash_highlight_content(Map.get(assigns, :title), message)
+
+    assigns =
+      assigns
+      |> assign(
+        highlight: highlight,
+        width: width,
+        message: message,
+        highlight_height: highlight_height,
+        highlight_content: highlight_content,
+        class:
+          merge_class(
+            "width-#{width} #{flash_compact_border_class(variant)} border-stroke bg-panel overflow-hidden",
+            Map.get(assigns, :class)
+          ),
+        highlight_class: "width-#{highlight_width} height-#{highlight_height} overflow-hidden",
+        highlight_style: flash_highlight_style(highlight),
+        body_class: "width-#{body_width} padding-left-1 padding-right-1 overflow-hidden",
+        title_class: "bold width-full overflow-hidden",
+        message_class: "width-full overflow-hidden"
+      )
+
+    ~H"""
+    <box id={@id} class={@class}>
+      <box class="inline width-full">
+        <box class={@highlight_class} style={@highlight_style}>{@highlight_content}</box>
+        <box class={@body_class}>
+          <box :if={@title} class={@title_class}>{@title}</box>
+          <box class={@message_class}>{@message}</box>
+        </box>
+      </box>
+    </box>
+    """
+  end
+
+  defp flash_compact_border_class(:rounded), do: "border-rounded"
+  defp flash_compact_border_class(_variant), do: "border"
+
+  defp render_square_flash(assigns) do
+    kind = Map.get(assigns, :kind, :info)
+    highlight = Map.get(assigns, :highlight) || flash_color(kind)
+    width = max(Map.get(assigns, :width, 40), 7)
+    body_width = max(width - 3, 1)
+    message = Map.get(assigns, :message) || ""
+    highlight_height = flash_content_line_count(Map.get(assigns, :title), message) + 2
+    highlight_content = flash_square_highlight_content(highlight_height)
+    right_border_content = flash_square_right_border_content(highlight_height)
+
+    assigns =
+      assigns
+      |> assign(
+        highlight: highlight,
+        width: width,
+        message: message,
+        highlight_height: highlight_height,
+        highlight_content: highlight_content,
+        right_border_content: right_border_content,
+        top_border_content: flash_square_horizontal_border_content("▁", width),
+        bottom_border_content: flash_square_horizontal_border_content("▔", width),
+        class:
+          merge_class(
+            "width-#{width}",
+            Map.get(assigns, :class)
+          ),
+        border_row_class: "width-#{width} height-1 text-stroke bg overflow-hidden",
+        highlight_class: "width-2 height-#{highlight_height} text-stroke overflow-hidden",
+        highlight_style: flash_highlight_style(highlight),
+        body_class:
+          "width-#{body_width} bg-panel padding-left-1 padding-right-1 padding-top-1 padding-bottom-1 overflow-hidden",
+        right_border_class:
+          "width-1 height-#{highlight_height} text-stroke bg-panel overflow-hidden",
+        title_class: "bold width-full overflow-hidden",
+        message_class: "width-full overflow-hidden"
+      )
+
+    ~H"""
+    <box id={@id} class={@class}>
+      <box class={@border_row_class}>{@top_border_content}</box>
+      <box class="inline width-full">
+        <box class={@highlight_class} style={@highlight_style}>{@highlight_content}</box>
+        <box class={@body_class}>
+          <box :if={@title} class={@title_class}>{@title}</box>
+          <box class={@message_class}>{@message}</box>
+        </box>
+        <box class={@right_border_class}>{@right_border_content}</box>
+      </box>
+      <box class={@border_row_class}>{@bottom_border_content}</box>
+    </box>
+    """
+  end
+
+  defp flash_highlight_style(highlight), do: %{background_color: highlight}
+
+  defp flash_highlight_content(title, message) do
+    rows = flash_content_line_count(title, message)
+
+    1..rows
+    |> Enum.map_join("\n", fn _ -> " " end)
+  end
+
+  defp flash_square_highlight_content(rows) do
+    1..rows
+    |> Enum.map_join("\n", fn _ -> "▌ " end)
+  end
+
+  defp flash_square_right_border_content(rows) do
+    1..rows
+    |> Enum.map_join("\n", fn _ -> "▐" end)
+  end
+
+  defp flash_square_horizontal_border_content(char, width) do
+    String.duplicate(char, width)
+  end
+
+  defp flash_content_line_count(title, message) do
+    max(title_line_count(title) + text_line_count(message), 1)
+  end
+
+  defp title_line_count(nil), do: 0
+  defp title_line_count(""), do: 0
+  defp title_line_count(title), do: text_line_count(title)
+
+  defp text_line_count(nil), do: 0
+  defp text_line_count(""), do: 0
+
+  defp text_line_count(value) do
+    lines = value |> to_string() |> String.split("\n")
+
+    if List.last(lines) == "" do
+      max(length(lines) - 1, 0)
+    else
+      length(lines)
+    end
+  end
+
+  defp flash_group_class(assigns, width) do
+    [
+      "fixed",
+      flash_placement(Map.get(assigns, :placement, "bottom-right"), Map.get(assigns, :offset, 1)),
+      "width-#{width}",
+      "layer-#{Map.get(assigns, :layer, 60)}"
+    ]
+    |> List.flatten()
+    |> Enum.join(" ")
+  end
+
+  defp flash_placement(placement, offset) do
+    offset = max(offset || 0, 0)
+
+    case normalize_flash_placement(placement) do
+      :top_left -> ["left-#{offset}", "top-#{offset}"]
+      :top_right -> ["right-#{offset}", "top-#{offset}"]
+      :bottom_left -> ["left-#{offset}", "bottom-#{offset}"]
+      _bottom_right -> ["right-#{offset}", "bottom-#{offset}"]
+    end
+  end
+
+  defp normalize_flash_placement(placement) do
+    case placement |> to_string() |> String.replace("-", "_") do
+      "top_left" -> :top_left
+      "top_right" -> :top_right
+      "bottom_left" -> :bottom_left
+      _ -> :bottom_right
+    end
+  end
+
+  defp flash_color(kind) do
+    case kind_name(kind) do
+      "error" -> "error"
+      "warning" -> "warning"
+      "success" -> "success"
+      "info" -> "primary"
+      _ -> "accent"
+    end
+  end
+
+  defp kind_name(nil), do: "info"
+
+  defp kind_name(kind) do
+    kind
+    |> to_string()
+    |> String.replace("_", "-")
+    |> String.downcase()
+  end
+
   attr :id, :string, required: true
   attr :width, :integer, default: nil
   attr :height, :integer, default: nil

--- a/lib/breeze/blocks.ex
+++ b/lib/breeze/blocks.ex
@@ -1405,9 +1405,17 @@ defmodule Breeze.Blocks do
     |> String.split()
     |> Enum.reduce([], fn token, acc ->
       case token do
-        "border-" <> rest when rest not in ["rounded"] -> ["text-" <> rest | acc]
-        "focus:border-" <> rest -> ["focus:text-" <> rest | acc]
-        _ -> acc
+        "border-" <> rest when rest not in ["rounded", "square", "none", "invisible"] ->
+          ["text-" <> rest | acc]
+
+        "focus:border-" <> rest when rest not in ["rounded", "square", "none", "invisible"] ->
+          ["focus:text-" <> rest | acc]
+
+        "focus:border-" <> _rest ->
+          acc
+
+        _ ->
+          acc
       end
     end)
     |> Enum.reverse()
@@ -1665,6 +1673,7 @@ defmodule Breeze.Blocks do
             "border-none" -> false
             "border" -> true
             "border-rounded" -> true
+            "border-square" -> true
             "border-invisible" -> true
             _ -> border?
           end

--- a/lib/breeze/blocks.ex
+++ b/lib/breeze/blocks.ex
@@ -1405,9 +1405,17 @@ defmodule Breeze.Blocks do
     |> String.split()
     |> Enum.reduce([], fn token, acc ->
       case token do
-        "border-" <> rest when rest not in ["rounded"] -> ["text-" <> rest | acc]
-        "focus:border-" <> rest -> ["focus:text-" <> rest | acc]
-        _ -> acc
+        "border-" <> rest when rest not in ["rounded", "square", "none", "invisible"] ->
+          ["text-" <> rest | acc]
+
+        "focus:border-" <> rest when rest not in ["rounded", "square", "none", "invisible"] ->
+          ["focus:text-" <> rest | acc]
+
+        "focus:border-" <> _rest ->
+          acc
+
+        _ ->
+          acc
       end
     end)
     |> Enum.reverse()
@@ -1417,6 +1425,326 @@ defmodule Breeze.Blocks do
   defp maybe_append_dimension(class, _dimension, nil), do: class
   defp maybe_append_dimension(class, :width, width), do: "#{class} width-#{width}"
   defp maybe_append_dimension(class, :height, height), do: "#{class} height-#{height}"
+
+  attr :id, :string, default: nil
+  attr :flash, :any, default: []
+  attr :variant, :string, default: "default"
+  attr :placement, :string, default: "bottom-right"
+  attr :width, :integer, default: 40
+  attr :offset, :integer, default: 1
+  attr :gap, :integer, default: 1
+  attr :layer, :integer, default: 60
+  attr :class, :string, default: nil
+  attr :style, :any, default: nil
+  attr :rest, :global
+
+  def flash_group(assigns) do
+    width = max(Map.get(assigns, :width, 40), 8)
+    gap = max(Map.get(assigns, :gap, 1), 0)
+    variant = flash_variant(Map.get(assigns, :variant, "default"))
+    gap = flash_variant_gap(gap, variant)
+    flash_entries = Breeze.Flash.entries(Map.get(assigns, :flash))
+
+    assigns =
+      assigns
+      |> assign(
+        flash_entries: flash_group_entries(flash_entries, assigns, gap, variant),
+        variant: variant,
+        width: width,
+        class:
+          merge_class(
+            flash_group_class(assigns, width),
+            class_override(assigns)
+          )
+      )
+
+    ~H"""
+    <box
+      :if={@flash_entries != []}
+      id={@id}
+      class={@class}
+      style={Breeze.Blocks.inline_style(assigns)}
+      {@rest}
+    >
+      <.flash
+        :for={flash <- @flash_entries}
+        id={flash.id}
+        kind={flash.kind}
+        title={Map.get(flash, :title)}
+        message={flash.message}
+        highlight={Map.get(flash, :highlight)}
+        variant={@variant}
+        width={@width}
+        class={flash.class}
+      />
+    </box>
+    """
+  end
+
+  defp flash_group_entries([], _assigns, _gap, _variant), do: []
+
+  defp flash_group_entries(entries, assigns, gap, variant) do
+    offset = max(Map.get(assigns, :offset, 1) || 0, 0)
+    layer = Map.get(assigns, :layer, 60)
+    item_offset = flash_item_initial_offset(Map.get(assigns, :placement, "bottom-right"), offset)
+
+    entries_with_heights = Enum.map(entries, &{&1, flash_entry_height(&1, variant)})
+    offsets = flash_item_offsets(entries_with_heights, item_offset, gap)
+
+    entries_with_heights
+    |> Enum.zip(offsets)
+    |> Enum.with_index()
+    |> Enum.map(fn {{{entry, _height}, item_offset}, index} ->
+      Map.put(
+        entry,
+        :class,
+        flash_item_class(item_offset, layer + index)
+      )
+    end)
+  end
+
+  defp flash_item_offsets(entries_with_heights, offset, gap) do
+    {offsets, _next_offset} =
+      Enum.reduce(entries_with_heights, {[], offset}, fn {_entry, height},
+                                                         {offsets, next_offset} ->
+        {[next_offset | offsets], next_offset + height + gap}
+      end)
+
+    Enum.reverse(offsets)
+  end
+
+  defp flash_item_initial_offset(placement, offset) do
+    case normalize_flash_placement(placement) do
+      placement when placement in [:top_left, :top_right] -> 0
+      _placement -> offset
+    end
+  end
+
+  defp flash_entry_height(entry, variant) do
+    padding = if variant == :square, do: 4, else: 2
+
+    flash_content_line_count(Map.get(entry, :title), Map.get(entry, :message)) + padding
+  end
+
+  defp flash_variant(variant) when variant in [:square, "square"], do: :square
+  defp flash_variant(variant) when variant in [:rounded, "rounded"], do: :rounded
+  defp flash_variant(_variant), do: :default
+
+  defp flash_variant_gap(gap, :square), do: max(gap - 1, 0)
+  defp flash_variant_gap(gap, _variant), do: gap
+
+  defp flash_item_class(offset, layer) do
+    "absolute left-0 top-#{offset} layer-#{layer}"
+  end
+
+  attr :id, :string, default: nil
+  attr :kind, :any, default: :info
+  attr :title, :string, default: nil
+  attr :message, :string, default: nil
+  attr :highlight, :any, default: nil
+  attr :variant, :any, default: :default
+  attr :width, :integer, default: 40
+  attr :class, :string, default: nil
+
+  defp flash(assigns) do
+    case flash_variant(Map.get(assigns, :variant, :default)) do
+      :square -> render_square_flash(assigns)
+      variant -> render_compact_flash(assigns, variant)
+    end
+  end
+
+  defp render_compact_flash(assigns, variant) do
+    kind = Map.get(assigns, :kind, :info)
+    highlight = Map.get(assigns, :highlight) || flash_color(kind)
+    highlight_width = 1
+    width = max(Map.get(assigns, :width, 40), highlight_width + 4)
+    body_width = max(width - highlight_width - 2, 1)
+    message = Map.get(assigns, :message) || ""
+    highlight_height = flash_content_line_count(Map.get(assigns, :title), message)
+    highlight_content = flash_highlight_content(Map.get(assigns, :title), message)
+
+    assigns =
+      assigns
+      |> assign(
+        highlight: highlight,
+        width: width,
+        message: message,
+        highlight_height: highlight_height,
+        highlight_content: highlight_content,
+        class:
+          merge_class(
+            "width-#{width} #{flash_compact_border_class(variant)} border-stroke bg-panel overflow-hidden",
+            Map.get(assigns, :class)
+          ),
+        highlight_class: "width-#{highlight_width} height-#{highlight_height} overflow-hidden",
+        highlight_style: flash_highlight_style(highlight),
+        body_class: "width-#{body_width} padding-left-1 padding-right-1 overflow-hidden",
+        title_class: "bold width-full overflow-hidden",
+        message_class: "width-full overflow-hidden"
+      )
+
+    ~H"""
+    <box id={@id} class={@class}>
+      <box class="inline width-full">
+        <box class={@highlight_class} style={@highlight_style}>{@highlight_content}</box>
+        <box class={@body_class}>
+          <box :if={@title} class={@title_class}>{@title}</box>
+          <box class={@message_class}>{@message}</box>
+        </box>
+      </box>
+    </box>
+    """
+  end
+
+  defp flash_compact_border_class(:rounded), do: "border-rounded"
+  defp flash_compact_border_class(_variant), do: "border"
+
+  defp render_square_flash(assigns) do
+    kind = Map.get(assigns, :kind, :info)
+    highlight = Map.get(assigns, :highlight) || flash_color(kind)
+    width = max(Map.get(assigns, :width, 40), 7)
+    body_width = max(width - 3, 1)
+    message = Map.get(assigns, :message) || ""
+    highlight_height = flash_content_line_count(Map.get(assigns, :title), message) + 2
+    highlight_content = flash_square_highlight_content(highlight_height)
+    right_border_content = flash_square_right_border_content(highlight_height)
+
+    assigns =
+      assigns
+      |> assign(
+        highlight: highlight,
+        width: width,
+        message: message,
+        highlight_height: highlight_height,
+        highlight_content: highlight_content,
+        right_border_content: right_border_content,
+        top_border_content: flash_square_horizontal_border_content("▁", width),
+        bottom_border_content: flash_square_horizontal_border_content("▔", width),
+        class:
+          merge_class(
+            "width-#{width}",
+            Map.get(assigns, :class)
+          ),
+        border_row_class: "width-#{width} height-1 text-stroke bg overflow-hidden",
+        highlight_class: "width-2 height-#{highlight_height} text-stroke overflow-hidden",
+        highlight_style: flash_highlight_style(highlight),
+        body_class:
+          "width-#{body_width} bg-panel padding-left-1 padding-right-1 padding-top-1 padding-bottom-1 overflow-hidden",
+        right_border_class:
+          "width-1 height-#{highlight_height} text-stroke bg-panel overflow-hidden",
+        title_class: "bold width-full overflow-hidden",
+        message_class: "width-full overflow-hidden"
+      )
+
+    ~H"""
+    <box id={@id} class={@class}>
+      <box class={@border_row_class}>{@top_border_content}</box>
+      <box class="inline width-full">
+        <box class={@highlight_class} style={@highlight_style}>{@highlight_content}</box>
+        <box class={@body_class}>
+          <box :if={@title} class={@title_class}>{@title}</box>
+          <box class={@message_class}>{@message}</box>
+        </box>
+        <box class={@right_border_class}>{@right_border_content}</box>
+      </box>
+      <box class={@border_row_class}>{@bottom_border_content}</box>
+    </box>
+    """
+  end
+
+  defp flash_highlight_style(highlight), do: %{background_color: highlight}
+
+  defp flash_highlight_content(title, message) do
+    rows = flash_content_line_count(title, message)
+
+    1..rows
+    |> Enum.map_join("\n", fn _ -> " " end)
+  end
+
+  defp flash_square_highlight_content(rows) do
+    1..rows
+    |> Enum.map_join("\n", fn _ -> "▌ " end)
+  end
+
+  defp flash_square_right_border_content(rows) do
+    1..rows
+    |> Enum.map_join("\n", fn _ -> "▐" end)
+  end
+
+  defp flash_square_horizontal_border_content(char, width) do
+    String.duplicate(char, width)
+  end
+
+  defp flash_content_line_count(title, message) do
+    max(title_line_count(title) + text_line_count(message), 1)
+  end
+
+  defp title_line_count(nil), do: 0
+  defp title_line_count(""), do: 0
+  defp title_line_count(title), do: text_line_count(title)
+
+  defp text_line_count(nil), do: 0
+  defp text_line_count(""), do: 0
+
+  defp text_line_count(value) do
+    lines = value |> to_string() |> String.split("\n")
+
+    if List.last(lines) == "" do
+      max(length(lines) - 1, 0)
+    else
+      length(lines)
+    end
+  end
+
+  defp flash_group_class(assigns, width) do
+    [
+      "fixed",
+      flash_placement(Map.get(assigns, :placement, "bottom-right"), Map.get(assigns, :offset, 1)),
+      "width-#{width}",
+      "layer-#{Map.get(assigns, :layer, 60)}"
+    ]
+    |> List.flatten()
+    |> Enum.join(" ")
+  end
+
+  defp flash_placement(placement, offset) do
+    offset = max(offset || 0, 0)
+
+    case normalize_flash_placement(placement) do
+      :top_left -> ["left-#{offset}", "top-#{offset}"]
+      :top_right -> ["right-#{offset}", "top-#{offset}"]
+      :bottom_left -> ["left-#{offset}", "bottom-#{offset}"]
+      _bottom_right -> ["right-#{offset}", "bottom-#{offset}"]
+    end
+  end
+
+  defp normalize_flash_placement(placement) do
+    case placement |> to_string() |> String.replace("-", "_") do
+      "top_left" -> :top_left
+      "top_right" -> :top_right
+      "bottom_left" -> :bottom_left
+      _ -> :bottom_right
+    end
+  end
+
+  defp flash_color(kind) do
+    case kind_name(kind) do
+      "error" -> "error"
+      "warning" -> "warning"
+      "success" -> "success"
+      "info" -> "primary"
+      _ -> "accent"
+    end
+  end
+
+  defp kind_name(nil), do: "info"
+
+  defp kind_name(kind) do
+    kind
+    |> to_string()
+    |> String.replace("_", "-")
+    |> String.downcase()
+  end
 
   attr :id, :string, required: true
   attr :width, :integer, default: nil
@@ -1665,6 +1993,7 @@ defmodule Breeze.Blocks do
             "border-none" -> false
             "border" -> true
             "border-rounded" -> true
+            "border-square" -> true
             "border-invisible" -> true
             _ -> border?
           end

--- a/lib/breeze/child_server.ex
+++ b/lib/breeze/child_server.ex
@@ -276,6 +276,12 @@ defmodule Breeze.ChildServer do
     {:noreply, term}
   end
 
+  def handle_info({:breeze_flash_timeout, id, token}, term) do
+    next_term = Breeze.View.__expire_flash__(term, id, token)
+    notify_invalidate(next_term)
+    {:noreply, next_term}
+  end
+
   def handle_info(message, term) do
     term = maybe_put_terminal(term, term.terminal)
 
@@ -383,6 +389,7 @@ defmodule Breeze.ChildServer do
       |> maybe_put_theme_assign(:actual_theme_mode, theme.mode)
       |> put_breeze_assign(:theme, breeze_theme_assign(term))
       |> put_breeze_assign(:keybindings, active_keybindings(term))
+      |> put_breeze_assign_new(:flash, [])
 
     %{term | assigns: assigns}
   end
@@ -407,6 +414,13 @@ defmodule Breeze.ChildServer do
   defp put_breeze_assign(assigns, key, value) do
     Map.update(assigns, :breeze, %{key => value}, fn
       breeze when is_map(breeze) -> Map.put(breeze, key, value)
+      _ -> %{key => value}
+    end)
+  end
+
+  defp put_breeze_assign_new(assigns, key, value) do
+    Map.update(assigns, :breeze, %{key => value}, fn
+      breeze when is_map(breeze) -> Map.put_new(breeze, key, value)
       _ -> %{key => value}
     end)
   end

--- a/lib/breeze/child_server.ex
+++ b/lib/breeze/child_server.ex
@@ -276,6 +276,12 @@ defmodule Breeze.ChildServer do
     {:noreply, term}
   end
 
+  def handle_info({:breeze_flash_timeout, id, token}, term) do
+    next_term = Breeze.View.__expire_flash__(term, id, token)
+    notify_invalidate(next_term)
+    {:noreply, next_term}
+  end
+
   def handle_info(message, term) do
     term = maybe_put_terminal(term, term.terminal)
 

--- a/lib/breeze/flash.ex
+++ b/lib/breeze/flash.ex
@@ -1,0 +1,397 @@
+defmodule Breeze.Flash do
+  @moduledoc false
+
+  @state_key :__breeze_flash__
+  @default_max 3
+  @default_duration 5_000
+
+  @doc false
+  def put(flash, kind, message, opts \\ []) do
+    opts = normalize_opts(opts)
+    flash = normalize_state(flash, opts)
+
+    flash
+    |> enqueue_entry(entry(kind, message, opts, flash.duration))
+    |> fill_visible()
+  end
+
+  @doc false
+  def clear(_flash, nil), do: []
+
+  def clear(%{@state_key => true} = flash, key) do
+    key = flash_key(key)
+
+    flash
+    |> Map.update!(:entries, &reject_matching(&1, key))
+    |> Map.update!(:queue, &reject_matching(&1, key))
+    |> fill_visible()
+  end
+
+  def clear(flash, key) do
+    key = flash_key(key)
+
+    flash
+    |> entries()
+    |> Enum.reject(&matches_key?(&1, key))
+  end
+
+  @doc false
+  def expire(%{@state_key => true} = flash, id, token) do
+    id = flash_key(id)
+
+    {expired?, entries} =
+      Enum.reduce(flash.entries, {false, []}, fn entry, {expired?, entries} ->
+        if flash_key(Map.get(entry, :id)) == id and Map.get(entry, :timer_token) == token do
+          {true, entries}
+        else
+          {expired?, [entry | entries]}
+        end
+      end)
+
+    if expired? do
+      flash
+      |> Map.put(:entries, Enum.reverse(entries))
+      |> fill_visible()
+    else
+      flash
+    end
+  end
+
+  def expire(flash, _id, _token), do: flash
+
+  @doc false
+  def schedule_visible(%{@state_key => true} = flash, schedule_fun)
+      when is_function(schedule_fun, 2) do
+    entries =
+      Enum.map(flash.entries, fn entry ->
+        cond do
+          Map.has_key?(entry, :timer_token) ->
+            entry
+
+          not scheduleable_duration?(Map.get(entry, :duration)) ->
+            entry
+
+          true ->
+            token = make_ref()
+            schedule_fun.({:breeze_flash_timeout, Map.fetch!(entry, :id), token}, entry.duration)
+            Map.put(entry, :timer_token, token)
+        end
+      end)
+
+    %{flash | entries: entries}
+  end
+
+  def schedule_visible(flash, _schedule_fun), do: flash
+
+  @doc false
+  def entries(%{@state_key => true, entries: entries}) do
+    Enum.map(entries, &public_entry/1)
+  end
+
+  def entries(nil), do: []
+  def entries(false), do: []
+
+  def entries(%{} = flash) do
+    if entry_map?(flash) do
+      [normalize_entry_map(flash, 0)]
+    else
+      flash
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {{kind, message}, index} ->
+        entries_from_kind(kind, message, index)
+      end)
+    end
+  end
+
+  def entries(flash) when is_list(flash) do
+    cond do
+      flash == [] ->
+        []
+
+      Keyword.keyword?(flash) and entry_keyword?(flash) ->
+        [normalize_entry_map(Map.new(flash), 0)]
+
+      Keyword.keyword?(flash) ->
+        flash
+        |> Enum.with_index()
+        |> Enum.flat_map(fn {{kind, message}, index} ->
+          entries_from_kind(kind, message, index)
+        end)
+
+      true ->
+        flash
+        |> Enum.with_index()
+        |> Enum.flat_map(fn {entry, index} ->
+          normalize_entry(entry, index)
+        end)
+    end
+  end
+
+  def entries({kind, message}), do: entries_from_kind(kind, message, 0)
+  def entries(message) when is_binary(message), do: [normalize_entry_map(%{message: message}, 0)]
+  def entries(_flash), do: []
+
+  @doc false
+  def queued_entries(%{@state_key => true, queue: queue}) do
+    Enum.map(queue, &public_entry/1)
+  end
+
+  def queued_entries(_flash), do: []
+
+  defp normalize_state(%{@state_key => true} = flash, opts) do
+    max = option(opts, [:max], Map.get(flash, :max, @default_max)) |> normalize_max()
+
+    duration =
+      option(
+        opts,
+        [:duration, :duration_ms, :timeout],
+        Map.get(flash, :duration, @default_duration)
+      )
+      |> normalize_duration()
+
+    flash
+    |> Map.put(:max, max)
+    |> Map.put(:duration, duration)
+    |> Map.update(
+      :entries,
+      [],
+      &Enum.map(&1, fn entry -> ensure_entry_duration(entry, duration) end)
+    )
+    |> Map.update(
+      :queue,
+      [],
+      &Enum.map(&1, fn entry -> ensure_entry_duration(entry, duration) end)
+    )
+    |> fill_visible()
+  end
+
+  defp normalize_state(flash, opts) do
+    max = option(opts, [:max], @default_max) |> normalize_max()
+
+    duration =
+      option(opts, [:duration, :duration_ms, :timeout], @default_duration) |> normalize_duration()
+
+    {visible, queue} =
+      flash
+      |> entries()
+      |> Enum.map(&ensure_entry_duration(&1, duration))
+      |> Enum.split(max)
+
+    %{
+      @state_key => true,
+      entries: visible,
+      queue: queue,
+      max: max,
+      duration: duration
+    }
+  end
+
+  defp enqueue_entry(%{entries: entries, queue: queue, max: max} = flash, entry) do
+    if length(entries) < max do
+      %{flash | entries: entries ++ [entry]}
+    else
+      %{flash | queue: queue ++ [entry]}
+    end
+  end
+
+  defp fill_visible(%{entries: entries, queue: queue, max: max} = flash) do
+    {entries, overflow} = Enum.split(entries, max)
+    queue = overflow ++ queue
+    capacity = max(max - length(entries), 0)
+    {promoted, queue} = Enum.split(queue, capacity)
+
+    %{flash | entries: entries ++ Enum.map(promoted, &Map.delete(&1, :timer_token)), queue: queue}
+  end
+
+  defp entry(kind, message, opts, default_duration) do
+    kind = normalize_kind(kind)
+
+    duration =
+      option(opts, [:duration, :duration_ms, :timeout], default_duration) |> normalize_duration()
+
+    %{
+      id: option(opts, [:id], generated_id(kind)),
+      kind: kind,
+      message: message_text(message),
+      duration: duration
+    }
+    |> maybe_put(:title, option(opts, [:title], nil))
+    |> maybe_put(:highlight, option(opts, [:highlight, :color], nil))
+  end
+
+  defp entries_from_kind(_kind, value, _index) when value in [nil, false], do: []
+
+  defp entries_from_kind(kind, value, index) when is_list(value) and not is_binary(value) do
+    if Keyword.keyword?(value) and entry_keyword?(value) do
+      [normalize_entry_map(value |> Map.new() |> Map.put_new(:kind, kind), index)]
+    else
+      value
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {entry, child_index} ->
+        normalize_entry(
+          Map.put(normalize_entry_payload(entry), :kind, kind),
+          {index, child_index}
+        )
+      end)
+    end
+  end
+
+  defp entries_from_kind(kind, value, index) when is_map(value) do
+    [normalize_entry_map(Map.put_new(value, :kind, kind), index)]
+  end
+
+  defp entries_from_kind(kind, value, index) do
+    [normalize_entry_map(%{kind: kind, message: value}, index)]
+  end
+
+  defp normalize_entry(entry, _index) when entry in [nil, false], do: []
+  defp normalize_entry(%{} = entry, index), do: [normalize_entry_map(entry, index)]
+
+  defp normalize_entry({kind, message}, index) do
+    entries_from_kind(kind, message, index)
+  end
+
+  defp normalize_entry(message, index) do
+    [normalize_entry_map(%{message: message}, index)]
+  end
+
+  defp normalize_entry_map(entry, index) do
+    entry = normalize_entry_payload(entry)
+    kind = normalize_kind(Map.get(entry, :kind, :info))
+
+    %{
+      id: Map.get(entry, :id) || indexed_id(kind, index),
+      kind: kind,
+      message: message_text(Map.get(entry, :message, Map.get(entry, :text, "")))
+    }
+    |> maybe_put(:title, Map.get(entry, :title))
+    |> maybe_put(:highlight, Map.get(entry, :highlight, Map.get(entry, :color)))
+  end
+
+  defp normalize_entry_payload(%{} = entry) do
+    Map.new(entry, fn {key, value} -> {normalize_entry_key(key), value} end)
+  end
+
+  defp normalize_entry_payload(entry), do: %{message: entry}
+
+  defp normalize_entry_key(key) when is_atom(key), do: key
+
+  defp normalize_entry_key(key) when is_binary(key) do
+    case key do
+      "id" -> :id
+      "kind" -> :kind
+      "message" -> :message
+      "text" -> :text
+      "title" -> :title
+      "highlight" -> :highlight
+      "color" -> :color
+      _ -> key
+    end
+  end
+
+  defp normalize_entry_key(key), do: key
+
+  defp entry_keyword?(keyword) do
+    Enum.any?(keyword, fn {key, _value} ->
+      normalize_entry_key(key) in [:id, :kind, :message, :text, :title, :highlight, :color]
+    end)
+  end
+
+  defp entry_map?(map) do
+    map
+    |> Map.keys()
+    |> Enum.any?(
+      &(normalize_entry_key(&1) in [:id, :kind, :message, :text, :title, :highlight, :color])
+    )
+  end
+
+  defp normalize_opts(opts) when is_map(opts), do: opts
+
+  defp normalize_opts(opts) when is_list(opts) do
+    if Keyword.keyword?(opts), do: Map.new(opts), else: %{}
+  end
+
+  defp normalize_opts(_opts), do: %{}
+
+  defp option(opts, keys, default) when is_list(keys) do
+    Enum.reduce_while(keys, default, fn key, _default ->
+      string_key = Atom.to_string(key)
+
+      cond do
+        Map.has_key?(opts, key) -> {:halt, Map.get(opts, key)}
+        Map.has_key?(opts, string_key) -> {:halt, Map.get(opts, string_key)}
+        true -> {:cont, default}
+      end
+    end)
+  end
+
+  defp normalize_kind(nil), do: :info
+  defp normalize_kind(kind), do: kind
+
+  defp normalize_max(value) when is_integer(value) and value > 0, do: value
+
+  defp normalize_max(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {parsed, ""} when parsed > 0 -> parsed
+      _ -> @default_max
+    end
+  end
+
+  defp normalize_max(_value), do: @default_max
+
+  defp normalize_duration(value) when value in [false, :infinity, "infinity"], do: false
+  defp normalize_duration(value) when is_integer(value) and value > 0, do: value
+
+  defp normalize_duration(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {parsed, ""} when parsed > 0 -> parsed
+      _ -> @default_duration
+    end
+  end
+
+  defp normalize_duration(_value), do: @default_duration
+
+  defp ensure_entry_duration(entry, duration) do
+    Map.put_new(entry, :duration, duration)
+  end
+
+  defp scheduleable_duration?(duration), do: is_integer(duration) and duration > 0
+
+  defp message_text(nil), do: ""
+  defp message_text(value) when is_binary(value), do: value
+  defp message_text(value) when is_atom(value), do: Atom.to_string(value)
+
+  defp message_text(value) do
+    to_string(value)
+  rescue
+    Protocol.UndefinedError -> inspect(value)
+  end
+
+  defp generated_id(kind), do: "flash-#{kind_token(kind)}-#{System.unique_integer([:positive])}"
+
+  defp indexed_id(kind, index), do: "flash-#{kind_token(kind)}-#{index_token(index)}"
+
+  defp index_token({left, right}), do: "#{left}-#{right}"
+  defp index_token(index), do: to_string(index)
+
+  defp reject_matching(entries, key), do: Enum.reject(entries, &matches_key?(&1, key))
+
+  defp matches_key?(entry, key) do
+    flash_key(Map.get(entry, :id)) == key or flash_key(Map.get(entry, :kind)) == key
+  end
+
+  defp flash_key(nil), do: nil
+  defp flash_key(value), do: value |> to_string() |> String.replace("_", "-")
+
+  defp kind_token(kind) do
+    kind
+    |> flash_key()
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9-]+/, "-")
+  end
+
+  defp public_entry(entry), do: Map.drop(entry, [:duration, :timer_token])
+
+  defp maybe_put(map, _key, value) when value in [nil, ""], do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -78,9 +78,11 @@ defmodule Breeze.Renderer do
   end
 
   defp put_breeze_render_context(assigns, opts) when is_map(assigns) do
-    Map.update(assigns, :breeze, render_context(opts), fn
-      breeze when is_map(breeze) -> Map.merge(breeze, render_context(opts))
-      _ -> render_context(opts)
+    context = render_context(opts)
+
+    Map.update(assigns, :breeze, Map.put(context, :flash, []), fn
+      breeze when is_map(breeze) -> breeze |> Map.merge(context) |> Map.put_new(:flash, [])
+      _ -> Map.put(context, :flash, [])
     end)
   end
 

--- a/lib/breeze/style.ex
+++ b/lib/breeze/style.ex
@@ -406,6 +406,9 @@ defmodule Breeze.Style do
   defp apply_style("border-rounded", {style, attrs}, _theme),
     do: {BackBreeze.Style.border(style, :rounded), attrs}
 
+  defp apply_style("border-square", {style, attrs}, _theme),
+    do: {%{style | border: square_border()}, attrs}
+
   defp apply_style("border-" <> color, {style, attrs}, theme),
     do: {BackBreeze.Style.border_color(style, Theme.resolve_color(theme, color)), attrs}
 
@@ -647,7 +650,21 @@ defmodule Breeze.Style do
   defp normalize_border(:line), do: BackBreeze.Border.line()
   defp normalize_border(:invisible), do: BackBreeze.Border.invisible()
   defp normalize_border(:rounded), do: BackBreeze.Border.rounded()
+  defp normalize_border(:square), do: square_border()
   defp normalize_border(value), do: value
+
+  defp square_border do
+    BackBreeze.Border.custom(%{
+      top: "▁",
+      bottom: "▔",
+      left: "▌",
+      right: "▐",
+      top_left: "▁",
+      top_right: "▁",
+      bottom_left: "▔",
+      bottom_right: "▔"
+    })
+  end
 
   defp truthy?(value), do: value not in [false, nil]
 

--- a/lib/breeze/template.ex
+++ b/lib/breeze/template.ex
@@ -201,12 +201,13 @@ defmodule Breeze.Template do
 
     attrs = eval_component_attrs(attrs, ctx)
     rest = Enum.filter(attrs, fn {key, _value} -> global_attr?(key) end)
+    caller_assigns = component_caller_assigns(ctx.assigns)
 
     assigns =
       attrs
       |> Map.new()
       |> maybe_put_rest(rest)
-      |> Map.put(:__breeze_caller_assigns__, ctx.assigns)
+      |> Map.put(:__breeze_caller_assigns__, caller_assigns)
       |> Map.merge(build_slots(children, ctx))
 
     {%__MODULE__{nodes: comp_nodes, env: comp_env}, comp_assigns} =
@@ -237,6 +238,12 @@ defmodule Breeze.Template do
 
     [{String.to_atom(name), [], attr_nodes ++ child_nodes}]
   end
+
+  defp component_caller_assigns(%{__breeze_caller_assigns__: caller_assigns})
+       when is_map(caller_assigns),
+       do: caller_assigns
+
+  defp component_caller_assigns(assigns), do: assigns
 
   defp merge_text_nodes(nodes) do
     nodes

--- a/lib/breeze/view.ex
+++ b/lib/breeze/view.ex
@@ -114,6 +114,7 @@ defmodule Breeze.View do
   The following styles are supported:
 
    * `border` - add a line border to the box
+   * `border-square` - add a square block border to the box
    * `bold` - make the text bold
    * `italic` - make the text italic
    * `inverse` - reverse the foreground-background
@@ -312,6 +313,7 @@ defmodule Breeze.View do
     helper_captures = pop_template_helper_captures(env)
     component_spec_names = Enum.map(component_specs, & &1.name)
     local_components = Enum.uniq(component_spec_names ++ local_component_names(env, components))
+    public_components = Enum.filter(local_components, &Module.defines?(env.module, {&1, 1}, :def))
 
     helper_definitions =
       helper_captures
@@ -378,7 +380,7 @@ defmodule Breeze.View do
       unquote_splicing(local_component_definitions)
       unquote_splicing(imported_component_definitions)
 
-      def __breeze_components__, do: unquote(local_components)
+      def __breeze_components__, do: unquote(public_components)
 
       def __breeze_component__(name, _assigns) do
         raise UndefinedFunctionError, module: __MODULE__, function: name, arity: 1
@@ -804,6 +806,41 @@ defmodule Breeze.View do
     Map.merge(assigns, Map.new(values))
   end
 
+  @doc """
+  Append a flash message to `assigns.breeze.flash`.
+
+  The resulting flash assign is a stack-friendly list consumed by
+  `Breeze.Blocks.flash_group/1`.
+
+      term
+      |> put_flash(:info, "Saved", max: 3, duration: 5_000)
+      |> put_flash(:error, "Publish failed", id: "publish-error", highlight: "error")
+
+  The left highlight strip can be customized with `:highlight` or `:color`.
+  It accepts Breeze semantic color names, ANSI color indexes, RGB tuples, and
+  `"#rgb"`/`"#rrggbb"` hex strings.
+  """
+  @spec put_flash(map(), atom() | String.t(), term(), keyword() | map()) :: map()
+  def put_flash(term_or_assigns, kind, message, opts \\ []) do
+    update_flash(term_or_assigns, &Breeze.Flash.put(&1, kind, message, opts))
+  end
+
+  @doc """
+  Clear flash messages from `assigns.breeze.flash`.
+
+  Without a second argument all flash messages are removed. With a second
+  argument, messages matching that kind or id are removed.
+  """
+  @spec clear_flash(map(), atom() | String.t() | nil) :: map()
+  def clear_flash(term_or_assigns, kind_or_id \\ nil) do
+    update_flash(term_or_assigns, &Breeze.Flash.clear(&1, kind_or_id))
+  end
+
+  @doc false
+  def __expire_flash__(term_or_assigns, id, token) do
+    update_flash(term_or_assigns, &Breeze.Flash.expire(&1, id, token))
+  end
+
   def focus(term, value) do
     %{term | focused: value, allow_unfocused?: is_nil(value)}
   end
@@ -963,4 +1000,36 @@ defmodule Breeze.View do
       end
     end)
   end
+
+  defp update_flash(%{assigns: assigns} = term, fun) when is_map(assigns) do
+    breeze = flash_breeze_assign(assigns)
+
+    flash =
+      breeze
+      |> Map.get(:flash)
+      |> fun.()
+      |> schedule_flash_timers(term)
+
+    %{term | assigns: Map.put(assigns, :breeze, Map.put(breeze, :flash, flash))}
+  end
+
+  defp update_flash(assigns, fun) when is_map(assigns) do
+    breeze = flash_breeze_assign(assigns)
+    Map.put(assigns, :breeze, Map.put(breeze, :flash, fun.(Map.get(breeze, :flash))))
+  end
+
+  defp flash_breeze_assign(assigns) do
+    case Map.get(assigns, :breeze) do
+      breeze when is_map(breeze) -> breeze
+      _ -> %{}
+    end
+  end
+
+  defp schedule_flash_timers(flash, %{view: view}) when not is_nil(view) do
+    Breeze.Flash.schedule_visible(flash, fn message, duration ->
+      Process.send_after(self(), message, duration)
+    end)
+  end
+
+  defp schedule_flash_timers(flash, _term), do: flash
 end

--- a/lib/breeze/view.ex
+++ b/lib/breeze/view.ex
@@ -313,6 +313,7 @@ defmodule Breeze.View do
     helper_captures = pop_template_helper_captures(env)
     component_spec_names = Enum.map(component_specs, & &1.name)
     local_components = Enum.uniq(component_spec_names ++ local_component_names(env, components))
+    public_components = Enum.filter(local_components, &Module.defines?(env.module, {&1, 1}, :def))
 
     helper_definitions =
       helper_captures
@@ -379,7 +380,7 @@ defmodule Breeze.View do
       unquote_splicing(local_component_definitions)
       unquote_splicing(imported_component_definitions)
 
-      def __breeze_components__, do: unquote(local_components)
+      def __breeze_components__, do: unquote(public_components)
 
       def __breeze_component__(name, _assigns) do
         raise UndefinedFunctionError, module: __MODULE__, function: name, arity: 1
@@ -805,6 +806,41 @@ defmodule Breeze.View do
     Map.merge(assigns, Map.new(values))
   end
 
+  @doc """
+  Append a flash message to `assigns.breeze.flash`.
+
+  The resulting flash assign is a stack-friendly list consumed by
+  `Breeze.Blocks.flash_group/1`.
+
+      term
+      |> put_flash(:info, "Saved", max: 3, duration: 5_000)
+      |> put_flash(:error, "Publish failed", id: "publish-error", highlight: "error")
+
+  The left highlight strip can be customized with `:highlight` or `:color`.
+  It accepts Breeze semantic color names, ANSI color indexes, RGB tuples, and
+  `"#rgb"`/`"#rrggbb"` hex strings.
+  """
+  @spec put_flash(map(), atom() | String.t(), term(), keyword() | map()) :: map()
+  def put_flash(term_or_assigns, kind, message, opts \\ []) do
+    update_flash(term_or_assigns, &Breeze.Flash.put(&1, kind, message, opts))
+  end
+
+  @doc """
+  Clear flash messages from `assigns.breeze.flash`.
+
+  Without a second argument all flash messages are removed. With a second
+  argument, messages matching that kind or id are removed.
+  """
+  @spec clear_flash(map(), atom() | String.t() | nil) :: map()
+  def clear_flash(term_or_assigns, kind_or_id \\ nil) do
+    update_flash(term_or_assigns, &Breeze.Flash.clear(&1, kind_or_id))
+  end
+
+  @doc false
+  def __expire_flash__(term_or_assigns, id, token) do
+    update_flash(term_or_assigns, &Breeze.Flash.expire(&1, id, token))
+  end
+
   def focus(term, value) do
     %{term | focused: value, allow_unfocused?: is_nil(value)}
   end
@@ -964,4 +1000,36 @@ defmodule Breeze.View do
       end
     end)
   end
+
+  defp update_flash(%{assigns: assigns} = term, fun) when is_map(assigns) do
+    breeze = flash_breeze_assign(assigns)
+
+    flash =
+      breeze
+      |> Map.get(:flash)
+      |> fun.()
+      |> schedule_flash_timers(term)
+
+    %{term | assigns: Map.put(assigns, :breeze, Map.put(breeze, :flash, flash))}
+  end
+
+  defp update_flash(assigns, fun) when is_map(assigns) do
+    breeze = flash_breeze_assign(assigns)
+    Map.put(assigns, :breeze, Map.put(breeze, :flash, fun.(Map.get(breeze, :flash))))
+  end
+
+  defp flash_breeze_assign(assigns) do
+    case Map.get(assigns, :breeze) do
+      breeze when is_map(breeze) -> breeze
+      _ -> %{}
+    end
+  end
+
+  defp schedule_flash_timers(flash, %{view: view}) when not is_nil(view) do
+    Breeze.Flash.schedule_visible(flash, fn message, duration ->
+      Process.send_after(self(), message, duration)
+    end)
+  end
+
+  defp schedule_flash_timers(flash, _term), do: flash
 end

--- a/lib/breeze/view.ex
+++ b/lib/breeze/view.ex
@@ -114,6 +114,7 @@ defmodule Breeze.View do
   The following styles are supported:
 
    * `border` - add a line border to the box
+   * `border-square` - add a square block border to the box
    * `bold` - make the text bold
    * `italic` - make the text italic
    * `inverse` - reverse the foreground-background

--- a/storybook/flash.story.exs
+++ b/storybook/flash.story.exs
@@ -1,0 +1,84 @@
+defmodule Breeze.Storybook.Stories.Blocks.FlashStory do
+  use Breeze.Storybook.Story
+
+  def story do
+    %{
+      id: "flash",
+      title: "Flash",
+      description: "Overlay flash messages that stack from a screen corner.",
+      variants: [
+        %{
+          id: "default",
+          label: "Default",
+          source: ~S(<.flash_group flash={@breeze.flash} />),
+          notes: [
+            "Default flash messages use a compact square-corner panel with a left highlight strip."
+          ]
+        },
+        %{
+          id: "square",
+          label: "Square",
+          source: ~S(<.flash_group flash={@breeze.flash} variant="square" />),
+          notes: [
+            "The square variant uses block glyphs for the frame and keeps the highlight inside the message."
+          ]
+        },
+        %{
+          id: "rounded",
+          label: "Rounded",
+          source: ~S(<.flash_group flash={@breeze.flash} variant="rounded" />),
+          notes: [
+            "The rounded variant uses the normal rounded border style with the same flash stack behavior."
+          ]
+        }
+      ],
+      notes: [
+        "Use Breeze.View.put_flash/4 to append messages and Breeze.View.clear_flash/1 or /2 to remove them.",
+        "Managed flash messages live in the Breeze namespace at @breeze.flash.",
+        "Each message can set a custom highlight color for the left column, including semantic tokens, ANSI indexes, RGB tuples, and hex strings.",
+        "Set variant=\"square\" or variant=\"rounded\" on the group to change the panel border."
+      ],
+      source: ~S(<.flash_group flash={@breeze.flash} />)
+    }
+  end
+
+  def render(story) do
+    variant = Map.get(story, :__breeze_story_variant__, "default")
+
+    assigns = %{
+      variant: variant,
+      breeze: %{
+        flash: [
+          %{
+            id: "storybook-flash-info",
+            kind: :info,
+            message: "Settings saved",
+            highlight: "#6bc2ff"
+          },
+          %{
+            id: "storybook-flash-success",
+            kind: :success,
+            title: "Deploy queued",
+            message: "Worker picked up the release",
+            highlight: {184, 187, 38}
+          }
+        ]
+      }
+    }
+
+    ~H"""
+    <box class="width-full height-full bg">
+      <box class="width-full bold">Flash Preview</box>
+      <box class="width-50 text-muted">
+        The flash stack is fixed to the bottom-right corner and does not affect layout.
+      </box>
+      <box class="padding-top-1 width-42">
+        <box>Status: Ready</box>
+        <box>Queue: 3 jobs</box>
+        <box>Region: eu-west</box>
+      </box>
+      <.flash_group flash={@breeze.flash} variant={@variant}/>
+    </box>
+    """
+  end
+end

--- a/test/breeze/blocks_test.exs
+++ b/test/breeze/blocks_test.exs
@@ -3,6 +3,7 @@ defmodule Breeze.BlocksTest do
 
   alias Breeze.Blocks
   alias Breeze.ChildServer
+  alias Breeze.Renderer
 
   defmodule UnderlineTabsExample do
     use Breeze.View
@@ -106,6 +107,168 @@ defmodule Breeze.BlocksTest do
 
     def handle_event(_, _, term), do: {:noreply, term}
     def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule FlashGroupExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <box>Page body</box>
+        <.flash_group id="flash-stack" flash={@flash} width={28} offset={0}/>
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashGapExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      assigns =
+        assign(assigns,
+          variant: Map.get(assigns, :variant, "default"),
+          gap: Map.get(assigns, :gap, 1)
+        )
+
+      ~H"""
+      <box class="width-screen height-screen bg">
+        <box class="width-screen height-screen bg-primary content-repeat">.</box>
+        <.flash_group
+          id="flash-stack"
+          flash={@flash}
+          variant={@variant}
+          width={20}
+          offset={0}
+          gap={@gap}
+        />
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashSlotExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group
+          flash={[%{id: "slot-flash", kind: :warning, highlight: "warning", message: "Careful now"}]}
+          placement="top-left"
+          width={24}
+          offset={0}
+        />
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashDefaultTopOffsetExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group
+          id="flash-stack"
+          flash={[%{id: "default-top-flash", kind: :info, message: "Offset once"}]}
+          placement="top-left"
+          width={24}
+        />
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashTitledExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group
+          flash={[
+        %{
+          id: "titled-flash",
+          kind: :success,
+          highlight: "accent",
+          title: "Saved",
+          message: "Draft persisted"
+        }
+      ]}
+          placement="top-left"
+          width={24}
+          offset={0}
+        />
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashSquareBorderExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group
+          flash={[
+        %{
+          id: "square-flash",
+          kind: :warning,
+          highlight: "warning",
+          title: "Saved #12",
+          message: "Draft synced"
+        }
+      ]}
+          placement="top-left"
+          variant="square"
+          width={25}
+          offset={0}
+        />
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashCustomColorExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group flash={@flash} placement="top-left" width={18} offset={0}/>
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashRoundedBorderExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group
+          flash={[%{id: "rounded-flash", kind: :info, message: "Rounded"}]}
+          placement="top-left"
+          variant="rounded"
+          width={20}
+          offset={0}
+        />
+      </box>
+      """
+    end
   end
 
   defmodule MutedListExample do
@@ -289,6 +452,52 @@ defmodule Breeze.BlocksTest do
         br-change="change"
         style="width-20 height-6"
       />
+      """
+    end
+
+    def handle_event("change", %{value: value}, term),
+      do: {:noreply, assign(term, selected: value)}
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule WrappedVirtualUncontrolledTreeExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    @nodes [
+      %{
+        id: "root",
+        label: "root",
+        children: [
+          %{id: "src", label: "src", children: [%{id: "lib", label: "lib"}]},
+          %{id: "mix", label: "mix.exs"}
+        ]
+      }
+    ]
+
+    def mount(_opts, term), do: {:ok, term |> focus("files") |> assign(selected: "root")}
+
+    def tree_wrapper(assigns) do
+      ~H"""
+      <.tree
+        id="files"
+        nodes={@nodes}
+        selected={@selected}
+        default_expanded={["root"]}
+        virtual_window={4}
+        br-change="change"
+        style="width-20 height-6"
+      />
+      """
+    end
+
+    def render(assigns) do
+      assigns = assign(assigns, nodes: @nodes)
+
+      ~H"""
+      <.tree_wrapper nodes={@nodes} selected={@selected}/>
       """
     end
 
@@ -485,6 +694,192 @@ defmodule Breeze.BlocksTest do
     assert box.content =~ ~r/\e\[[0-9;]*38;5;4mDetails/
   end
 
+  test "flash_group renders a fixed bottom-right stack with custom highlights" do
+    flash = [
+      %{id: "saved", kind: :success, message: "Saved draft", highlight: "accent"},
+      %{id: "publish-error", kind: :error, title: "Publish failed", message: "Try again"}
+    ]
+
+    {acc, box} =
+      Renderer.render(FlashGroupExample, %{flash: flash},
+        terminal: %Termite.Terminal{size: %{width: 60, height: 12}}
+      )
+
+    stack = Map.fetch!(acc.boxes, "flash-stack")
+    assert stack.position == :fixed
+    assert stack.right == 0
+    assert stack.bottom == 0
+
+    plain_content = Regex.replace(~r/\e\[[0-9;]*m/u, box.content, "")
+    assert plain_content =~ "Page body"
+    assert plain_content =~ "Saved draft"
+    assert plain_content =~ "Publish failed"
+    assert plain_content =~ "Try again"
+    assert box.content =~ ~r/\e\[[0-9;]*48;5;5(?:;|m)/
+  end
+
+  test "flash item component stays private" do
+    Code.ensure_loaded!(Breeze.Blocks)
+
+    assert function_exported?(Breeze.Blocks, :flash_group, 1)
+    refute function_exported?(Breeze.Blocks, :flash, 1)
+    refute :flash in Breeze.Blocks.__breeze_components__()
+  end
+
+  test "flash_group leaves gaps transparent over existing content" do
+    flash = [
+      %{id: "one", kind: :info, message: "One"},
+      %{id: "two", kind: :info, message: "Two"}
+    ]
+
+    {_acc, box} =
+      Renderer.render(FlashGapExample, %{flash: flash},
+        terminal: %Termite.Terminal{size: %{width: 30, height: 10}}
+      )
+
+    assert {".", gap_style} = Map.fetch!(box.layer_map, {6, 10})
+    assert gap_style =~ "48;5;4"
+  end
+
+  test "square flash_group subtracts one row from the configured gap" do
+    flash = [
+      %{id: "one", kind: :info, message: "One"},
+      %{id: "two", kind: :info, message: "Two"}
+    ]
+
+    {_acc, box} =
+      Renderer.render(FlashGapExample, %{flash: flash, variant: "square"},
+        terminal: %Termite.Terminal{size: %{width: 30, height: 12}}
+      )
+
+    assert {"▔", bottom_border_style} = Map.fetch!(box.layer_map, {6, 10})
+    refute bottom_border_style =~ "49m"
+
+    {_acc, box} =
+      Renderer.render(FlashGapExample, %{flash: flash, variant: "square", gap: 2},
+        terminal: %Termite.Terminal{size: %{width: 30, height: 12}}
+      )
+
+    assert {".", gap_style} = Map.fetch!(box.layer_map, {6, 10})
+    assert gap_style =~ "48;5;4"
+
+    assert {"▁", top_border_style} = Map.fetch!(box.layer_map, {1, 10})
+    refute top_border_style =~ "49m"
+    assert top_border_style =~ ~r/48;(?:5|2);/
+  end
+
+  test "flash_group renders message content and semantic warning highlight" do
+    {acc, box} = Renderer.render(FlashSlotExample, %{})
+
+    plain_content = Regex.replace(~r/\e\[[0-9;]*m/u, box.content, "")
+    assert plain_content =~ "Careful now"
+    assert box.content =~ ~r/\e\[[0-9;]*48;5;3(?:;|m)/
+
+    flash_box = Map.fetch!(acc.boxes, "slot-flash")
+    inline_box = hd(flash_box.children)
+    [highlight_box, body_box] = inline_box.children
+
+    assert flash_box.style.border.top == "─"
+    assert flash_box.style.border.top_left == "┌"
+    assert highlight_box.style.width == 1
+    assert body_box.style.width == 21
+  end
+
+  test "flash_group applies the default top offset once" do
+    {acc, box} = Renderer.render(FlashDefaultTopOffsetExample, %{})
+
+    stack_box = Map.fetch!(acc.boxes, "flash-stack")
+    flash_box = Map.fetch!(acc.boxes, "default-top-flash")
+
+    assert stack_box.top == 1
+    assert flash_box.top == 0
+    assert {"┌", _style} = Map.fetch!(box.layer_map, {1, 1})
+    refute match?({"┌", _style}, Map.get(box.layer_map, {2, 1}))
+  end
+
+  test "flash highlight fills the message content height" do
+    {_acc, box} = Renderer.render(FlashTitledExample, %{})
+
+    assert {" ", first_row_style} = Map.fetch!(box.layer_map, {1, 1})
+    assert {" ", second_row_style} = Map.fetch!(box.layer_map, {2, 1})
+
+    assert first_row_style =~ "48;5;5"
+    assert second_row_style =~ "48;5;5"
+  end
+
+  test "flash_group can use square block borders with a padded color strip" do
+    {acc, box} = Renderer.render(FlashSquareBorderExample, %{})
+
+    plain_content = Regex.replace(~r/\e\[[0-9;]*m/u, box.content, "")
+    assert plain_content =~ "▁▁▁▁▁"
+    assert plain_content =~ "▔▔▔▔▔"
+    assert plain_content =~ "Saved #12"
+    assert plain_content =~ "Draft synced"
+
+    flash_box = Map.fetch!(acc.boxes, "square-flash")
+    assert flash_box.style.border == BackBreeze.Border.none()
+
+    assert {"▌", border_strip_style} = Map.fetch!(box.layer_map, {1, 0})
+    assert {" ", inner_strip_style} = Map.fetch!(box.layer_map, {1, 1})
+    assert {"▌", text_row_strip_style} = Map.fetch!(box.layer_map, {2, 0})
+
+    assert border_strip_style =~ "48;5;3"
+    assert border_strip_style =~ "38;5;7"
+    assert inner_strip_style =~ "48;5;3"
+    assert text_row_strip_style =~ "48;5;3"
+
+    assert {"▁", top_border_style} = Map.fetch!(box.layer_map, {0, 0})
+    assert {"▔", bottom_border_style} = Map.fetch!(box.layer_map, {5, 0})
+
+    refute top_border_style =~ "49m"
+    refute bottom_border_style =~ "49m"
+    assert top_border_style =~ ~r/48;(?:5|2);/
+    assert bottom_border_style =~ ~r/48;(?:5|2);/
+  end
+
+  test "square flash_group block borders use the active theme background" do
+    {_acc, box} =
+      Renderer.render(FlashSquareBorderExample, %{}, theme: Breeze.Theme.builtin(:gruvbox))
+
+    assert {"▁", top_border_style} = Map.fetch!(box.layer_map, {0, 0})
+
+    refute top_border_style =~ "49m"
+    assert top_border_style =~ "48;2;40;40;40"
+
+    assert {"▐", right_border_style} = Map.fetch!(box.layer_map, {1, 24})
+    assert right_border_style =~ "48;2;50;48;47"
+  end
+
+  test "flash_group supports custom hex and RGB tuple highlight colors" do
+    {_acc, hex_box} =
+      Renderer.render(FlashCustomColorExample, %{
+        flash: [%{id: "hex-flash", kind: :info, message: "Hex", highlight: "#f0a"}]
+      })
+
+    assert {" ", hex_highlight_style} = Map.fetch!(hex_box.layer_map, {1, 1})
+    assert hex_highlight_style =~ "48;2;255;0;170"
+
+    {_acc, rgb_box} =
+      Renderer.render(FlashCustomColorExample, %{
+        flash: [%{id: "rgb-flash", kind: :info, message: "RGB", color: {1, 2, 3}}]
+      })
+
+    assert {" ", rgb_highlight_style} = Map.fetch!(rgb_box.layer_map, {1, 1})
+    assert rgb_highlight_style =~ "48;2;1;2;3"
+  end
+
+  test "flash_group can use rounded borders" do
+    {acc, box} = Renderer.render(FlashRoundedBorderExample, %{})
+
+    plain_content = Regex.replace(~r/\e\[[0-9;]*m/u, box.content, "")
+    assert plain_content =~ "Rounded"
+
+    flash_box = Map.fetch!(acc.boxes, "rounded-flash")
+    assert flash_box.style.border.top == "─"
+    assert flash_box.style.border.top_left == "╭"
+    assert flash_box.style.border.bottom_right == "╯"
+  end
+
   test "list can render muted while unfocused and restore active colors on focus" do
     {:ok, pid} =
       ChildServer.start(
@@ -577,6 +972,20 @@ defmodule Breeze.BlocksTest do
 
   test "tree virtual window can use implicit-owned expanded state" do
     {:ok, pid} = ChildServer.start(view: VirtualUncontrolledTreeExample, start_opts: [])
+
+    {:ok, _acc, _box} = ChildServer.render(pid, focused: "files", implicit_state: %{})
+
+    assert {:noreply, "files", true} = ChildServer.dispatch_input(pid, "ArrowDown")
+    assert {:noreply, "files", true} = ChildServer.dispatch_input(pid, "Enter")
+
+    {:ok, _acc, box} = ChildServer.render(pid, focused: "files", implicit_state: %{})
+
+    assert box.content =~ "⌄src"
+    assert box.content =~ "lib"
+  end
+
+  test "wrapped virtual tree can use implicit-owned expanded state" do
+    {:ok, pid} = ChildServer.start(view: WrappedVirtualUncontrolledTreeExample, start_opts: [])
 
     {:ok, _acc, _box} = ChildServer.render(pid, focused: "files", implicit_state: %{})
 

--- a/test/breeze/blocks_test.exs
+++ b/test/breeze/blocks_test.exs
@@ -299,6 +299,52 @@ defmodule Breeze.BlocksTest do
     def handle_info(_, term), do: {:noreply, term}
   end
 
+  defmodule WrappedVirtualUncontrolledTreeExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    @nodes [
+      %{
+        id: "root",
+        label: "root",
+        children: [
+          %{id: "src", label: "src", children: [%{id: "lib", label: "lib"}]},
+          %{id: "mix", label: "mix.exs"}
+        ]
+      }
+    ]
+
+    def mount(_opts, term), do: {:ok, term |> focus("files") |> assign(selected: "root")}
+
+    def tree_wrapper(assigns) do
+      ~H"""
+      <.tree
+        id="files"
+        nodes={@nodes}
+        selected={@selected}
+        default_expanded={["root"]}
+        virtual_window={4}
+        br-change="change"
+        style="width-20 height-6"
+      />
+      """
+    end
+
+    def render(assigns) do
+      assigns = assign(assigns, nodes: @nodes)
+
+      ~H"""
+      <.tree_wrapper nodes={@nodes} selected={@selected}/>
+      """
+    end
+
+    def handle_event("change", %{value: value}, term),
+      do: {:noreply, assign(term, selected: value)}
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
   defmodule EmptyTreeExample do
     use Breeze.View
     import Breeze.Blocks
@@ -577,6 +623,20 @@ defmodule Breeze.BlocksTest do
 
   test "tree virtual window can use implicit-owned expanded state" do
     {:ok, pid} = ChildServer.start(view: VirtualUncontrolledTreeExample, start_opts: [])
+
+    {:ok, _acc, _box} = ChildServer.render(pid, focused: "files", implicit_state: %{})
+
+    assert {:noreply, "files", true} = ChildServer.dispatch_input(pid, "ArrowDown")
+    assert {:noreply, "files", true} = ChildServer.dispatch_input(pid, "Enter")
+
+    {:ok, _acc, box} = ChildServer.render(pid, focused: "files", implicit_state: %{})
+
+    assert box.content =~ "⌄src"
+    assert box.content =~ "lib"
+  end
+
+  test "wrapped virtual tree can use implicit-owned expanded state" do
+    {:ok, pid} = ChildServer.start(view: WrappedVirtualUncontrolledTreeExample, start_opts: [])
 
     {:ok, _acc, _box} = ChildServer.render(pid, focused: "files", implicit_state: %{})
 

--- a/test/breeze/blocks_test.exs
+++ b/test/breeze/blocks_test.exs
@@ -3,6 +3,7 @@ defmodule Breeze.BlocksTest do
 
   alias Breeze.Blocks
   alias Breeze.ChildServer
+  alias Breeze.Renderer
 
   defmodule UnderlineTabsExample do
     use Breeze.View
@@ -106,6 +107,168 @@ defmodule Breeze.BlocksTest do
 
     def handle_event(_, _, term), do: {:noreply, term}
     def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule FlashGroupExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <box>Page body</box>
+        <.flash_group id="flash-stack" flash={@flash} width={28} offset={0}/>
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashGapExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      assigns =
+        assign(assigns,
+          variant: Map.get(assigns, :variant, "default"),
+          gap: Map.get(assigns, :gap, 1)
+        )
+
+      ~H"""
+      <box class="width-screen height-screen bg">
+        <box class="width-screen height-screen bg-primary content-repeat">.</box>
+        <.flash_group
+          id="flash-stack"
+          flash={@flash}
+          variant={@variant}
+          width={20}
+          offset={0}
+          gap={@gap}
+        />
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashSlotExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group
+          flash={[%{id: "slot-flash", kind: :warning, highlight: "warning", message: "Careful now"}]}
+          placement="top-left"
+          width={24}
+          offset={0}
+        />
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashDefaultTopOffsetExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group
+          id="flash-stack"
+          flash={[%{id: "default-top-flash", kind: :info, message: "Offset once"}]}
+          placement="top-left"
+          width={24}
+        />
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashTitledExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group
+          flash={[
+        %{
+          id: "titled-flash",
+          kind: :success,
+          highlight: "accent",
+          title: "Saved",
+          message: "Draft persisted"
+        }
+      ]}
+          placement="top-left"
+          width={24}
+          offset={0}
+        />
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashSquareBorderExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group
+          flash={[
+        %{
+          id: "square-flash",
+          kind: :warning,
+          highlight: "warning",
+          title: "Saved #12",
+          message: "Draft synced"
+        }
+      ]}
+          placement="top-left"
+          variant="square"
+          width={25}
+          offset={0}
+        />
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashCustomColorExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group flash={@flash} placement="top-left" width={18} offset={0}/>
+      </box>
+      """
+    end
+  end
+
+  defmodule FlashRoundedBorderExample do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-screen height-screen">
+        <.flash_group
+          flash={[%{id: "rounded-flash", kind: :info, message: "Rounded"}]}
+          placement="top-left"
+          variant="rounded"
+          width={20}
+          offset={0}
+        />
+      </box>
+      """
+    end
   end
 
   defmodule MutedListExample do
@@ -529,6 +692,192 @@ defmodule Breeze.BlocksTest do
     assert box.content =~ "Details"
     assert box.content =~ ~r/\e\[[0-9;]*38;5;4m[╭│╰]/
     assert box.content =~ ~r/\e\[[0-9;]*38;5;4mDetails/
+  end
+
+  test "flash_group renders a fixed bottom-right stack with custom highlights" do
+    flash = [
+      %{id: "saved", kind: :success, message: "Saved draft", highlight: "accent"},
+      %{id: "publish-error", kind: :error, title: "Publish failed", message: "Try again"}
+    ]
+
+    {acc, box} =
+      Renderer.render(FlashGroupExample, %{flash: flash},
+        terminal: %Termite.Terminal{size: %{width: 60, height: 12}}
+      )
+
+    stack = Map.fetch!(acc.boxes, "flash-stack")
+    assert stack.position == :fixed
+    assert stack.right == 0
+    assert stack.bottom == 0
+
+    plain_content = Regex.replace(~r/\e\[[0-9;]*m/u, box.content, "")
+    assert plain_content =~ "Page body"
+    assert plain_content =~ "Saved draft"
+    assert plain_content =~ "Publish failed"
+    assert plain_content =~ "Try again"
+    assert box.content =~ ~r/\e\[[0-9;]*48;5;5(?:;|m)/
+  end
+
+  test "flash item component stays private" do
+    Code.ensure_loaded!(Breeze.Blocks)
+
+    assert function_exported?(Breeze.Blocks, :flash_group, 1)
+    refute function_exported?(Breeze.Blocks, :flash, 1)
+    refute :flash in Breeze.Blocks.__breeze_components__()
+  end
+
+  test "flash_group leaves gaps transparent over existing content" do
+    flash = [
+      %{id: "one", kind: :info, message: "One"},
+      %{id: "two", kind: :info, message: "Two"}
+    ]
+
+    {_acc, box} =
+      Renderer.render(FlashGapExample, %{flash: flash},
+        terminal: %Termite.Terminal{size: %{width: 30, height: 10}}
+      )
+
+    assert {".", gap_style} = Map.fetch!(box.layer_map, {6, 10})
+    assert gap_style =~ "48;5;4"
+  end
+
+  test "square flash_group subtracts one row from the configured gap" do
+    flash = [
+      %{id: "one", kind: :info, message: "One"},
+      %{id: "two", kind: :info, message: "Two"}
+    ]
+
+    {_acc, box} =
+      Renderer.render(FlashGapExample, %{flash: flash, variant: "square"},
+        terminal: %Termite.Terminal{size: %{width: 30, height: 12}}
+      )
+
+    assert {"▔", bottom_border_style} = Map.fetch!(box.layer_map, {6, 10})
+    refute bottom_border_style =~ "49m"
+
+    {_acc, box} =
+      Renderer.render(FlashGapExample, %{flash: flash, variant: "square", gap: 2},
+        terminal: %Termite.Terminal{size: %{width: 30, height: 12}}
+      )
+
+    assert {".", gap_style} = Map.fetch!(box.layer_map, {6, 10})
+    assert gap_style =~ "48;5;4"
+
+    assert {"▁", top_border_style} = Map.fetch!(box.layer_map, {1, 10})
+    refute top_border_style =~ "49m"
+    assert top_border_style =~ ~r/48;(?:5|2);/
+  end
+
+  test "flash_group renders message content and semantic warning highlight" do
+    {acc, box} = Renderer.render(FlashSlotExample, %{})
+
+    plain_content = Regex.replace(~r/\e\[[0-9;]*m/u, box.content, "")
+    assert plain_content =~ "Careful now"
+    assert box.content =~ ~r/\e\[[0-9;]*48;5;3(?:;|m)/
+
+    flash_box = Map.fetch!(acc.boxes, "slot-flash")
+    inline_box = hd(flash_box.children)
+    [highlight_box, body_box] = inline_box.children
+
+    assert flash_box.style.border.top == "─"
+    assert flash_box.style.border.top_left == "┌"
+    assert highlight_box.style.width == 1
+    assert body_box.style.width == 21
+  end
+
+  test "flash_group applies the default top offset once" do
+    {acc, box} = Renderer.render(FlashDefaultTopOffsetExample, %{})
+
+    stack_box = Map.fetch!(acc.boxes, "flash-stack")
+    flash_box = Map.fetch!(acc.boxes, "default-top-flash")
+
+    assert stack_box.top == 1
+    assert flash_box.top == 0
+    assert {"┌", _style} = Map.fetch!(box.layer_map, {1, 1})
+    refute match?({"┌", _style}, Map.get(box.layer_map, {2, 1}))
+  end
+
+  test "flash highlight fills the message content height" do
+    {_acc, box} = Renderer.render(FlashTitledExample, %{})
+
+    assert {" ", first_row_style} = Map.fetch!(box.layer_map, {1, 1})
+    assert {" ", second_row_style} = Map.fetch!(box.layer_map, {2, 1})
+
+    assert first_row_style =~ "48;5;5"
+    assert second_row_style =~ "48;5;5"
+  end
+
+  test "flash_group can use square block borders with a padded color strip" do
+    {acc, box} = Renderer.render(FlashSquareBorderExample, %{})
+
+    plain_content = Regex.replace(~r/\e\[[0-9;]*m/u, box.content, "")
+    assert plain_content =~ "▁▁▁▁▁"
+    assert plain_content =~ "▔▔▔▔▔"
+    assert plain_content =~ "Saved #12"
+    assert plain_content =~ "Draft synced"
+
+    flash_box = Map.fetch!(acc.boxes, "square-flash")
+    assert flash_box.style.border == BackBreeze.Border.none()
+
+    assert {"▌", border_strip_style} = Map.fetch!(box.layer_map, {1, 0})
+    assert {" ", inner_strip_style} = Map.fetch!(box.layer_map, {1, 1})
+    assert {"▌", text_row_strip_style} = Map.fetch!(box.layer_map, {2, 0})
+
+    assert border_strip_style =~ "48;5;3"
+    assert border_strip_style =~ "38;5;7"
+    assert inner_strip_style =~ "48;5;3"
+    assert text_row_strip_style =~ "48;5;3"
+
+    assert {"▁", top_border_style} = Map.fetch!(box.layer_map, {0, 0})
+    assert {"▔", bottom_border_style} = Map.fetch!(box.layer_map, {5, 0})
+
+    refute top_border_style =~ "49m"
+    refute bottom_border_style =~ "49m"
+    assert top_border_style =~ ~r/48;(?:5|2);/
+    assert bottom_border_style =~ ~r/48;(?:5|2);/
+  end
+
+  test "square flash_group block borders use the active theme background" do
+    {_acc, box} =
+      Renderer.render(FlashSquareBorderExample, %{}, theme: Breeze.Theme.builtin(:gruvbox))
+
+    assert {"▁", top_border_style} = Map.fetch!(box.layer_map, {0, 0})
+
+    refute top_border_style =~ "49m"
+    assert top_border_style =~ "48;2;40;40;40"
+
+    assert {"▐", right_border_style} = Map.fetch!(box.layer_map, {1, 24})
+    assert right_border_style =~ "48;2;50;48;47"
+  end
+
+  test "flash_group supports custom hex and RGB tuple highlight colors" do
+    {_acc, hex_box} =
+      Renderer.render(FlashCustomColorExample, %{
+        flash: [%{id: "hex-flash", kind: :info, message: "Hex", highlight: "#f0a"}]
+      })
+
+    assert {" ", hex_highlight_style} = Map.fetch!(hex_box.layer_map, {1, 1})
+    assert hex_highlight_style =~ "48;2;255;0;170"
+
+    {_acc, rgb_box} =
+      Renderer.render(FlashCustomColorExample, %{
+        flash: [%{id: "rgb-flash", kind: :info, message: "RGB", color: {1, 2, 3}}]
+      })
+
+    assert {" ", rgb_highlight_style} = Map.fetch!(rgb_box.layer_map, {1, 1})
+    assert rgb_highlight_style =~ "48;2;1;2;3"
+  end
+
+  test "flash_group can use rounded borders" do
+    {acc, box} = Renderer.render(FlashRoundedBorderExample, %{})
+
+    plain_content = Regex.replace(~r/\e\[[0-9;]*m/u, box.content, "")
+    assert plain_content =~ "Rounded"
+
+    flash_box = Map.fetch!(acc.boxes, "rounded-flash")
+    assert flash_box.style.border.top == "─"
+    assert flash_box.style.border.top_left == "╭"
+    assert flash_box.style.border.bottom_right == "╯"
   end
 
   test "list can render muted while unfocused and restore active colors on focus" do

--- a/test/breeze/style_test.exs
+++ b/test/breeze/style_test.exs
@@ -81,6 +81,21 @@ defmodule Breeze.StyleTest do
     assert element.style.border == BackBreeze.Border.none()
   end
 
+  test "supports border-square class" do
+    element =
+      Style.empty()
+      |> Style.put_class("border-square")
+      |> Style.to_element([])
+
+    assert element.style.border.style == :custom
+    assert element.style.border.top == "▁"
+    assert element.style.border.bottom == "▔"
+    assert element.style.border.left == "▌"
+    assert element.style.border.right == "▐"
+    assert element.style.border.top_left == "▁"
+    assert element.style.border.bottom_right == "▔"
+  end
+
   test "resolve_dimensions reads width and height from classes" do
     assert Style.resolve_dimensions("width-12 height-4", nil) == %{width: 12, height: 4}
   end

--- a/test/breeze/view_test.exs
+++ b/test/breeze/view_test.exs
@@ -2,6 +2,7 @@ defmodule Breeze.ViewTest do
   use ExUnit.Case, async: true
 
   import Breeze.View
+  import Breeze.TestSupport.WaitUntil
 
   defmodule BreezeAssignsView do
     use Breeze.View
@@ -13,6 +14,55 @@ defmodule Breeze.ViewTest do
     end
 
     def handle_event(_, _, term), do: {:noreply, term}
+  end
+
+  defmodule FlashLifecycleView do
+    use Breeze.View
+
+    def render(assigns) do
+      ~H"""
+      <box>flash lifecycle</box>
+      """
+    end
+
+    def handle_event("push", _event, term) do
+      term =
+        term
+        |> put_flash(:info, "One", id: "one", max: 2, duration: 20)
+        |> put_flash(:warning, "Two", id: "two", duration: 250)
+        |> put_flash(:error, "Three", id: "three", duration: 250)
+
+      {:noreply, term}
+    end
+
+    def handle_event("push_serial", _event, term) do
+      term =
+        term
+        |> put_flash(:info, "First", id: "first", max: 1, duration: 220)
+        |> put_flash(:success, "Second", id: "second", duration: 100)
+
+      {:noreply, term}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule FreshFlashView do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def render(assigns) do
+      ~H"""
+      <box>
+        <box>fresh flash</box>
+        <.flash_group flash={@breeze.flash}/>
+      </box>
+      """
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
   end
 
   test "update_implicit updates an existing implicit state" do
@@ -51,6 +101,116 @@ defmodule Breeze.ViewTest do
     assert updated.focus_keybindings == %{
              "editor" => [%{key: "Enter", label: "Save", handler: nil}]
            }
+  end
+
+  test "put_flash appends stackable flash entries" do
+    term = %Breeze.Term{assigns: %{}}
+
+    updated =
+      term
+      |> put_flash(:info, "Saved", id: "save", highlight: "accent")
+      |> put_flash(:error, "Publish failed", id: "publish-error", highlight: "error")
+      |> put_flash(:info, "Custom", id: "custom", color: "#f0a")
+
+    assert Breeze.Flash.entries(updated.assigns.breeze.flash) == [
+             %{id: "save", kind: :info, message: "Saved", highlight: "accent"},
+             %{
+               id: "publish-error",
+               kind: :error,
+               message: "Publish failed",
+               highlight: "error"
+             },
+             %{id: "custom", kind: :info, message: "Custom", highlight: "#f0a"}
+           ]
+
+    assert Breeze.Flash.queued_entries(updated.assigns.breeze.flash) == []
+  end
+
+  test "put_flash queues entries past the visible max" do
+    term =
+      %Breeze.Term{assigns: %{}}
+      |> put_flash(:info, "One", id: "one", max: 2, duration: false)
+      |> put_flash(:info, "Two", id: "two")
+      |> put_flash(:info, "Three", id: "three")
+
+    assert Enum.map(Breeze.Flash.entries(term.assigns.breeze.flash), & &1.id) == ["one", "two"]
+    assert Enum.map(Breeze.Flash.queued_entries(term.assigns.breeze.flash), & &1.id) == ["three"]
+  end
+
+  test "clear_flash removes messages by kind, id, or all messages" do
+    term =
+      %Breeze.Term{assigns: %{}}
+      |> put_flash(:info, "Saved", id: "save")
+      |> put_flash(:error, "Publish failed", id: "publish-error")
+
+    assert Breeze.Flash.entries(clear_flash(term, :info).assigns.breeze.flash) == [
+             %{id: "publish-error", kind: :error, message: "Publish failed"}
+           ]
+
+    assert Breeze.Flash.entries(clear_flash(term, "publish-error").assigns.breeze.flash) == [
+             %{id: "save", kind: :info, message: "Saved"}
+           ]
+
+    assert clear_flash(term).assigns.breeze.flash == []
+  end
+
+  test "standard flash assign exists before any flash helper runs" do
+    session = Breeze.Test.start!(FreshFlashView)
+    on_exit(fn -> Breeze.Test.stop(session) end)
+
+    assert Breeze.Test.render!(session) =~ "fresh flash"
+
+    assert {_acc, %{content: content}} = Breeze.Renderer.render(FreshFlashView, %{})
+    assert content =~ "fresh flash"
+  end
+
+  test "flash timeout clears visible entries and promotes queued entries" do
+    session = Breeze.Test.start!(FlashLifecycleView)
+    on_exit(fn -> Breeze.Test.stop(session) end)
+
+    assert {:noreply, _focused, true} = Breeze.Test.event(session, "push", %{})
+
+    flash = Breeze.Test.metadata(session).assigns.breeze.flash
+    assert Enum.map(Breeze.Flash.entries(flash), & &1.id) == ["one", "two"]
+    assert Enum.map(Breeze.Flash.queued_entries(flash), & &1.id) == ["three"]
+
+    wait_until(fn ->
+      flash = Breeze.Test.metadata(session).assigns.breeze.flash
+
+      Enum.map(Breeze.Flash.entries(flash), & &1.id) == ["two", "three"] and
+        Breeze.Flash.queued_entries(flash) == []
+    end)
+  end
+
+  test "queued flash starts its timeout only after it is promoted" do
+    session = Breeze.Test.start!(FlashLifecycleView)
+    on_exit(fn -> Breeze.Test.stop(session) end)
+
+    assert {:noreply, _focused, true} = Breeze.Test.event(session, "push_serial", %{})
+
+    Process.sleep(130)
+
+    flash = Breeze.Test.metadata(session).assigns.breeze.flash
+    assert Enum.map(Breeze.Flash.entries(flash), & &1.id) == ["first"]
+    assert Enum.map(Breeze.Flash.queued_entries(flash), & &1.id) == ["second"]
+
+    wait_until(fn ->
+      flash = Breeze.Test.metadata(session).assigns.breeze.flash
+
+      Enum.map(Breeze.Flash.entries(flash), & &1.id) == ["second"] and
+        Breeze.Flash.queued_entries(flash) == []
+    end)
+
+    Process.sleep(50)
+
+    flash = Breeze.Test.metadata(session).assigns.breeze.flash
+    assert Enum.map(Breeze.Flash.entries(flash), & &1.id) == ["second"]
+
+    wait_until(fn ->
+      Breeze.Test.metadata(session).assigns.breeze.flash
+      |> Breeze.Flash.entries()
+      |> Enum.empty?()
+    end)
   end
 
   test "switch_theme applies a named theme and standard Breeze metadata assigns" do

--- a/test/breeze/view_test.exs
+++ b/test/breeze/view_test.exs
@@ -2,6 +2,7 @@ defmodule Breeze.ViewTest do
   use ExUnit.Case, async: true
 
   import Breeze.View
+  import Breeze.TestSupport.WaitUntil
 
   defmodule BreezeAssignsView do
     use Breeze.View
@@ -13,6 +14,38 @@ defmodule Breeze.ViewTest do
     end
 
     def handle_event(_, _, term), do: {:noreply, term}
+  end
+
+  defmodule FlashLifecycleView do
+    use Breeze.View
+
+    def render(assigns) do
+      ~H"""
+      <box>flash lifecycle</box>
+      """
+    end
+
+    def handle_event("push", _event, term) do
+      term =
+        term
+        |> put_flash(:info, "One", id: "one", max: 2, duration: 20)
+        |> put_flash(:warning, "Two", id: "two", duration: 250)
+        |> put_flash(:error, "Three", id: "three", duration: 250)
+
+      {:noreply, term}
+    end
+
+    def handle_event("push_serial", _event, term) do
+      term =
+        term
+        |> put_flash(:info, "First", id: "first", max: 1, duration: 220)
+        |> put_flash(:success, "Second", id: "second", duration: 100)
+
+      {:noreply, term}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
   end
 
   test "update_implicit updates an existing implicit state" do
@@ -51,6 +84,106 @@ defmodule Breeze.ViewTest do
     assert updated.focus_keybindings == %{
              "editor" => [%{key: "Enter", label: "Save", handler: nil}]
            }
+  end
+
+  test "put_flash appends stackable flash entries" do
+    term = %Breeze.Term{assigns: %{}}
+
+    updated =
+      term
+      |> put_flash(:info, "Saved", id: "save", highlight: "accent")
+      |> put_flash(:error, "Publish failed", id: "publish-error", highlight: "error")
+      |> put_flash(:info, "Custom", id: "custom", color: "#f0a")
+
+    assert Breeze.Flash.entries(updated.assigns.breeze.flash) == [
+             %{id: "save", kind: :info, message: "Saved", highlight: "accent"},
+             %{
+               id: "publish-error",
+               kind: :error,
+               message: "Publish failed",
+               highlight: "error"
+             },
+             %{id: "custom", kind: :info, message: "Custom", highlight: "#f0a"}
+           ]
+
+    assert Breeze.Flash.queued_entries(updated.assigns.breeze.flash) == []
+  end
+
+  test "put_flash queues entries past the visible max" do
+    term =
+      %Breeze.Term{assigns: %{}}
+      |> put_flash(:info, "One", id: "one", max: 2, duration: false)
+      |> put_flash(:info, "Two", id: "two")
+      |> put_flash(:info, "Three", id: "three")
+
+    assert Enum.map(Breeze.Flash.entries(term.assigns.breeze.flash), & &1.id) == ["one", "two"]
+    assert Enum.map(Breeze.Flash.queued_entries(term.assigns.breeze.flash), & &1.id) == ["three"]
+  end
+
+  test "clear_flash removes messages by kind, id, or all messages" do
+    term =
+      %Breeze.Term{assigns: %{}}
+      |> put_flash(:info, "Saved", id: "save")
+      |> put_flash(:error, "Publish failed", id: "publish-error")
+
+    assert Breeze.Flash.entries(clear_flash(term, :info).assigns.breeze.flash) == [
+             %{id: "publish-error", kind: :error, message: "Publish failed"}
+           ]
+
+    assert Breeze.Flash.entries(clear_flash(term, "publish-error").assigns.breeze.flash) == [
+             %{id: "save", kind: :info, message: "Saved"}
+           ]
+
+    assert clear_flash(term).assigns.breeze.flash == []
+  end
+
+  test "flash timeout clears visible entries and promotes queued entries" do
+    session = Breeze.Test.start!(FlashLifecycleView)
+    on_exit(fn -> Breeze.Test.stop(session) end)
+
+    assert {:noreply, _focused, true} = Breeze.Test.event(session, "push", %{})
+
+    flash = Breeze.Test.metadata(session).assigns.breeze.flash
+    assert Enum.map(Breeze.Flash.entries(flash), & &1.id) == ["one", "two"]
+    assert Enum.map(Breeze.Flash.queued_entries(flash), & &1.id) == ["three"]
+
+    wait_until(fn ->
+      flash = Breeze.Test.metadata(session).assigns.breeze.flash
+
+      Enum.map(Breeze.Flash.entries(flash), & &1.id) == ["two", "three"] and
+        Breeze.Flash.queued_entries(flash) == []
+    end)
+  end
+
+  test "queued flash starts its timeout only after it is promoted" do
+    session = Breeze.Test.start!(FlashLifecycleView)
+    on_exit(fn -> Breeze.Test.stop(session) end)
+
+    assert {:noreply, _focused, true} = Breeze.Test.event(session, "push_serial", %{})
+
+    Process.sleep(130)
+
+    flash = Breeze.Test.metadata(session).assigns.breeze.flash
+    assert Enum.map(Breeze.Flash.entries(flash), & &1.id) == ["first"]
+    assert Enum.map(Breeze.Flash.queued_entries(flash), & &1.id) == ["second"]
+
+    wait_until(fn ->
+      flash = Breeze.Test.metadata(session).assigns.breeze.flash
+
+      Enum.map(Breeze.Flash.entries(flash), & &1.id) == ["second"] and
+        Breeze.Flash.queued_entries(flash) == []
+    end)
+
+    Process.sleep(50)
+
+    flash = Breeze.Test.metadata(session).assigns.breeze.flash
+    assert Enum.map(Breeze.Flash.entries(flash), & &1.id) == ["second"]
+
+    wait_until(fn ->
+      Breeze.Test.metadata(session).assigns.breeze.flash
+      |> Breeze.Flash.entries()
+      |> Enum.empty?()
+    end)
   end
 
   test "switch_theme applies a named theme and standard Breeze metadata assigns" do

--- a/test/breeze_storybook/discovery_test.exs
+++ b/test/breeze_storybook/discovery_test.exs
@@ -25,4 +25,10 @@ defmodule Breeze.Storybook.DiscoveryTest do
     assert Enum.map(stories, & &1.id) == ["dropdown"]
     assert %{id: "dropdown"} = Registry.first_story("storybook", file: "dropdown.story.exs")
   end
+
+  test "flash story covers each flash_group variant" do
+    [%{id: "flash", variants: variants}] = Registry.stories("storybook", file: "flash.story.exs")
+
+    assert Enum.map(variants, & &1.id) == ["default", "square", "rounded"]
+  end
 end

--- a/test/breeze_storybook/view_test.exs
+++ b/test/breeze_storybook/view_test.exs
@@ -33,6 +33,30 @@ defmodule Breeze.Storybook.ViewTest do
     def resize(term), do: term.size
   end
 
+  defp select_story!(pid, story_id) do
+    state = :sys.get_state(pid)
+    stories = state.assigns.stories
+    current = Enum.find_index(stories, &(&1.id == state.assigns.current_story_id))
+    target = Enum.find_index(stories, &(&1.id == story_id))
+
+    assert is_integer(current)
+    assert is_integer(target)
+
+    move_story!(pid, target - current)
+    assert :sys.get_state(pid).assigns.current_story_id == story_id
+  end
+
+  defp move_story!(_pid, 0), do: :ok
+
+  defp move_story!(pid, steps) do
+    key = if steps > 0, do: "ArrowDown", else: "ArrowUp"
+
+    1..abs(steps)
+    |> Enum.each(fn _ ->
+      assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, key)
+    end)
+  end
+
   test "dropdown story renders a single visible closed indicator" do
     terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
     {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
@@ -120,8 +144,7 @@ defmodule Breeze.Storybook.ViewTest do
     {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "input")
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
 
     child = :sys.get_state(pid).children["storybook-preview"].pid
@@ -149,8 +172,7 @@ defmodule Breeze.Storybook.ViewTest do
     {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "input")
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
 
     child = :sys.get_state(pid).children["storybook-preview"].pid
@@ -178,8 +200,7 @@ defmodule Breeze.Storybook.ViewTest do
     {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "input")
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
 
     assert {:noreply, "storybook-preview::storybook-input-active", true} =
@@ -284,10 +305,7 @@ defmodule Breeze.Storybook.ViewTest do
     {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "modal")
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
 
     assert {:noreply, "storybook-preview::storybook-modal-trigger", true} =
@@ -460,9 +478,7 @@ defmodule Breeze.Storybook.ViewTest do
     {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "list")
     assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, terminal: terminal)
 
     plain_content = Regex.replace(~r/\e\[[0-9;]*m/u, box.content, "")
@@ -488,9 +504,7 @@ defmodule Breeze.Storybook.ViewTest do
     {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "list")
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
 
     assert {:noreply, "storybook-variant-tabs", true} =
@@ -535,9 +549,7 @@ defmodule Breeze.Storybook.ViewTest do
     {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "list")
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
 
     assert {:noreply, "storybook-preview::storybook-list-muted", true} =
@@ -600,6 +612,12 @@ defmodule Breeze.Storybook.ViewTest do
     send(pid, {reader, {:data, "\e[B"}})
 
     wait_until(fn ->
+      :sys.get_state(view_pid).assigns.current_story_id == "flash"
+    end)
+
+    send(pid, {reader, {:data, "\e[B"}})
+
+    wait_until(fn ->
       :sys.get_state(view_pid).assigns.current_story_id == "input"
     end)
 
@@ -654,12 +672,7 @@ defmodule Breeze.Storybook.ViewTest do
     {:ok, pid} = Breeze.ChildServer.start(view: Breeze.Storybook.View, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "scroll")
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
 
     assert {:noreply, "storybook-preview::storybook-scroll", true} =


### PR DESCRIPTION
Adds a flash state API with put, clear, expiry, visible limits, and queued promotion, plus a flash_group renderer with placement, variants, and semantic or custom highlights. Includes square border styling to avoid a border in the middle of a background color.