### PR TITLE
refactor(Breeze.Telemetry): wrap :telemetry to allow disabling

### DIFF
--- a/lib/breeze/child_server.ex
+++ b/lib/breeze/child_server.ex
@@ -1911,13 +1911,10 @@ defmodule Breeze.ChildServer do
   defp profile(nil, _label, _metric, fun), do: fun.()
 
   defp profile(scope, label, metric, fun) do
-    :telemetry.span(
+    Breeze.Telemetry.span(
       [:breeze, :render],
       %{scope: scope, label: label, metric: metric},
-      fn ->
-        result = fun.()
-        {result, %{scope: scope, label: label, metric: metric}}
-      end
+      fun
     )
   end
 end

--- a/lib/breeze/debug_profiler.ex
+++ b/lib/breeze/debug_profiler.ex
@@ -33,7 +33,8 @@ defmodule Breeze.DebugProfiler do
   end
 
   def enabled? do
-    not Application.get_env(:breeze, :disable_telemetry, false)
+    Breeze.Telemetry.enabled?() and
+      not Application.get_env(:breeze, :disable_debug_profiler, false)
   end
 
   defp ensure_handler do

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -1724,35 +1724,20 @@ defmodule Breeze.Renderer do
   defp profile(nil, _label, _metric, fun), do: fun.()
 
   defp profile(scope, label, metric, fun) do
-    if telemetry_enabled?() do
-      :telemetry.span(
-        [:breeze, :render],
-        %{scope: scope, label: label, metric: metric},
-        fn ->
-          result = fun.()
-          {result, %{scope: scope, label: label, metric: metric}}
-        end
-      )
-    else
-      fun.()
-    end
+    Breeze.Telemetry.span(
+      [:breeze, :render],
+      %{scope: scope, label: label, metric: metric},
+      fun
+    )
   end
 
   defp emit_metric(nil, _label, _metric, _value), do: :ok
 
   defp emit_metric(scope, label, metric, value) do
-    if telemetry_enabled?() do
-      :telemetry.execute(
-        [:breeze, :render, :metric],
-        %{value: value},
-        %{scope: scope, label: label, metric: metric}
-      )
-    else
-      :ok
-    end
-  end
-
-  defp telemetry_enabled? do
-    not Application.get_env(:breeze, :disable_telemetry, false)
+    Breeze.Telemetry.execute(
+      [:breeze, :render, :metric],
+      %{value: value},
+      %{scope: scope, label: label, metric: metric}
+    )
   end
 end

--- a/lib/breeze/server/render_tracking.ex
+++ b/lib/breeze/server/render_tracking.ex
@@ -2,7 +2,9 @@ defmodule Breeze.Server.RenderTracking do
   @moduledoc false
 
   def new_table do
-    :ets.new(__MODULE__, [:public, :bag, write_concurrency: true])
+    if not disabled?() do
+      :ets.new(__MODULE__, [:public, :bag, write_concurrency: true])
+    end
   end
 
   def begin(table) do

--- a/lib/breeze/telemetry.ex
+++ b/lib/breeze/telemetry.ex
@@ -1,0 +1,26 @@
+defmodule Breeze.Telemetry do
+  @moduledoc false
+
+  def span(event, metadata, fun) when is_function(fun, 0) do
+    if enabled?() do
+      :telemetry.span(event, metadata, fn ->
+        result = fun.()
+        {result, metadata}
+      end)
+    else
+      fun.()
+    end
+  end
+
+  def execute(event, measurements, metadata) do
+    if enabled?() do
+      :telemetry.execute(event, measurements, metadata)
+    end
+
+    :ok
+  end
+
+  def enabled? do
+    not Application.get_env(:breeze, :disable_telemetry, false)
+  end
+end

--- a/test/breeze/initial_render_test.exs
+++ b/test/breeze/initial_render_test.exs
@@ -1,0 +1,36 @@
+defmodule Breeze.InitialRenderTest do
+  use ExUnit.Case, async: true
+
+  defmodule EmptyView do
+    use Breeze.View
+
+    def render(assigns) do
+      send(assigns.owner, :view_rendered)
+
+      ~H"""
+      <box>Count: {@count}</box>
+      """
+    end
+  end
+
+  test "the initial render prepass only runs once when implicit state remains empty" do
+    {:ok, pid} =
+      Breeze.ChildServer.start(view: EmptyView, assigns: %{count: 0, owner: self()})
+
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, [])
+    initial_render_count = drain_view_renders()
+    assert initial_render_count > 1
+
+    assert :ok = Breeze.ChildServer.update_assigns(pid, %{count: 1, owner: self()})
+    assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, [])
+    assert drain_view_renders() == initial_render_count - 1
+  end
+
+  defp drain_view_renders(count \\ 0) do
+    receive do
+      :view_rendered -> drain_view_renders(count + 1)
+    after
+      0 -> count
+    end
+  end
+end

--- a/test/breeze/telemetry_test.exs
+++ b/test/breeze/telemetry_test.exs
@@ -1,0 +1,50 @@
+defmodule Breeze.TelemetryTest do
+  use ExUnit.Case, async: false
+
+  @event [:breeze, :telemetry_test]
+
+  setup do
+    previous = Application.get_env(:breeze, :disable_telemetry, :unset)
+    handler_id = "breeze-telemetry-test-#{System.unique_integer([:positive])}"
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        [@event ++ [:start], @event ++ [:stop], @event],
+        &__MODULE__.handle_event/4,
+        self()
+      )
+
+    on_exit(fn ->
+      :telemetry.detach(handler_id)
+
+      case previous do
+        :unset -> Application.delete_env(:breeze, :disable_telemetry)
+        value -> Application.put_env(:breeze, :disable_telemetry, value)
+      end
+    end)
+
+    :ok
+  end
+
+  test "span emits telemetry and returns the wrapped result" do
+    Application.delete_env(:breeze, :disable_telemetry)
+
+    assert :result = Breeze.Telemetry.span(@event, %{source: :test}, fn -> :result end)
+    assert_receive {[:breeze, :telemetry_test, :start], %{}, %{source: :test}}
+    assert_receive {[:breeze, :telemetry_test, :stop], %{duration: duration}, %{source: :test}}
+    assert is_integer(duration)
+  end
+
+  test "disabled telemetry executes the function without emitting events" do
+    Application.put_env(:breeze, :disable_telemetry, true)
+
+    assert :result = Breeze.Telemetry.span(@event, %{source: :test}, fn -> :result end)
+    assert :ok = Breeze.Telemetry.execute(@event, %{value: 1}, %{source: :test})
+    refute_receive _event
+  end
+
+  def handle_event(event, measurements, metadata, pid) do
+    send(pid, {event, measurements, metadata})
+  end
+end


### PR DESCRIPTION
There are some application configs that can be set to disable telemetry and debug profiling. This is useful in environments where these libraries aren't available such as popcorn.