### PR TITLE
fix(Breeze.InputRouter): harden IEx shell proxy and palette probes

### DIFF
--- a/lib/breeze/input_router.ex
+++ b/lib/breeze/input_router.ex
@@ -6,6 +6,8 @@ defmodule Breeze.InputRouter do
   alias Breeze.InputRouter.{IExShellProxy, SilentGroupLeader, TerminalStart}
   alias Breeze.InputCapture
 
+  @theme_probe_drain_timeout_ms 1_000
+
   defstruct [
     :terminal,
     :reader,
@@ -109,12 +111,26 @@ defmodule Breeze.InputRouter do
   end
 
   def handle_info(
-        {:theme_probe_timeout, key},
-        %{theme_probe: %{key: key, palette: palette}} = state
+        {:theme_probe_timeout, key, ref},
+        %{theme_probe: %{key: key, ref: ref, status: :active} = probe} = state
       ) do
-    Breeze.Theme.finish_runtime_palette_probe(state.terminal, palette)
+    {:noreply, start_theme_probe_drain(state, probe)}
+  end
+
+  def handle_info({:theme_probe_timeout, _key, _ref}, state), do: {:noreply, state}
+
+  def handle_info(
+        {:theme_probe_drain_timeout, key, ref},
+        %{theme_probe: %{key: key, ref: ref, status: :draining} = probe} = state
+      ) do
+    unless Map.get(probe, :finished?, false) do
+      Breeze.Theme.finish_runtime_palette_probe(state.terminal, probe.palette)
+    end
+
     {:noreply, %{state | theme_probe: nil}}
   end
+
+  def handle_info({:theme_probe_drain_timeout, _key, _ref}, state), do: {:noreply, state}
 
   def handle_info({:DOWN, _ref, :process, pid, _reason}, %{server_pid: pid} = state) do
     stop(state)
@@ -163,8 +179,21 @@ defmodule Breeze.InputRouter do
   end
 
   defp theme_probe_reply?(state, data) do
-    is_map(state.theme_probe) and is_binary(data) and String.starts_with?(data, "\e]")
+    is_map(state.theme_probe) and
+      theme_probe_data?(state.theme_probe.buffer, data)
   end
+
+  defp theme_probe_data?(buffer, data) when is_binary(data) do
+    String.starts_with?(data, "\e]") or incomplete_theme_probe_reply?(buffer)
+  end
+
+  defp theme_probe_data?(_buffer, _data), do: false
+
+  defp incomplete_theme_probe_reply?(buffer) when is_binary(buffer) do
+    :binary.match(buffer, "\e]") != :nomatch
+  end
+
+  defp incomplete_theme_probe_reply?(_buffer), do: false
 
   defp stop_decoded_input?({:key, key}, state), do: stop_global_key?(key, state)
   defp stop_decoded_input?(_decoded, _state), do: false
@@ -192,26 +221,37 @@ defmodule Breeze.InputRouter do
     :exit, _reason -> false
   end
 
-  defp maybe_start_theme_probe(%{theme_probe: probe} = state, _theme) when is_map(probe),
+  defp maybe_start_theme_probe(%{theme_probe: %{status: :active}} = state, _theme),
     do: state
 
   defp maybe_start_theme_probe(state, theme) do
     if requested_system_theme?(theme) do
       case Breeze.Theme.start_runtime_palette_probe(state.terminal) do
         {:start, key, query} ->
+          cancel_theme_probe_timer(state.theme_probe)
+
+          ref = make_ref()
           terminal = Termite.Terminal.write(state.terminal, query)
 
           timer =
             Process.send_after(
               self(),
-              {:theme_probe_timeout, key},
+              {:theme_probe_timeout, key, ref},
               Breeze.Theme.runtime_palette_probe_timeout_ms()
             )
 
           %{
             state
             | terminal: terminal,
-              theme_probe: %{key: key, buffer: "", palette: %{}, timer: timer}
+              theme_probe: %{
+                key: key,
+                ref: ref,
+                buffer: "",
+                palette: %{},
+                timer: timer,
+                status: :active,
+                finished?: false
+              }
           }
 
         _ ->
@@ -229,14 +269,36 @@ defmodule Breeze.InputRouter do
 
     probe = %{probe | palette: palette, buffer: buffer}
 
-    if Breeze.Theme.runtime_palette_probe_complete?(palette) do
-      Process.cancel_timer(probe.timer)
-      Breeze.Theme.finish_runtime_palette_probe(state.terminal, palette)
-      %{state | theme_probe: nil}
-    else
-      %{state | theme_probe: probe}
+    cond do
+      Breeze.Theme.runtime_palette_probe_complete?(palette) and
+          not Map.get(probe, :finished?, false) ->
+        Breeze.Theme.finish_runtime_palette_probe(state.terminal, palette)
+        start_theme_probe_drain(state, %{probe | finished?: true})
+
+      true ->
+        %{state | theme_probe: probe}
     end
   end
+
+  defp start_theme_probe_drain(state, probe) do
+    cancel_theme_probe_timer(probe)
+
+    timer =
+      Process.send_after(
+        self(),
+        {:theme_probe_drain_timeout, probe.key, probe.ref},
+        @theme_probe_drain_timeout_ms
+      )
+
+    %{state | theme_probe: %{probe | status: :draining, timer: timer}}
+  end
+
+  defp cancel_theme_probe_timer(%{timer: timer}) when is_reference(timer) do
+    Process.cancel_timer(timer)
+    :ok
+  end
+
+  defp cancel_theme_probe_timer(_probe), do: :ok
 
   defp maybe_complete_initial_theme_probe(terminal, theme) do
     if requested_system_theme?(theme) do
@@ -273,7 +335,7 @@ defmodule Breeze.InputRouter do
 
       receive do
         {^reader, {:data, data}} = message when is_binary(data) ->
-          if String.starts_with?(data, "\e]") do
+          if theme_probe_data?(buffer, data) do
             {palette, buffer} = Breeze.Theme.merge_runtime_palette_data(buffer, palette, data)
 
             collect_initial_theme_probe_replies(
@@ -367,13 +429,35 @@ defmodule Breeze.InputRouter do
     try do
       Process.group_leader(self(), silent_group_leader)
 
+      terminal = Termite.Terminal.start(terminal_opts)
+      maybe_restore_target_shell_input_mode(terminal, original_group_leader)
+
       %TerminalStart{
-        terminal: Termite.Terminal.start(terminal_opts),
+        terminal: terminal,
         silent_group_leader: silent_group_leader
       }
     after
       Process.group_leader(self(), original_group_leader)
     end
+  end
+
+  defp maybe_restore_target_shell_input_mode(
+         %Termite.Terminal{adapter: {Termite.Terminal.Shell, _shell}},
+         group_leader
+       )
+       when node(group_leader) != node() do
+    set_target_shell_input_mode(:cooked)
+  end
+
+  defp maybe_restore_target_shell_input_mode(_terminal, _group_leader), do: :ok
+
+  defp set_target_shell_input_mode(mode) when mode in [:raw, :cooked] do
+    case :shell.start_interactive({:noshell, mode}) do
+      :ok -> :ok
+      {:error, _reason} -> :ok
+    end
+  catch
+    _kind, _reason -> :ok
   end
 
   defp maybe_replace_iex_shell_reader(

--- a/lib/breeze/input_router/iex_shell_proxy.ex
+++ b/lib/breeze/input_router/iex_shell_proxy.ex
@@ -1,28 +1,36 @@
 defmodule Breeze.InputRouter.IExShellProxy do
   @moduledoc false
 
-  def start_link(target) do
-    previous_group_leader = Process.group_leader()
+  def start_link(target, opts \\ []) do
+    previous_group_leader = Keyword.get(opts, :group_leader, Process.group_leader())
+    input_mode_fun = Keyword.get(opts, :input_mode_fun, &set_input_mode/2)
 
-    with {:ok, user_drv, previous_group, reader} <- start_reader(target) do
+    with {:ok, user_drv, previous_group, reader} <-
+           start_reader(target, previous_group_leader, opts) do
       {:ok,
        %{
          pid: reader,
          user_drv: user_drv,
          previous_group: previous_group,
-         previous_group_leader: previous_group_leader
+         previous_group_leader: previous_group_leader,
+         input_mode_fun: input_mode_fun
        }}
     end
   end
 
   def stop(nil), do: :ok
 
-  def stop(%{
-        pid: pid,
-        user_drv: user_drv,
-        previous_group: previous_group,
-        previous_group_leader: previous_group_leader
-      }) do
+  def stop(%{} = proxy) do
+    %{
+      pid: pid,
+      user_drv: user_drv,
+      previous_group: previous_group,
+      previous_group_leader: previous_group_leader
+    } = proxy
+
+    input_mode_fun = Map.get(proxy, :input_mode_fun, &set_input_mode/2)
+
+    restore_input_mode(user_drv, input_mode_fun)
     restore_user_drv_group(user_drv, previous_group)
     restore_process_group_leader(previous_group_leader)
     stop_proxy(pid)
@@ -30,9 +38,13 @@ defmodule Breeze.InputRouter.IExShellProxy do
     :ok
   end
 
-  defp start_reader(target) do
-    with user_drv when is_pid(user_drv) <- Process.whereis(:user_drv),
-         {:ok, previous_group, _user_group} <- current_user_drv_groups(user_drv) do
+  defp start_reader(target, group_leader, opts) do
+    user_drv_lookup = Keyword.get(opts, :user_drv_lookup, &user_drv_on_node/1)
+    input_mode_fun = Keyword.get(opts, :input_mode_fun, &set_input_mode/2)
+
+    with user_drv when is_pid(user_drv) <- user_drv_lookup.(node(group_leader)),
+         {:ok, previous_group, _user_group} <- current_user_drv_groups(user_drv),
+         :ok <- input_mode_fun.(node(user_drv), :raw) do
       proxy = spawn_link(fn -> proxy_loop(target, user_drv, %{}) end)
       set_user_drv_group(user_drv, proxy)
       Process.group_leader(self(), proxy)
@@ -43,6 +55,14 @@ defmodule Breeze.InputRouter.IExShellProxy do
     end
   catch
     _kind, _reason -> :error
+  end
+
+  defp user_drv_on_node(target_node) when target_node == node(), do: Process.whereis(:user_drv)
+
+  defp user_drv_on_node(target_node) do
+    :erpc.call(target_node, :erlang, :whereis, [:user_drv])
+  catch
+    _kind, _reason -> nil
   end
 
   defp proxy_loop(target, user_drv, pending) do
@@ -193,6 +213,31 @@ defmodule Breeze.InputRouter.IExShellProxy do
   end
 
   defp restore_user_drv_group(_user_drv, _previous_group), do: :ok
+
+  defp restore_input_mode(user_drv, input_mode_fun) when is_pid(user_drv) do
+    input_mode_fun.(node(user_drv), :cooked)
+    :ok
+  catch
+    _kind, _reason -> :ok
+  end
+
+  defp restore_input_mode(_user_drv, _input_mode_fun), do: :ok
+
+  defp set_input_mode(target_node, mode) when mode in [:raw, :cooked] do
+    result =
+      if target_node == node() do
+        :shell.start_interactive({:noshell, mode})
+      else
+        :erpc.call(target_node, :shell, :start_interactive, [{:noshell, mode}])
+      end
+
+    case result do
+      :ok -> :ok
+      {:error, _reason} -> :ok
+    end
+  catch
+    _kind, _reason -> :ok
+  end
 
   defp restore_process_group_leader(previous_group_leader) when is_pid(previous_group_leader) do
     Process.group_leader(self(), previous_group_leader)

--- a/lib/breeze/theme/probe.ex
+++ b/lib/breeze/theme/probe.ex
@@ -181,11 +181,11 @@ defmodule Breeze.Theme.Probe do
   end
 
   defp palette_query_sequence do
-    foreground_background = ["\e]10;?\a", "\e]11;?\a"]
+    foreground_background = ["\e]10;?\e\\", "\e]11;?\e\\"]
 
     indexed =
       Enum.map(@required_palette_indexes, fn index ->
-        ["\e]4;", Integer.to_string(index), ";?\a"]
+        ["\e]4;", Integer.to_string(index), ";?\e\\"]
       end)
 
     IO.iodata_to_binary(foreground_background ++ indexed)

--- a/test/breeze/input_router/iex_shell_proxy_test.exs
+++ b/test/breeze/input_router/iex_shell_proxy_test.exs
@@ -1,0 +1,104 @@
+defmodule Breeze.InputRouter.IExShellProxyTest do
+  use ExUnit.Case, async: true
+
+  alias Breeze.InputRouter.IExShellProxy
+
+  defmodule FakeUserDrv do
+    use GenServer
+
+    def start_link(owner) do
+      user_group = owner
+      previous_group = owner
+
+      data =
+        Tuple.duplicate(nil, 9)
+        |> put_elem(7, user_group)
+        |> put_elem(8, previous_group)
+
+      GenServer.start_link(__MODULE__, {:fake_user_drv, data})
+    end
+
+    def start_link_with_state(state) do
+      GenServer.start_link(__MODULE__, state)
+    end
+
+    @impl true
+    def init(state), do: {:ok, state}
+  end
+
+  test "proxies the group leader node user_drv and restores it on stop" do
+    parent = self()
+    original_group_leader = Process.group_leader()
+    {:ok, user_drv} = FakeUserDrv.start_link(parent)
+
+    input_mode_fun = fn node, mode ->
+      send(parent, {:input_mode, node, mode})
+      :ok
+    end
+
+    user_drv_lookup = fn node ->
+      send(parent, {:lookup, node})
+      user_drv
+    end
+
+    {:ok, proxy} =
+      IExShellProxy.start_link(parent,
+        input_mode_fun: input_mode_fun,
+        user_drv_lookup: user_drv_lookup
+      )
+
+    try do
+      assert_receive {:lookup, node}
+      assert node == node(original_group_leader)
+      assert_receive {:input_mode, user_drv_node, :raw}
+      assert user_drv_node == node(user_drv)
+      assert Process.group_leader() == proxy.pid
+
+      {_state_name, data} = :sys.get_state(user_drv)
+      assert elem(data, 8) == proxy.pid
+
+      send(proxy.pid, {user_drv, {:data, "x"}})
+      assert_receive {:data, "x"}
+
+      proxy_ref = Process.monitor(proxy.pid)
+
+      assert :ok = IExShellProxy.stop(proxy)
+      assert_receive {:input_mode, ^user_drv_node, :cooked}
+      assert_receive {^user_drv, :activate}
+      assert Process.group_leader() == original_group_leader
+      assert_receive {:DOWN, ^proxy_ref, :process, _pid, _reason}
+
+      {_state_name, data} = :sys.get_state(user_drv)
+      assert elem(data, 8) == parent
+      refute Process.alive?(proxy.pid)
+    after
+      Process.group_leader(self(), original_group_leader)
+
+      if Process.alive?(proxy.pid) do
+        IExShellProxy.stop(proxy)
+      end
+    end
+  end
+
+  test "does not switch input mode when user_drv state cannot be inspected" do
+    parent = self()
+    original_group_leader = Process.group_leader()
+    {:ok, user_drv} = FakeUserDrv.start_link_with_state(:unexpected_state)
+
+    input_mode_fun = fn node, mode ->
+      send(parent, {:input_mode, node, mode})
+      :ok
+    end
+
+    user_drv_lookup = fn _node -> user_drv end
+
+    assert :error =
+             IExShellProxy.start_link(parent,
+               input_mode_fun: input_mode_fun,
+               user_drv_lookup: user_drv_lookup
+             )
+
+    refute_received {:input_mode, _, _}
+    assert Process.group_leader() == original_group_leader
+  end
+end

--- a/test/breeze/input_router_test.exs
+++ b/test/breeze/input_router_test.exs
@@ -65,6 +65,84 @@ defmodule Breeze.InputRouterTest do
     end
   end
 
+  defmodule SplitPaletteAdapter do
+    @behaviour Termite.Terminal.Adapter
+
+    def start(_opts) do
+      {:ok, %{ref: make_ref(), size: %{width: 80, height: 24}}}
+    end
+
+    def reader(term), do: {:ok, term.ref}
+    def resize(term), do: term.size
+
+    def write(term, str) do
+      if String.contains?(str, "\e]10;?") do
+        owner = self()
+        ref = term.ref
+
+        send(owner, {ref, {:data, "\e]10;rgb:f0f0/f0f0/f0f0\a"}})
+        send(owner, {ref, {:data, "\e]11;rgb:1010/1111/1212\a"}})
+        send(owner, {ref, {:data, "\e]4;1;rgb:aaaa/2222/3333\a"}})
+        send(owner, {ref, {:data, "\e]4;2;rgb:2222/aaaa/3333\a"}})
+        send(owner, {ref, {:data, "\e]4;3;rgb:cccc/bbbb/3333\a"}})
+        send(owner, {ref, {:data, "\e]4;4;rgb:3333/5555/aaaa\a"}})
+        send(owner, {ref, {:data, "\e]4;5;rgb:9999/3333/aaaa\a"}})
+        send(owner, {ref, {:data, "\e]4;6;rgb:3333/aaaa/aaaa\a"}})
+        send(owner, {ref, {:data, "\e]4;9;rgb:dddd/6666/4444\a"}})
+        send(owner, {ref, {:data, "\e]4;10;rgb:4444/cccc/5555\a"}})
+        send(owner, {ref, {:data, "\e]4;11;rgb:e6e6/d1d1/5a5a\a"}})
+        send(owner, {ref, {:data, "\e]4;12;rgb:5f5f/7b7b/e0e0\a"}})
+        send(owner, {ref, {:data, "\e]4;13;rgb:b3b3/6b6b/d4d4\a"}})
+        send(owner, {ref, {:data, "\e]"}})
+        send(owner, {ref, {:data, "4;14;rgb:5a5a/d6d6/d6d6\a"}})
+      end
+
+      {:ok, term}
+    end
+  end
+
+  defmodule DelayedPaletteAdapter do
+    @behaviour Termite.Terminal.Adapter
+
+    def start(_opts) do
+      {:ok, %{ref: make_ref(), size: %{width: 80, height: 24}}}
+    end
+
+    def reader(term), do: {:ok, term.ref}
+    def resize(term), do: term.size
+
+    def write(term, str) do
+      if String.contains?(str, "\e]10;?") do
+        owner = self()
+        ref = term.ref
+
+        send(owner, {ref, {:data, "\e]10;rgb:f0f0/f0f0/f0f0\a"}})
+        send(owner, {ref, {:data, "\e]11;rgb:1010/1111/1212\a"}})
+        send(owner, {ref, {:data, "\e]4;1;rgb:aaaa/2222/3333\a"}})
+        send(owner, {ref, {:data, "\e]4;2;rgb:2222/aaaa/3333\a"}})
+        send(owner, {ref, {:data, "\e]4;3;rgb:cccc/bbbb/3333\a"}})
+        send(owner, {ref, {:data, "\e]4;4;rgb:3333/5555/aaaa\a"}})
+
+        Process.send_after(
+          owner,
+          {ref,
+           {:data,
+            "\e]4;5;rgb:9999/3333/aaaa\a" <>
+              "\e]4;6;rgb:3333/aaaa/aaaa\a" <>
+              "\e]4;9;rgb:dddd/6666/4444\a" <>
+              "\e]4;10;rgb:4444/cccc/5555\a" <>
+              "\e]4;11;rgb:e6e6/d1d1/5a5a\a" <>
+              "\e]4;12;rgb:5f5f/7b7b/e0e0\a" <>
+              "\e]4;13;rgb:b3b3/6b6b/d4d4\a" <>
+              "\e]4;14;rgb:5a5a/d6d6/d6d6\a"}},
+          Breeze.Theme.runtime_palette_probe_timeout_ms() + 20
+        )
+      end
+
+      {:ok, term}
+    end
+  end
+
   defmodule BlockingView do
     use Breeze.View
 
@@ -277,6 +355,35 @@ defmodule Breeze.InputRouterTest do
     wait_until(fn ->
       Enum.all?([supervisor, server, root, child], &(not Process.alive?(&1)))
     end)
+  end
+
+  defmodule ThemeProbeLeakView do
+    use Breeze.View
+
+    def mount(opts, term) do
+      {:ok,
+       term
+       |> put_theme(Theme.builtin(:gruvbox))
+       |> assign(parent: Keyword.fetch!(opts, :parent))}
+    end
+
+    def render(assigns) do
+      ~H"""
+      <box>probe</box>
+      """
+    end
+
+    def handle_event(_, %{"key" => "t"}, term) do
+      send(term.assigns.parent, :theme_switch)
+      {:noreply, put_theme(term, :system)}
+    end
+
+    def handle_event(_, event, term) do
+      send(term.assigns.parent, {:leaked_input, event})
+      {:noreply, term}
+    end
+
+    def handle_info(_, term), do: {:noreply, term}
   end
 
   test "stop global keys are handled even while the app server is blocked" do
@@ -704,6 +811,71 @@ defmodule Breeze.InputRouterTest do
     wait_until(fn ->
       :sys.get_state(server_pid).frame.base_output =~ "mode=system status=ready"
     end)
+
+    Process.exit(pid, :normal)
+  end
+
+  test "split runtime palette replies are consumed instead of forwarded as input" do
+    parent = self()
+
+    {:ok, pid} =
+      Breeze.InputRouter.start_link(
+        view: ThemeProbeLeakView,
+        start_opts: [parent: parent],
+        hide_cursor: false,
+        terminal_opts: [adapter: SplitPaletteAdapter],
+        halt_fun: fn -> send(parent, :halted) end
+      )
+
+    state = :sys.get_state(pid)
+    reader = state.reader
+    server_pid = state.server_pid
+    child_pid = :sys.get_state(server_pid).view_pid
+
+    send(pid, {reader, {:data, "t"}})
+    assert_receive :theme_switch
+
+    wait_until(fn ->
+      metadata = ChildServer.metadata(child_pid)
+      metadata.theme.mode == :system and metadata.theme.variables[:palette_probe_status] == :ready
+    end)
+
+    refute_receive {:leaked_input, _event}, 50
+
+    Process.exit(pid, :normal)
+  end
+
+  test "late runtime palette replies are drained instead of forwarded as input" do
+    parent = self()
+
+    {:ok, pid} =
+      Breeze.InputRouter.start_link(
+        view: ThemeProbeLeakView,
+        start_opts: [parent: parent],
+        hide_cursor: false,
+        terminal_opts: [adapter: DelayedPaletteAdapter],
+        halt_fun: fn -> send(parent, :halted) end
+      )
+
+    state = :sys.get_state(pid)
+    reader = state.reader
+    server_pid = state.server_pid
+    child_pid = :sys.get_state(server_pid).view_pid
+
+    send(pid, {reader, {:data, "t"}})
+    assert_receive :theme_switch
+
+    wait_until(
+      fn ->
+        metadata = ChildServer.metadata(child_pid)
+
+        metadata.theme.mode == :system and
+          metadata.theme.variables[:palette_probe_status] == :ready
+      end,
+      80
+    )
+
+    refute_receive {:leaked_input, _event}, 50
 
     Process.exit(pid, :normal)
   end

--- a/test/breeze/theme_test.exs
+++ b/test/breeze/theme_test.exs
@@ -159,6 +159,21 @@ defmodule Breeze.ThemeTest do
     assert Theme.color(theme, :background) == 0
   end
 
+  test "runtime palette query uses ST terminators instead of BEL" do
+    ref = make_ref()
+
+    terminal = %Termite.Terminal{
+      reader: ref,
+      adapter: {PaletteAdapter, %{ref: ref}},
+      size: %{width: 80, height: 24}
+    }
+
+    assert {:start, {:reader, ^ref}, query} = Theme.start_runtime_palette_probe(terminal)
+    refute query =~ "\a"
+    assert query =~ "\e]10;?\e\\"
+    assert query =~ "\e]4;14;?\e\\"
+  end
+
   test "system can derive colors from a probed runtime palette" do
     ref = make_ref()
 


### PR DESCRIPTION
Restore the target shell input mode when pausing IEx, and make the IEx shell proxy look up user_drv on the target group leader node.

Validate user_drv state before switching it to raw mode, restore cooked mode when stopping the proxy, and wait for the proxy process to exit in tests.

Keep runtime palette probe replies out of normal input by handling split OSC replies, draining late replies after probe timeout, and ignoring stale probe timers.

Use ST-terminated OSC palette queries instead of BEL-terminated queries to avoid sending Ctrl-G through the Erlang terminal driver. This prevents the erlang break prompt from displaying and rendering in the middle of the terminal.