### PR TITLE
feat(Breeze.Style): support responsive breakpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The project began as the engine for the Snake game included in the
 - Slots
 - Scrollable viewports through implicit modifiers (`scroll_y`, `scroll_x`,
   `scroll`)
+- Minimum-width breakpoints for responsive terminal layouts
 - Built-in blocks for common interface patterns (`list`, `dropdown`, `tabs`,
   `markdown`, `scroll`, `panel`, `modal`)
 

--- a/examples/posting.exs
+++ b/examples/posting.exs
@@ -66,10 +66,10 @@ defmodule Posting do
             <box class="inline width-full height-1">
               <box class="bold text-primary">Req It Ralph</box>
               <box class="text-muted"> 0.0.1</box>
-              <box class="text-muted">
+              <box class="hidden md:block text-muted">
                 {" "}{@breeze.theme.name}/{@breeze.theme.actual_mode} ({@breeze.theme.status})
               </box>
-              <box class="width-full text-right text-muted">{@user_host}</box>
+              <box class="hidden md:block md:width-full text-right text-muted">{@user_host}</box>
             </box>
           </box>
           <box style="grid grid-cols-5 height-2 padding-bottom-1">
@@ -95,21 +95,25 @@ defmodule Posting do
             <box style="bg-primary text-bg width-1">▐</box>
           </box>
           <box style="grid grid-cols-1 grid-rows-2 height-full">
-            <box style="grid grid-cols-2 height-full">
-              <.panel id="collection-panel" class="height-full width-full overflow-hidden bg">
-                <box class="width-full height-full padding-right-1 padding-bottom-1 overflow-hidden">
-                  <.list
-                    id="collection"
-                    variant="muted"
-                    list-scroll-padding={1}
-                    class="bg height-full width-full overflow-scroll border-0 focus:border-0"
-                    item_style="width-full"
+            <box class="grid grid-cols-1 md:grid-cols-2 height-full">
+              <box class="hidden md:block">
+                <.panel id="collection-panel" class="height-full width-full overflow-hidden bg">
+                  <box
+                    class="width-full height-full padding-right-1 padding-bottom-1 overflow-hidden"
                   >
-                    <:item :for={{val, label} <- @collection} value={val}>{label}</:item>
-                  </.list>
-                </box>
-              </.panel>
-              <box style="grid grid-cols-1 grid-rows-2 height-full">
+                    <.list
+                      id="collection"
+                      variant="muted"
+                      list-scroll-padding={1}
+                      class="bg height-full width-full overflow-scroll border-0 focus:border-0"
+                      item_style="width-full"
+                    >
+                      <:item :for={{val, label} <- @collection} value={val}>{label}</:item>
+                    </.list>
+                  </box>
+                </.panel>
+              </box>
+              <box class="grid grid-cols-1 grid-rows-2 height-full">
                 <.panel id="request-panel" class="height-full overflow-hidden bg focus:border-accent">
                   <.tabs
                     id="request-tabs"
@@ -322,8 +326,6 @@ defmodule Posting do
 
   def handle_event(_, %{"key" => "q"}, term), do: {:stop, term}
   def handle_event(_, _, term), do: {:noreply, term}
-
-  def handle_info(:resize, term), do: {:noreply, term}
 
   def handle_info(_, term), do: {:noreply, term}
 

--- a/examples/responsive.exs
+++ b/examples/responsive.exs
@@ -1,0 +1,60 @@
+defmodule Responsive do
+  use Breeze.View
+
+  def mount(_opts, term), do: {:ok, term}
+
+  def render(assigns) do
+    ~H"""
+    <box class="width-screen height-screen overflow-hidden bg padding-0 sm:padding-1 lg:padding-2">
+      <box class="bold text-primary">Operations</box>
+      <box class="text-muted">
+        {@breeze.terminal.width}×{@breeze.terminal.height} · {@breeze.breakpoint} breakpoint
+      </box>
+      <box class="md:hidden text-muted">[O] [A] [Q] [N] · q quit</box>
+      <box class="hidden md:block text-muted">Overview  Activity  Queue  Nodes · q quit</box>
+      <box
+        class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-0 gap-y-0 sm:gap-x-1 sm:gap-y-1 lg:gap-x-2 width-full sm:padding-top-1"
+      >
+        <box
+          class="border-none sm:border-square lg:border-rounded border-primary bg-panel width-full height-2 sm:height-4 overflow-hidden padding-left-0 padding-right-0 sm:padding-left-1 sm:padding-right-1"
+        >
+          <box class="bold">Overview</box>
+          <box class="text-success">Healthy</box>
+        </box>
+        <box
+          class="border-none sm:border-square lg:border-rounded border-accent bg-panel width-full height-2 sm:height-4 overflow-hidden padding-left-0 padding-right-0 sm:padding-left-1 sm:padding-right-1"
+        >
+          <box class="bold">Activity</box>
+          <box>128 events</box>
+        </box>
+        <box
+          class="border-none sm:border-square lg:border-rounded border-warning bg-panel width-full height-2 sm:height-4 overflow-hidden padding-left-0 padding-right-0 sm:padding-left-1 sm:padding-right-1"
+        >
+          <box class="bold">Queue</box>
+          <box>7 waiting</box>
+        </box>
+        <box
+          class="border-none sm:border-square lg:border-rounded border-success bg-panel width-full height-2 sm:height-4 overflow-hidden padding-left-0 padding-right-0 sm:padding-left-1 sm:padding-right-1"
+        >
+          <box class="bold">Nodes</box>
+          <box>12 online</box>
+        </box>
+      </box>
+      <box class="hidden lg:block padding-top-1 text-muted">
+        Wide layout keeps every service visible in a single row.
+      </box>
+    </box>
+    """
+  end
+
+  def handle_event(_, _, term), do: {:noreply, term}
+  def handle_info(_, term), do: {:noreply, term}
+end
+
+Breeze.Example.run(
+  [
+    view: Responsive,
+    global_keybindings: [{"q", fn _event, term -> {:stop, term} end}]
+  ],
+  keep_alive: :infinity
+)

--- a/lib/breeze/child_server.ex
+++ b/lib/breeze/child_server.ex
@@ -422,6 +422,8 @@ defmodule Breeze.ChildServer do
       |> maybe_put_theme_assign(:actual_theme_mode, theme.mode)
       |> put_breeze_assign(:theme, breeze_theme_assign(term))
       |> put_breeze_assign(:keybindings, active_keybindings(term))
+      |> put_breeze_assign(:terminal, breeze_terminal_assign(term))
+      |> put_breeze_assign(:breakpoint, breeze_breakpoint_assign(term))
       |> put_breeze_assign_new(:flash, [])
 
     %{term | assigns: assigns}
@@ -458,6 +460,18 @@ defmodule Breeze.ChildServer do
     end)
   end
 
+  defp breeze_terminal_assign(%{terminal: %{size: %{width: width, height: height}}}),
+    do: %{width: width, height: height}
+
+  defp breeze_terminal_assign(_term), do: nil
+
+  defp breeze_breakpoint_assign(term) do
+    case breeze_terminal_assign(term) do
+      %{width: width} -> Breeze.Style.breakpoint(width)
+      _terminal -> Breeze.Style.breakpoint(nil)
+    end
+  end
+
   defp breeze_theme_assign(%{theme: theme, assigns: assigns}) do
     current = get_in(assigns, [:breeze, :theme]) || %{}
     name = Map.get(current, :name) || Map.get(current, "name") || theme.name || theme.mode
@@ -482,6 +496,7 @@ defmodule Breeze.ChildServer do
 
     term = %{term | theme: theme}
     term = %{term | focused: Keyword.get(opts, :focused, term.focused)}
+    term = sync_theme_assigns(term)
 
     initial_implicit_state =
       Keyword.get(opts, :implicit_state, %{})

--- a/lib/breeze/inspector.ex
+++ b/lib/breeze/inspector.ex
@@ -205,6 +205,7 @@ defmodule Breeze.Inspector do
         view_pid: Map.get(state, :view_pid)
       },
       screen: screen,
+      breakpoint: Breeze.Style.breakpoint(screen.width),
       last_render_at: nested_state_field(state, :frame, :last_render_at),
       last_interaction_at: nested_state_field(state, :input, :last_interaction_at),
       counts: %{
@@ -987,7 +988,7 @@ defmodule Breeze.Inspector do
         ),
       meta_text:
         truncate(
-          "hovered=#{selected_label(snapshot.hovered, snapshot.hovered_id || "-")} selected=#{selected_label(selected, snapshot.selected_id || "-")} focused=#{snapshot.focused || "-"} dock=#{snapshot.panel_position} move=#{snapshot.move_key}",
+          "screen=#{snapshot.screen.width}x#{snapshot.screen.height} breakpoint=#{snapshot.breakpoint} hovered=#{selected_label(snapshot.hovered, snapshot.hovered_id || "-")} selected=#{selected_label(selected, snapshot.selected_id || "-")} focused=#{snapshot.focused || "-"} dock=#{snapshot.panel_position} move=#{snapshot.move_key}",
           width - 2
         ),
       layout_text: truncate(layout_line(selected), width - 2),

--- a/lib/breeze/remote_inspector/view.ex
+++ b/lib/breeze/remote_inspector/view.ex
@@ -50,6 +50,8 @@ defmodule Breeze.RemoteInspector.View do
     breeze = assigns |> Map.get(:breeze, %{}) |> Map.put_new(:keybindings, [])
     now = System.system_time(:millisecond)
     active_render_tree = active_render_tree(assigns, active_source, active, render_tree_kind)
+    inspected_screen = if(active, do: Map.get(active.snapshot, :screen), else: nil)
+    inspected_breakpoint = inspected_breakpoint(active, inspected_screen)
     logs = Map.get(assigns, :logs, %{})
     log_sources = Logs.build_sources(logs, Map.get(assigns, :log_sources, %{}))
     log_source = Logs.source(logs, active_source)
@@ -59,7 +61,8 @@ defmodule Breeze.RemoteInspector.View do
         active: active,
         active_source: active_source,
         now: now,
-        screen_text: format_screen(assigns.screen),
+        screen_text: format_screen(inspected_screen),
+        breakpoint_text: inspected_breakpoint,
         latest_source_text: format_source(assigns.latest_source),
         source_entries: source_entries(assigns.snapshots, active_source),
         active_source_text: if(active, do: format_source(active.source), else: "-"),
@@ -126,6 +129,7 @@ defmodule Breeze.RemoteInspector.View do
           <.sidebar
             active={@active}
             screen_text={@screen_text}
+            breakpoint_text={@breakpoint_text}
             snapshots={@snapshots}
             latest_source_text={@latest_source_text}
             active_selected_text={@active_selected_text}
@@ -227,6 +231,7 @@ defmodule Breeze.RemoteInspector.View do
 
   attr :active, :any, required: true
   attr :screen_text, :string, required: true
+  attr :breakpoint_text, :string, required: true
   attr :snapshots, :map, required: true
   attr :latest_source_text, :string, required: true
   attr :active_selected_text, :string, required: true
@@ -242,6 +247,7 @@ defmodule Breeze.RemoteInspector.View do
     <box class="width-32 height-full border-rounded overflow-hidden bg padding-right-1">
       <box class="width-full bold text-primary">Remote Inspector</box>
       <box class="width-full text-muted">screen={@screen_text}</box>
+      <box class="width-full text-muted">breakpoint={@breakpoint_text}</box>
       <box class="width-full text-muted">sources={map_size(@snapshots)}</box>
       <box class="width-full text-muted">latest={@latest_source_text}</box>
       <box class="width-full">
@@ -998,6 +1004,14 @@ defmodule Breeze.RemoteInspector.View do
 
   defp format_screen(%{width: width, height: height}), do: "#{width}x#{height}"
   defp format_screen(_screen), do: "-"
+
+  defp inspected_breakpoint(nil, _screen), do: "-"
+
+  defp inspected_breakpoint(active, screen) do
+    Map.get_lazy(active.snapshot, :breakpoint, fn ->
+      Breeze.Style.breakpoint(if(is_map(screen), do: Map.get(screen, :width), else: nil))
+    end)
+  end
 
   defp theme_rows(nil), do: []
 

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -29,6 +29,7 @@ defmodule Breeze.Renderer do
       rendered
       |> Breeze.Template.render_to_tree(assigns)
 
+    root_children = prune_hidden_nodes(root_children, opts)
     opts = maybe_attach_live_viewports(root_tag, root_children, opts)
     build_from_tree_nodes(root_tag, root_children, opts)
   end
@@ -58,6 +59,7 @@ defmodule Breeze.Renderer do
         Breeze.Template.render_to_tree(rendered, assigns)
       end)
 
+    root_children = prune_hidden_nodes(root_children, opts)
     opts = maybe_attach_live_viewports(root_tag, root_children, opts)
 
     {acc, box} =
@@ -90,12 +92,18 @@ defmodule Breeze.Renderer do
   defp put_breeze_render_context(assigns, _opts), do: assigns
 
   defp render_context(opts) do
+    terminal = terminal_context(Keyword.get(opts, :terminal))
+
     %{
-      terminal: terminal_context(Keyword.get(opts, :terminal)),
+      terminal: terminal,
+      breakpoint: breakpoint(terminal),
       implicit_state: Keyword.get(opts, :implicit_state, %{}),
       implicit_meta: Keyword.get(opts, :implicit_meta, %{})
     }
   end
+
+  defp breakpoint(%{width: width}), do: Breeze.Style.breakpoint(width)
+  defp breakpoint(_terminal), do: Breeze.Style.breakpoint(nil)
 
   defp terminal_context(%{size: %{width: width, height: height}}) do
     %{width: width, height: height}
@@ -152,6 +160,70 @@ defmodule Breeze.Renderer do
   end
 
   defp render_tree_enabled?(opts), do: Keyword.get(opts, :render_tree?, false) == true
+
+  defp prune_hidden_nodes(nodes, opts) when is_list(nodes) do
+    Enum.flat_map(nodes, fn
+      {tag, metadata, children} when is_atom(tag) and is_list(children) ->
+        if structurally_hidden?(children, opts) do
+          []
+        else
+          [{tag, metadata, prune_hidden_nodes(children, opts)}]
+        end
+
+      node ->
+        [node]
+    end)
+  end
+
+  defp structurally_hidden?(nodes, opts) do
+    class = attribute_value(nodes, "class")
+    style = attribute_value(nodes, "style")
+    tokens = class_tokens(class) ++ class_style_tokens(style)
+
+    hidden_token?(tokens) and not state_dependent_visibility?(tokens) and
+      hidden_element?(class, style, opts)
+  end
+
+  defp attribute_value(nodes, name) do
+    Enum.find_value(nodes, fn
+      {:attribute, [^name, value]} -> value
+      _node -> nil
+    end)
+  end
+
+  defp class_tokens(class) when is_binary(class), do: String.split(class, " ", trim: true)
+
+  defp class_tokens(class) when is_map(class) do
+    class
+    |> Enum.filter(fn {_token, enabled?} -> enabled? end)
+    |> Enum.flat_map(fn {token, _enabled?} -> class_tokens(token) end)
+  end
+
+  defp class_tokens(class) when is_list(class), do: Enum.flat_map(class, &class_tokens/1)
+  defp class_tokens(_class), do: []
+
+  defp class_style_tokens(style) when is_binary(style), do: class_tokens(style)
+  defp class_style_tokens(_style), do: []
+
+  defp hidden_token?(tokens),
+    do: Enum.any?(tokens, &(&1 == "hidden" or String.ends_with?(&1, ":hidden")))
+
+  defp state_dependent_visibility?(tokens) do
+    Enum.any?(tokens, fn token ->
+      modifiers = token |> String.split(":") |> Enum.drop(-1)
+      Enum.any?(modifiers, &(&1 in ["focus", "selected", "placeholder"]))
+    end)
+  end
+
+  defp hidden_element?(class, style, opts) do
+    element =
+      RenderStyle.empty()
+      |> RenderStyle.put_class(class)
+      |> RenderStyle.put_style(style)
+      |> RenderStyle.to_element(terminal: Keyword.get(opts, :terminal))
+
+    match?(%{style: %{width: 0, height: 0, overflow: :hidden}}, element)
+  end
 
   defp put_render_tree_node(%{render_tree?: true} = acc, idx, tag) do
     update_in(acc, [:render_tree_nodes], &Map.put(&1 || %{}, idx, %{idx: idx, tag: tag}))
@@ -687,6 +759,8 @@ defmodule Breeze.Renderer do
         final_box
       end
 
+    final_box = collapse_hidden_box(final_box)
+
     stored_box = storage_box(final_box)
 
     boxes =
@@ -712,6 +786,32 @@ defmodule Breeze.Renderer do
       box
     end
   end
+
+  defp collapse_hidden_box(%Box{style: %{width: 0, height: 0, overflow: :hidden}} = box) do
+    hidden_style = %BackBreeze.Style{width: 0, height: 0, overflow: :hidden}
+
+    %{
+      box
+      | content: "",
+        children: Enum.map(box.children, &collapse_box/1),
+        style: hidden_style
+    }
+  end
+
+  defp collapse_hidden_box(box), do: box
+
+  defp collapse_box(%Box{} = box) do
+    hidden_style = %BackBreeze.Style{width: 0, height: 0, overflow: :hidden}
+
+    %{
+      box
+      | content: "",
+        children: Enum.map(box.children, &collapse_box/1),
+        style: hidden_style
+    }
+  end
+
+  defp collapse_box(_content), do: ""
 
   defp storage_content(%VirtualText{cache?: false}), do: ""
   defp storage_content(content), do: content

--- a/lib/breeze/style.ex
+++ b/lib/breeze/style.ex
@@ -3,10 +3,30 @@ defmodule Breeze.Style do
 
   alias Breeze.Theme
 
+  @width_breakpoints %{
+    "sm" => 40,
+    "md" => 60,
+    "lg" => 80,
+    "xl" => 120,
+    "2xl" => 160
+  }
+
+  @breakpoint_thresholds [{160, "2xl"}, {120, "xl"}, {80, "lg"}, {60, "md"}, {40, "sm"}]
+
   @type state :: %{class: list(), style: list()}
 
   @spec empty() :: state()
   def empty, do: %{class: [], style: []}
+
+  @doc false
+  def breakpoint(width) when is_integer(width) do
+    case Enum.find(@breakpoint_thresholds, fn {minimum, _name} -> width >= minimum end) do
+      {_minimum, name} -> name
+      nil -> "base"
+    end
+  end
+
+  def breakpoint(_width), do: "base"
 
   @spec put_class(state(), term()) :: state()
   def put_class(style_state, value) do
@@ -94,6 +114,7 @@ defmodule Breeze.Style do
       |> maybe_put_default_scrollbar_foreground(attributes)
       |> maybe_adjust_scrollbar_tone(theme, :mute, Map.get(attributes, :scrollbar_mute))
       |> maybe_adjust_scrollbar_tone(theme, :emphasize, Map.get(attributes, :scrollbar_emphasize))
+      |> normalize_hidden_style()
 
     struct(Breeze.Element, %{style: Map.from_struct(bb_style), attributes: attributes})
   end
@@ -108,8 +129,11 @@ defmodule Breeze.Style do
   defp apply_style("reverse", {style, attrs}, _theme),
     do: {BackBreeze.Style.reverse(style), attrs}
 
+  defp apply_style("block", {style, attrs}, _theme),
+    do: {restore_hidden_style(style), Map.put(attrs, :display, :block)}
+
   defp apply_style("inline", {style, attrs}, _theme),
-    do: {style, Map.put(attrs, :display, :inline)}
+    do: {restore_hidden_style(style), Map.put(attrs, :display, :inline)}
 
   defp apply_style("hidden", {style, attrs}, _theme) do
     style =
@@ -131,7 +155,7 @@ defmodule Breeze.Style do
         _ -> %BackBreeze.Grid{columns: 1}
       end
 
-    {style, Map.put(attrs, :display, display)}
+    {restore_hidden_style(style), Map.put(attrs, :display, display)}
   end
 
   defp apply_style("grid-cols-" <> num, {style, attrs}, _theme) do
@@ -944,7 +968,15 @@ defmodule Breeze.Style do
             else: {:halt, {nil, false}}
 
         other, {_token, placeholder?} ->
-          {:halt, {other, placeholder?}}
+          cond do
+            Map.has_key?(@width_breakpoints, other) ->
+              if breakpoint_matches?(opts, :width, @width_breakpoints[other]),
+                do: {:cont, {nil, placeholder?}},
+                else: {:halt, {nil, false}}
+
+            true ->
+              {:halt, {other, placeholder?}}
+          end
       end)
 
     cond do
@@ -953,6 +985,28 @@ defmodule Breeze.Style do
       true -> token
     end
   end
+
+  defp breakpoint_matches?(opts, dimension, minimum) do
+    case Keyword.get(opts, :terminal) do
+      %{size: %{^dimension => value}} when is_integer(value) -> value >= minimum
+      _ -> false
+    end
+  end
+
+  defp restore_hidden_style(%{width: 0, height: 0, overflow: :hidden} = style) do
+    style
+    |> BackBreeze.Style.width(:auto)
+    |> BackBreeze.Style.height(:auto)
+    |> BackBreeze.Style.overflow(:auto)
+  end
+
+  defp restore_hidden_style(style), do: style
+
+  defp normalize_hidden_style(%{width: 0, height: 0, overflow: :hidden}) do
+    %BackBreeze.Style{width: 0, height: 0, overflow: :hidden}
+  end
+
+  defp normalize_hidden_style(style), do: style
 
   defp apply_theme_defaults(style, theme) do
     defaults = Theme.default_style(theme)

--- a/lib/breeze/view.ex
+++ b/lib/breeze/view.ex
@@ -127,7 +127,9 @@ defmodule Breeze.View do
    * `italic` - make the text italic
    * `inverse` - reverse the foreground-background
    * `reverse` - reverse the foreground-background
+   * `block` - display the element as a block
    * `inline` - display the elements inline (join horizontally)
+   * `hidden` - collapse the element and hide its contents
    * `grid` - lay out child elements in a grid
    * `grid-cols-n` - set the number of grid columns
    * `grid-rows-n` - set the number of grid rows
@@ -155,6 +157,38 @@ defmodule Breeze.View do
     <box>Four</box>
   </box>
   ```
+
+  ### Responsive styles
+
+  Responsive modifiers apply styles at or above a minimum terminal width.
+  Unprefixed styles provide the base layout, and prefixed styles override them
+  as the terminal grows:
+
+  | Modifier | Minimum width |
+  |----------|---------------|
+  | `sm:`    | 40 columns    |
+  | `md:`    | 60 columns    |
+  | `lg:`    | 80 columns    |
+  | `xl:`    | 120 columns   |
+  | `2xl:`   | 160 columns   |
+
+  ```heex
+  <box class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+    <box>Always shown</box>
+    <box class="hidden md:block">Shown from 60 columns</box>
+    <box class="hidden lg:block">Shown from 80 columns</box>
+  </box>
+  ```
+
+  Responsive and state modifiers can be chained. For example,
+  `md:focus:border-primary` requires at least 60 columns and focus. Responsive
+  styles are reevaluated whenever the terminal is resized. Hidden elements do
+  not participate in layout or grid track counting until a display utility such
+  as `md:block` reveals them.
+
+  The current dimensions and active breakpoint are available to templates as
+  `@breeze.terminal.width`, `@breeze.terminal.height`, and
+  `@breeze.breakpoint`.
 
   ### Colors
 

--- a/test/breeze/example_snapshot_test.exs
+++ b/test/breeze/example_snapshot_test.exs
@@ -192,6 +192,35 @@ defmodule Breeze.ExampleSnapshotTest do
     )
   end
 
+  test "responsive example progressively adds layout chrome" do
+    compact = Breeze.Test.start!(Responsive, size: {39, 24})
+    medium = Breeze.Test.start!(Responsive, size: {60, 24})
+    large = Breeze.Test.start!(Responsive, size: {80, 24})
+
+    on_exit(fn ->
+      Breeze.Test.stop(compact)
+      Breeze.Test.stop(medium)
+      Breeze.Test.stop(large)
+    end)
+
+    compact_content = Breeze.Test.render!(compact)
+    assert compact_content =~ "39×24 · base breakpoint"
+    assert compact_content =~ "[O] [A] [Q] [N]"
+    assert compact_content =~ "Nodes"
+    refute compact_content =~ "▁"
+    refute compact_content =~ "╭"
+
+    medium_content = Breeze.Test.render!(medium)
+    assert medium_content =~ "60×24 · md breakpoint"
+    assert medium_content =~ "Overview  Activity  Queue  Nodes"
+    assert medium_content =~ "▁"
+
+    large_content = Breeze.Test.render!(large)
+    assert large_content =~ "80×24 · lg breakpoint"
+    assert large_content =~ "╭"
+    assert large_content =~ "single row"
+  end
+
   test "docs example snapshots stdlib scrolling" do
     session =
       Breeze.Test.start!(Docs,

--- a/test/breeze/inspector_test.exs
+++ b/test/breeze/inspector_test.exs
@@ -88,6 +88,8 @@ defmodule Breeze.InspectorTest do
     assert snapshot.hovered_id == "nested"
     assert snapshot.toggle_key == "F4"
     assert snapshot.move_key == "PageUp"
+    assert snapshot.screen == %{width: 80, height: 24}
+    assert snapshot.breakpoint == "lg"
     assert snapshot.selected.actual_id == "field"
     assert snapshot.selected.focus_meta == %{group: :form}
     assert snapshot.hovered.actual_id == "nested"
@@ -452,6 +454,7 @@ defmodule Breeze.InspectorTest do
 
     assert length(content_rows) == Inspector.panel_height()
     assert Enum.any?(content_rows, &String.contains?(&1.content, "Inspector [F4]"))
+    assert Enum.any?(content_rows, &String.contains?(&1.content, "screen=80x24 breakpoint=lg"))
     assert Enum.any?(marker_rows, &(&1.char == "("))
     assert Enum.any?(marker_rows, &(&1.char == "["))
   end

--- a/test/breeze/remote_inspector_test.exs
+++ b/test/breeze/remote_inspector_test.exs
@@ -114,6 +114,8 @@ defmodule Breeze.RemoteInspectorTest do
       focused: "url",
       last_render_at: 123,
       last_interaction_at: 456,
+      screen: %{width: 59, height: 24},
+      breakpoint: "sm",
       theme: theme,
       source: %{node: :app@host, server_pid: self(), view_pid: self()},
       render_tree: %{
@@ -275,6 +277,9 @@ defmodule Breeze.RemoteInspectorTest do
       )
 
     assert output =~ "Remote Inspector"
+    assert output =~ "screen=59x24"
+    assert output =~ "breakpoint=sm"
+    refute output =~ "screen=80x32"
     assert output =~ "theme=demo mode=custom dark=true"
     assert output =~ "counts=elements=12 focusables=3"
     assert output =~ "mouse_targets=9 children=1"

--- a/test/breeze/renderer_test.exs
+++ b/test/breeze/renderer_test.exs
@@ -482,6 +482,21 @@ defmodule Breeze.RendererTest do
     end
   end
 
+  defmodule ResponsiveHiddenGridChildExample do
+    use Breeze.View
+
+    def render(assigns) do
+      ~H"""
+      <box class="grid grid-cols-1 md:grid-cols-2 width-full height-6">
+        <box id="collection" focusable class="hidden md:block">
+          <box>Collection</box>
+        </box>
+        <box>Request</box>
+      </box>
+      """
+    end
+  end
+
   describe "render_to_string/2" do
     test "converts the boxes to terminal output" do
       assert Renderer.render_to_string(Example, %{name: "world"}) ==
@@ -507,6 +522,32 @@ defmodule Breeze.RendererTest do
     test "inline overflow-hidden boxes keep their intrinsic width" do
       assert Renderer.render_to_string(InlineOverflowExample, %{}) =~ "Esc"
       assert Renderer.render_to_string(InlineOverflowExample, %{}) =~ "Close"
+    end
+
+    test "hidden responsive children do not occupy grid tracks" do
+      narrow_terminal = %Termite.Terminal{size: %{width: 59, height: 6}}
+      wide_terminal = %Termite.Terminal{size: %{width: 60, height: 6}}
+
+      narrow =
+        Renderer.render_to_string(ResponsiveHiddenGridChildExample, %{},
+          terminal: narrow_terminal
+        )
+
+      wide =
+        Renderer.render_to_string(ResponsiveHiddenGridChildExample, %{}, terminal: wide_terminal)
+
+      {narrow_acc, _narrow_box} =
+        Renderer.render(ResponsiveHiddenGridChildExample, %{}, terminal: narrow_terminal)
+
+      {wide_acc, _wide_box} =
+        Renderer.render(ResponsiveHiddenGridChildExample, %{}, terminal: wide_terminal)
+
+      assert narrow |> String.split("\n") |> hd() |> String.trim() == "Request"
+      refute narrow =~ "Collection"
+      refute "collection" in narrow_acc.focusables
+      assert wide =~ "Collection"
+      assert wide =~ "Request"
+      assert "collection" in wide_acc.focusables
     end
 
     test "accepts BackBreeze.Style structs" do

--- a/test/breeze/style_test.exs
+++ b/test/breeze/style_test.exs
@@ -84,6 +84,73 @@ defmodule Breeze.StyleTest do
     assert element.style.overflow == :hidden
   end
 
+  describe "responsive modifiers" do
+    test "applies width breakpoints at their minimum width" do
+      class =
+        "grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6"
+
+      assert grid_columns(class, {39, 24}) == 1
+      assert grid_columns(class, {40, 24}) == 2
+      assert grid_columns(class, {60, 24}) == 3
+      assert grid_columns(class, {80, 24}) == 4
+      assert grid_columns(class, {120, 24}) == 5
+      assert grid_columns(class, {160, 24}) == 6
+    end
+
+    test "supports chained responsive and state modifiers" do
+      class = "text-1 md:focus:text-2 focus:md:bold"
+
+      narrow = responsive_element(class, {59, 24}, focus: true)
+      wide_unfocused = responsive_element(class, {60, 24})
+      wide_focused = responsive_element(class, {60, 24}, focus: true)
+
+      assert narrow.style.foreground_color == 1
+      refute narrow.style.bold
+      assert wide_unfocused.style.foreground_color == 1
+      refute wide_unfocused.style.bold
+      assert wide_focused.style.foreground_color == 2
+      assert wide_focused.style.bold
+    end
+
+    test "display utilities reveal a responsively hidden box" do
+      narrow = responsive_element("hidden md:block", {59, 24})
+      wide = responsive_element("hidden md:block", {60, 24})
+
+      assert narrow.style.width == 0
+      assert narrow.style.height == 0
+      assert narrow.style.overflow == :hidden
+
+      assert wide.attributes.display == :block
+      assert wide.style.width == :auto
+      assert wide.style.height == :auto
+      assert wide.style.overflow == :auto
+    end
+
+    test "hidden suppresses decorative styles until a display utility reveals them" do
+      class = "hidden md:block border-rounded padding-2 bg-primary"
+      narrow = responsive_element(class, {59, 24})
+      wide = responsive_element(class, {60, 24})
+
+      assert narrow.style.border == BackBreeze.Border.none()
+      assert narrow.style.padding == 0
+      assert narrow.style.background_color == nil
+
+      assert wide.style.border == BackBreeze.Border.rounded()
+      assert wide.style.padding == 2
+      assert wide.style.background_color == 4
+    end
+
+    test "does not apply responsive modifiers without terminal dimensions" do
+      element =
+        Style.empty()
+        |> Style.put_class("text-1 sm:text-2 sm:bold")
+        |> Style.to_element([])
+
+      assert element.style.foreground_color == 1
+      refute element.style.bold
+    end
+  end
+
   test "supports border-invisible class" do
     element =
       Style.empty()
@@ -93,6 +160,20 @@ defmodule Breeze.StyleTest do
     assert element.style.border == BackBreeze.Border.invisible()
     assert element.style.border.left == " "
     assert element.style.border.top == " "
+  end
+
+  defp grid_columns(class, size) do
+    class
+    |> responsive_element(size)
+    |> then(& &1.attributes.display.columns)
+  end
+
+  defp responsive_element(class, {width, height}, opts \\ []) do
+    terminal = %Termite.Terminal{size: %{width: width, height: height}}
+
+    Style.empty()
+    |> Style.put_class(class)
+    |> Style.to_element(Keyword.put(opts, :terminal, terminal))
   end
 
   test "supports border-none class" do

--- a/test/breeze/view_test.exs
+++ b/test/breeze/view_test.exs
@@ -9,7 +9,9 @@ defmodule Breeze.ViewTest do
 
     def render(assigns) do
       ~H"""
-      <box>{@breeze.theme.name}/{@breeze.theme.actual_mode}/{@breeze.theme.status}</box>
+      <box>
+        {@breeze.theme.name}/{@breeze.theme.actual_mode}/{@breeze.theme.status}/{@breeze.terminal.width}x{@breeze.terminal.height}/{@breeze.breakpoint}
+      </box>
       """
     end
 
@@ -265,7 +267,7 @@ defmodule Breeze.ViewTest do
   test "rendering exposes theme metadata in the Breeze assigns namespace" do
     session = Breeze.Test.start!(BreezeAssignsView, theme: Breeze.Theme.builtin(:gruvbox))
 
-    assert Breeze.Test.render!(session) =~ "gruvbox-dark/custom/ready"
+    assert Breeze.Test.render!(session) =~ "gruvbox-dark/custom/ready/80x24/lg"
 
     Breeze.Test.stop(session)
   end

--- a/test/examples/posting_test.exs
+++ b/test/examples/posting_test.exs
@@ -4,6 +4,50 @@ defmodule PostingTest do
 
   alias Breeze.Server.Diagnostics
 
+  test "compact layout hides header metadata and the collection panel below md" do
+    compact_terminal = %Termite.Terminal{size: %{width: 59, height: 24}}
+    {:ok, compact_pid} = Breeze.ChildServer.start(view: Posting, terminal: compact_terminal)
+
+    assert {:ok, _acc, compact_box} =
+             Breeze.ChildServer.render(compact_pid, terminal: compact_terminal)
+
+    compact_content = visible(compact_box.content)
+    assert compact_content =~ "Req It Ralph"
+    assert compact_content =~ "Headers  Body  Query  Auth  Info  Options"
+    refute compact_content =~ "gruvbox/"
+    refute compact_content =~ "gazler@gazler-arch"
+    refute compact_content =~ "echo post"
+
+    request_tabs_row =
+      compact_content
+      |> String.split("\n")
+      |> Enum.find_index(&String.contains?(&1, "Headers  Body  Query"))
+
+    assert request_tabs_row < 10
+
+    compact_rows = String.split(compact_content, "\n")
+
+    assert compact_rows
+           |> Enum.at(request_tabs_row - 1)
+           |> String.trim_leading()
+           |> String.starts_with?("╭")
+
+    assert compact_rows
+           |> Enum.at(request_tabs_row + 2)
+           |> String.trim_leading()
+           |> String.starts_with?("│")
+
+    md_terminal = %Termite.Terminal{size: %{width: 60, height: 24}}
+    {:ok, md_pid} = Breeze.ChildServer.start(view: Posting, terminal: md_terminal)
+
+    assert {:ok, _acc, md_box} = Breeze.ChildServer.render(md_pid, terminal: md_terminal)
+
+    md_content = visible(md_box.content)
+    assert md_content =~ "gruvbox/"
+    assert md_content =~ "gazler@"
+    assert md_content =~ "echo post"
+  end
+
   test "F1 opens help modal and focuses it, Escape closes and restores url focus" do
     terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
     {:ok, pid} = Breeze.ChildServer.start(view: Posting, terminal: terminal)
@@ -445,7 +489,10 @@ defmodule PostingInspectorTest do
         String.starts_with?(key, "__inspector__") and Keyword.get(flags, :id) == nil
       end)
       |> Enum.map(fn {key, _flags} -> {key, state.rendered.mouse_targets[key]} end)
-      |> Enum.reject(fn {_key, bounds} -> is_nil(bounds) end)
+      |> Enum.reject(fn {_key, bounds} ->
+        is_nil(bounds) or
+          bounds.bottom >= terminal.size.height - Breeze.Inspector.panel_height()
+      end)
       |> Enum.min_by(fn {_key, bounds} ->
         (bounds.right - bounds.left + 1) * (bounds.bottom - bounds.top + 1)
       end)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,7 @@
 Application.put_env(:breeze, :example_mode, :load_only)
 Application.put_env(:breeze, :example_user_host, "gazler@gazler-arch")
 
-for file <- ~w(counter.exs docs.exs modal.exs posting.exs snake.exs tabs.exs) do
+for file <- ~w(counter.exs docs.exs modal.exs posting.exs responsive.exs snake.exs tabs.exs) do
   Code.require_file(Path.expand("../examples/#{file}", __DIR__))
 end
 


### PR DESCRIPTION
Add width-based responsive breakpoints for adapting layouts to terminal size:

- sm: 40 columns
- md: 60 columns
- lg: 80 columns
- xl: 120 columns
- 2xl: 160 columns

Responsive style prefixes such as md:grid-cols-2 apply at the named width and above. They support any style change—including layout, sizing, borders, text styling, and visibility—not only showing or hiding content.

Hidden elements are pruned which means that they do not count as grid items, refleting how hidden elements display in the browser.

The responsive example demonstrates these behaviours, the posting example hides its theme, username, and navigation panel below md, and the inspector reports the inspected application’s dimensions and active breakpoint. Breakpoints depend on width only, reflecting how terminal layouts typically adapt.