### PR TITLE
Perf/template render

### DIFF
--- a/lib/breeze/html_formatter.ex
+++ b/lib/breeze/html_formatter.ex
@@ -61,7 +61,7 @@ defmodule Breeze.HTMLFormatter do
       |> Map.put(:file, Keyword.get(opts, :file, "nofile"))
       |> Map.put(:line, 1)
 
-    Breeze.Template.compile!(source, env)
+    Breeze.Template.parse!(source, env)
   end
 
   defp format_nodes(nodes, indent, line_length) when is_list(nodes) do
@@ -246,39 +246,7 @@ defmodule Breeze.HTMLFormatter do
   end
 
   defp expr_to_string(expr) do
-    expr
-    |> denormalize_assign_refs()
-    |> Macro.to_string()
-  end
-
-  defp denormalize_assign_refs(ast) do
-    Macro.prewalk(ast, fn
-      {:__breeze_assign__, name} when is_atom(name) ->
-        {:@, [], [{name, [], nil}]}
-
-      {:__breeze_var__, name} when is_atom(name) ->
-        {name, [], nil}
-
-      {:__breeze_literal__, value} ->
-        value
-
-      {:__breeze_access__, receiver, field} when is_atom(field) ->
-        {{:., [], [receiver, field]}, [no_parens: true], []}
-
-      {:__breeze_helper__, _module, name, _arity, args} when is_atom(name) and is_list(args) ->
-        {name, [], args}
-
-      {{:., _, [{:__aliases__, _, [:Map]}, :get]}, _, [{:assigns, _, _}, name]}
-      when is_atom(name) ->
-        {:@, [], [{name, [], nil}]}
-
-      {{:., _, [_module, :__breeze_eval_helper__]}, _, [name, _arity, args]}
-      when is_atom(name) and is_list(args) ->
-        {name, [], args}
-
-      node ->
-        node
-    end)
+    Macro.to_string(expr)
   end
 
   defp indent(level), do: String.duplicate(" ", level)

--- a/lib/breeze/implicit/textarea.ex
+++ b/lib/breeze/implicit/textarea.ex
@@ -217,25 +217,35 @@ defmodule Breeze.Implicit.Textarea do
     width = max(width, 1)
     indexed_graphemes = Enum.with_index(String.graphemes(content))
 
-    {lines, current_line, column, cursor_row, cursor_x} =
-      wrap_graphemes(indexed_graphemes, cursor, width, [], [], 0, nil, nil)
+    {reversed_lines, current_line, column, line_count, cursor_row, cursor_x} =
+      wrap_graphemes(indexed_graphemes, cursor, width, [], [], 0, 0, nil, nil)
 
     {lines, cursor_row, cursor_x} =
       if cursor == String.length(content) do
         if column >= width and current_line != "" do
-          {lines ++ [current_line, ""], length(lines) + 1, 0}
+          {Enum.reverse(["", current_line | reversed_lines]), line_count + 1, 0}
         else
-          {lines ++ [current_line], length(lines), column}
+          {Enum.reverse([current_line | reversed_lines]), line_count, column}
         end
       else
-        {lines ++ [current_line], cursor_row, cursor_x}
+        {Enum.reverse([current_line | reversed_lines]), cursor_row, cursor_x}
       end
 
     {lines, cursor_row, cursor_x}
   end
 
-  defp wrap_graphemes([], _cursor, _width, lines, current_items, column, cursor_row, cursor_x) do
-    {lines, items_to_string(current_items), column, cursor_row || 0, cursor_x || 0}
+  defp wrap_graphemes(
+         [],
+         _cursor,
+         _width,
+         lines,
+         current_items,
+         column,
+         line_count,
+         cursor_row,
+         cursor_x
+       ) do
+    {lines, items_to_string(current_items), column, line_count, cursor_row || 0, cursor_x || 0}
   end
 
   defp wrap_graphemes(
@@ -245,12 +255,13 @@ defmodule Breeze.Implicit.Textarea do
          lines,
          current_items,
          column,
+         line_count,
          cursor_row,
          cursor_x
        ) do
     {cursor_row, cursor_x} =
       if grapheme_index == cursor do
-        {length(lines), column}
+        {line_count, column}
       else
         {cursor_row, cursor_x}
       end
@@ -263,9 +274,10 @@ defmodule Breeze.Implicit.Textarea do
           rest,
           cursor,
           width,
-          lines ++ [items_to_string(current_items)],
+          [items_to_string(current_items) | lines],
           [],
           0,
+          line_count + 1,
           cursor_row,
           cursor_x
         )
@@ -276,8 +288,9 @@ defmodule Breeze.Implicit.Textarea do
           cursor,
           width,
           lines,
-          current_items ++ [{grapheme, grapheme_width}],
+          [{grapheme, grapheme_width} | current_items],
           column + grapheme_width,
+          line_count,
           cursor_row,
           cursor_x
         )
@@ -289,9 +302,10 @@ defmodule Breeze.Implicit.Textarea do
               [{grapheme, grapheme_index} | rest],
               cursor,
               width,
-              lines ++ [items_to_string(current_items)],
+              [items_to_string(current_items) | lines],
               [],
               0,
+              line_count + 1,
               cursor_row,
               cursor_x
             )
@@ -301,9 +315,10 @@ defmodule Breeze.Implicit.Textarea do
               [{grapheme, grapheme_index} | rest],
               cursor,
               width,
-              lines ++ [items_to_string(line_items)],
+              [items_to_string(line_items) | lines],
               carry_items,
               items_width(carry_items),
+              line_count + 1,
               cursor_row,
               cursor_x
             )
@@ -312,18 +327,19 @@ defmodule Breeze.Implicit.Textarea do
   end
 
   defp split_at_last_whitespace(items) do
-    case Enum.find_index(Enum.reverse(items), fn {grapheme, _width} -> whitespace?(grapheme) end) do
+    case Enum.find_index(items, fn {grapheme, _width} -> whitespace?(grapheme) end) do
       nil ->
         nil
 
       reverse_index ->
-        split_index = length(items) - reverse_index
-        Enum.split(items, split_index)
+        {carry_items, line_items} = Enum.split(items, reverse_index)
+        {line_items, carry_items}
     end
   end
 
   defp items_to_string(items) do
     items
+    |> Enum.reverse()
     |> Enum.map_join("", fn {grapheme, _width} -> grapheme end)
   end
 

--- a/lib/breeze/logger/collector.ex
+++ b/lib/breeze/logger/collector.ex
@@ -102,7 +102,8 @@ defmodule Breeze.Logger.Collector do
   def init(opts) do
     {:ok,
      %{
-       entries: [],
+       entries: :queue.new(),
+       entry_count: 0,
        configurations: %{},
        subscribers: %{},
        default_handler_config: nil,
@@ -137,20 +138,20 @@ defmodule Breeze.Logger.Collector do
     {old_subscription, subscribers} = Map.pop(state.subscribers, pid)
     demonitor(old_subscription)
 
-    send(pid, {:logger_snapshot, state.entries})
+    send(pid, {:logger_snapshot, entries_to_list(state)})
     subscription = %{ref: Process.monitor(pid)}
     {:reply, :ok, %{state | subscribers: Map.put(subscribers, pid, subscription)}}
   end
 
   def handle_call(:clear, _from, state) do
     Enum.each(Map.keys(state.subscribers), &send(&1, {:logger_snapshot, []}))
-    state = %{state | entries: []}
+    state = %{state | entries: :queue.new(), entry_count: 0}
     maybe_publish_logs(state)
     {:reply, :ok, state}
   end
 
   def handle_call(:entries, _from, state) do
-    {:reply, state.entries, state}
+    {:reply, entries_to_list(state), state}
   end
 
   def handle_call(:status, _from, state) do
@@ -169,14 +170,12 @@ defmodule Breeze.Logger.Collector do
   def handle_cast({:log, entry}, state) do
     entry = normalize_entry(entry)
 
-    entries =
-      state.entries
-      |> Kernel.++([entry])
-      |> Enum.take(-effective_max_entries(state))
+    {entries, entry_count} =
+      put_entry(state.entries, state.entry_count, entry, effective_max_entries(state))
 
     Enum.each(Map.keys(state.subscribers), &send(&1, {:logger_entry, entry}))
     maybe_publish_log_entry(state, entry)
-    {:noreply, %{state | entries: entries}}
+    {:noreply, %{state | entries: entries, entry_count: entry_count}}
   end
 
   @impl true
@@ -297,6 +296,21 @@ defmodule Breeze.Logger.Collector do
     |> Enum.max(fn -> @default_max_entries end)
   end
 
+  defp put_entry(entries, entry_count, entry, max_entries) do
+    entry
+    |> :queue.in(entries)
+    |> trim_entries(entry_count + 1, max_entries)
+  end
+
+  defp trim_entries(entries, entry_count, max_entries) when entry_count > max_entries do
+    {{:value, _entry}, entries} = :queue.out(entries)
+    trim_entries(entries, entry_count - 1, max_entries)
+  end
+
+  defp trim_entries(entries, entry_count, _max_entries), do: {entries, entry_count}
+
+  defp entries_to_list(%{entries: entries}), do: :queue.to_list(entries)
+
   defp reject_monitor(entries, ref) do
     entries
     |> Enum.reject(fn {_pid, entry} -> entry.ref == ref end)
@@ -347,7 +361,7 @@ defmodule Breeze.Logger.Collector do
   defp maybe_publish_logs(state) do
     case remote_inspector_view(state) do
       nil -> :ok
-      view -> Breeze.RemoteInspector.publish_logs(state.entries, view: view)
+      view -> Breeze.RemoteInspector.publish_logs(entries_to_list(state), view: view)
     end
   end
 

--- a/lib/breeze/remote_inspector.ex
+++ b/lib/breeze/remote_inspector.ex
@@ -321,11 +321,7 @@ defmodule Breeze.RemoteInspector.Server do
     key = source_key(source)
     now = System.system_time(:millisecond)
 
-    log_entry = %{
-      source: source,
-      entries: normalize_log_entries(entries),
-      updated_at: now
-    }
+    log_entry = new_log_buffer(source, normalize_log_entries(entries), now)
 
     state =
       state
@@ -347,11 +343,12 @@ defmodule Breeze.RemoteInspector.Server do
       state
       |> ensure_source_monitor(source_pid, key)
       |> update_in([:logs], fn logs ->
-        current =
-          Map.get(logs, key, %{source: source, entries: [], updated_at: now})
+        current = Map.get(logs, key, new_log_buffer(source, [], now))
 
-        entries = trim_log_entries(current.entries ++ [entry])
-        Map.put(logs, key, %{current | source: source, entries: entries, updated_at: now})
+        current = append_log_entry(current, entry)
+        current = %{current | source: source, updated_at: now}
+
+        Map.put(logs, key, current)
       end)
       |> mark_log_dirty(key)
 
@@ -381,7 +378,7 @@ defmodule Breeze.RemoteInspector.Server do
     state =
       Enum.reduce(state.dirty_logs, state, fn key, acc ->
         case Map.fetch(acc.logs, key) do
-          {:ok, log_entry} -> push_log_event(acc, {:snapshot, key, log_entry})
+          {:ok, log_entry} -> push_log_event(acc, {:snapshot, key, public_log_entry(log_entry)})
           :error -> acc
         end
       end)
@@ -553,7 +550,7 @@ defmodule Breeze.RemoteInspector.Server do
     %{
       snapshots: state.snapshots,
       latest_source: state.latest_source,
-      logs: state.logs
+      logs: Map.new(state.logs, fn {key, entry} -> {key, public_log_entry(entry)} end)
     }
   end
 
@@ -601,4 +598,60 @@ defmodule Breeze.RemoteInspector.Server do
     end)
     |> elem(0)
   end
+
+  defp new_log_buffer(source, entries, updated_at) do
+    %{
+      source: source,
+      entries: :queue.from_list(entries),
+      entry_count: length(entries),
+      entry_bytes: Enum.reduce(entries, 0, &(&2 + byte_size(&1.line))),
+      updated_at: updated_at
+    }
+  end
+
+  defp append_log_entry(buffer, entry) do
+    buffer = ensure_log_buffer(buffer)
+
+    %{
+      buffer
+      | entries: :queue.in(entry, buffer.entries),
+        entry_count: buffer.entry_count + 1,
+        entry_bytes: buffer.entry_bytes + byte_size(entry.line)
+    }
+    |> trim_log_buffer()
+  end
+
+  defp trim_log_buffer(%{entry_count: count, entry_bytes: bytes} = buffer)
+       when count > @max_log_entries or bytes > @max_log_bytes do
+    {{:value, entry}, entries} = :queue.out(buffer.entries)
+
+    %{
+      buffer
+      | entries: entries,
+        entry_count: count - 1,
+        entry_bytes: bytes - byte_size(entry.line)
+    }
+    |> trim_log_buffer()
+  end
+
+  defp trim_log_buffer(buffer), do: buffer
+
+  defp ensure_log_buffer(%{entry_count: count, entry_bytes: bytes} = buffer)
+       when is_integer(count) and is_integer(bytes),
+       do: buffer
+
+  defp ensure_log_buffer(%{source: source, entries: entries, updated_at: updated_at})
+       when is_list(entries) do
+    new_log_buffer(source, trim_log_entries(entries), updated_at)
+  end
+
+  defp public_log_entry(%{entry_count: _count} = buffer) do
+    %{
+      source: buffer.source,
+      entries: :queue.to_list(buffer.entries),
+      updated_at: buffer.updated_at
+    }
+  end
+
+  defp public_log_entry(%{entries: entries} = log_entry) when is_list(entries), do: log_entry
 end

--- a/lib/breeze/renderer.ex
+++ b/lib/breeze/renderer.ex
@@ -131,7 +131,8 @@ defmodule Breeze.Renderer do
 
     acc = %{acc | elements: Map.put(acc.elements, acc.id, acc.flags)}
     ids = Enum.reverse(acc.ids)
-    focusables = Enum.reverse(acc.focusables) |> then(&Enum.filter(ids, fn id -> id in &1 end))
+    focusable_ids = MapSet.new(acc.focusables)
+    focusables = Enum.filter(ids, &MapSet.member?(focusable_ids, &1))
     acc = %{acc | ids: ids, focusables: focusables}
 
     acc =
@@ -161,7 +162,7 @@ defmodule Breeze.Renderer do
 
   defp put_render_tree_child(%{render_tree?: true} = acc, parent_id, child_ref) do
     update_in(acc, [:render_tree_children], fn children ->
-      Map.update(children || %{}, parent_id, [child_ref], &(&1 ++ [child_ref]))
+      Map.update(children || %{}, parent_id, [child_ref], &[child_ref | &1])
     end)
   end
 
@@ -180,6 +181,7 @@ defmodule Breeze.Renderer do
         child_nodes =
           children
           |> Map.get(idx, [])
+          |> Enum.reverse()
           |> Enum.flat_map(fn
             {:id, child_id} ->
               case assemble_render_tree(child_id, nodes, children) do
@@ -417,7 +419,7 @@ defmodule Breeze.Renderer do
       box = %{box | content: content}
       build_tree(rest, box, children, style_state, flags, acc, opts, current_id, tag)
     else
-      children = children ++ [content]
+      children = [content | children]
       build_tree(rest, box, children, style_state, flags, acc, opts, current_id, tag)
     end
   end
@@ -428,7 +430,7 @@ defmodule Breeze.Renderer do
       box = %{box | content: content}
       build_tree(rest, box, children, style_state, flags, acc, opts, current_id, tag)
     else
-      children = children ++ [content]
+      children = [content | children]
       build_tree(rest, box, children, style_state, flags, acc, opts, current_id, tag)
     end
   end

--- a/lib/breeze/server/frame.ex
+++ b/lib/breeze/server/frame.ex
@@ -89,15 +89,25 @@ defmodule Breeze.Server.Frame do
   end
 
   defp changed_base_rows(prev_lines, lines) do
-    lines
-    |> Enum.with_index()
-    |> Enum.reduce(MapSet.new(), fn {line, row}, acc ->
-      if line == Enum.at(prev_lines, row, "") do
-        acc
-      else
-        MapSet.put(acc, row)
-      end
-    end)
+    do_changed_base_rows(prev_lines, lines, 0, MapSet.new())
+  end
+
+  defp do_changed_base_rows(_prev_lines, [], _row, changed_rows), do: changed_rows
+
+  defp do_changed_base_rows([line | prev_lines], [line | lines], row, changed_rows) do
+    do_changed_base_rows(prev_lines, lines, row + 1, changed_rows)
+  end
+
+  defp do_changed_base_rows([_prev_line | prev_lines], [_line | lines], row, changed_rows) do
+    do_changed_base_rows(prev_lines, lines, row + 1, MapSet.put(changed_rows, row))
+  end
+
+  defp do_changed_base_rows([], ["" | lines], row, changed_rows) do
+    do_changed_base_rows([], lines, row + 1, changed_rows)
+  end
+
+  defp do_changed_base_rows([], [_line | lines], row, changed_rows) do
+    do_changed_base_rows([], lines, row + 1, MapSet.put(changed_rows, row))
   end
 
   defp changed_overlay_rows(prev_overlays, overlays) do
@@ -162,14 +172,28 @@ defmodule Breeze.Server.Frame do
   end
 
   defp row_patch_payload(lines, changed_rows, screen_width) do
+    lines = List.to_tuple(lines)
+    line_count = tuple_size(lines)
+
     changed_rows
     |> Enum.sort()
     |> Enum.map(fn row ->
-      line = Enum.at(lines, row, "")
+      line = line_at(lines, row, line_count)
       write_row_payload(row, line, screen_width)
     end)
     |> IO.iodata_to_binary()
   end
+
+  defp line_at(lines, row, line_count) when row < 0 do
+    tuple_line_at(lines, line_count + row, line_count)
+  end
+
+  defp line_at(lines, row, line_count), do: tuple_line_at(lines, row, line_count)
+
+  defp tuple_line_at(lines, row, line_count) when row >= 0 and row < line_count,
+    do: elem(lines, row)
+
+  defp tuple_line_at(_lines, _row, _line_count), do: ""
 
   defp write_row_payload(row, line, screen_width) do
     visible_width = visible_width(line)

--- a/lib/breeze/template.ex
+++ b/lib/breeze/template.ex
@@ -1,10 +1,37 @@
 defmodule Breeze.Template do
   @moduledoc false
 
+  defmodule Syntax do
+    @moduledoc false
+
+    defstruct [:nodes, :env]
+
+    @type t :: %__MODULE__{nodes: list(), env: Macro.Env.t()}
+  end
+
   defstruct [:nodes, :env]
 
   @type t :: %__MODULE__{nodes: list(), env: Macro.Env.t()}
   @type rendered :: t() | {t(), map()}
+
+  @expression_pseudo_vars [:__CALLER__, :__DIR__, :__ENV__, :__MODULE__, :__STACKTRACE__]
+  @bitstring_specifiers [
+    :big,
+    :binary,
+    :bitstring,
+    :bits,
+    :bytes,
+    :float,
+    :integer,
+    :little,
+    :native,
+    :signed,
+    :unit,
+    :unsigned,
+    :utf8,
+    :utf16,
+    :utf32
+  ]
 
   defguardp is_name_char(char)
             when (char >= ?a and char <= ?z) or (char >= ?A and char <= ?Z) or
@@ -13,14 +40,76 @@ defmodule Breeze.Template do
 
   defguardp is_ws(char) when char == ?\s or char == ?\n or char == ?\t or char == ?\r
 
-  def compile!(source, %Macro.Env{} = env) when is_binary(source) do
+  def parse!(source, %Macro.Env{} = env) when is_binary(source) do
     {nodes, rest} = parse_nodes(source, nil, env, [])
 
     if rest != "" do
       raise "unexpected trailing template content: #{inspect(rest)}"
     end
 
-    %__MODULE__{nodes: nodes, env: Macro.Env.prune_compile_info(env)}
+    %Syntax{nodes: nodes, env: Macro.Env.prune_compile_info(env)}
+  end
+
+  def compile!(source, %Macro.Env{} = env) when is_binary(source) do
+    compile!(source, env, [])
+  end
+
+  def compile!(source, %Macro.Env{} = env, opts) when is_binary(source) and is_list(opts) do
+    %Syntax{nodes: nodes} = parse!(source, env)
+
+    %__MODULE__{
+      nodes: compile_nodes(nodes, env, opts),
+      env: Macro.Env.prune_compile_info(env)
+    }
+  end
+
+  defp compile_nodes(nodes, env, opts) do
+    Enum.map(nodes, &compile_node(&1, env, opts))
+  end
+
+  defp compile_node({:text, segments}, env, opts) do
+    segments =
+      Enum.map(segments, fn
+        {:expr, expr} -> {:expr, compile_expr(expr, env, opts)}
+        text -> text
+      end)
+
+    {:text, segments}
+  end
+
+  defp compile_node({:expr, expr}, env, opts), do: {:expr, compile_expr(expr, env, opts)}
+
+  defp compile_node({:element, name, attrs, directives, children}, env, opts) do
+    attrs =
+      Enum.map(attrs, fn
+        {:dynamic, attr_name, expr} -> {:dynamic, attr_name, compile_expr(expr, env, opts)}
+        {:spread, expr} -> {:spread, compile_expr(expr, env, opts)}
+        attr -> attr
+      end)
+
+    directives = %{
+      for: compile_for_directive(directives[:for], env, opts),
+      if: compile_optional_expr(directives[:if], env, opts),
+      let: compile_let_directive(directives[:let], env, opts)
+    }
+
+    {:element, name, attrs, directives, compile_nodes(children, env, opts)}
+  end
+
+  defp compile_optional_expr(nil, _env, _opts), do: nil
+  defp compile_optional_expr(expr, env, opts), do: compile_expr(expr, env, opts)
+
+  defp compile_for_directive(nil, _env, _opts), do: nil
+
+  defp compile_for_directive({pattern_string, pattern_ast, enumerable_ast}, env, opts) do
+    {pattern_string, compile_for_pattern(pattern_ast, env, opts),
+     compile_expr(enumerable_ast, env, opts)}
+  end
+
+  defp compile_let_directive(nil, _env, _opts), do: nil
+
+  defp compile_let_directive({pattern_string, pattern_ast}, env, opts) do
+    {pattern_string, compile_for_pattern(pattern_ast, env, opts)}
   end
 
   def render_to_string({%__MODULE__{} = template, comp_assigns}, _assigns) do
@@ -289,6 +378,9 @@ defmodule Breeze.Template do
 
   defp node_local_helper_captures(_node), do: []
 
+  defp expr_local_helper_captures({:__breeze_compiled__, _module, _id, helpers}), do: helpers
+  defp expr_local_helper_captures({:__breeze_compiled_pattern__, _module, _id}), do: []
+
   defp expr_local_helper_captures(expr) do
     {_expr, helpers} =
       Macro.prewalk(expr, [], fn
@@ -366,15 +458,13 @@ defmodule Breeze.Template do
 
   defp render_node({:text, segments}, ctx) do
     Enum.map_join(segments, "", fn
-      {:expr, expr} -> expr |> eval_expr(ctx) |> normalize_output()
+      {:expr, expr} -> render_expr_to_string(expr, ctx)
       text when is_binary(text) -> text
     end)
   end
 
   defp render_node({:expr, expr}, ctx) do
-    expr
-    |> eval_expr(ctx)
-    |> normalize_output()
+    render_expr_to_string(expr, ctx)
   end
 
   defp render_node({:element, name, attrs, directives, children}, ctx) do
@@ -386,6 +476,23 @@ defmodule Breeze.Template do
         ""
       end
     end)
+  end
+
+  defp render_expr_to_string(expr, ctx) do
+    case expr do
+      {:render_slot, _meta, [slot_arg]} ->
+        slot_arg
+        |> eval_expr(ctx)
+        |> Breeze.View.render_slot()
+
+      {:render_slot, _meta, [slot_arg, assigns_arg]} ->
+        Breeze.View.render_slot(eval_expr(slot_arg, ctx), eval_expr(assigns_arg, ctx))
+
+      _ ->
+        expr
+        |> eval_expr(ctx)
+        |> normalize_output()
+    end
   end
 
   defp render_element("." <> component, attrs, children, ctx) do
@@ -617,6 +724,12 @@ defmodule Breeze.Template do
           :error -> :error
         end
 
+      {:__breeze_compiled_pattern__, module, id} ->
+        case apply(module, :__breeze_match_pattern__, [id, value, ctx.vars]) do
+          {:ok, new_vars} -> {:ok, Map.merge(ctx.vars, new_vars)}
+          :error -> :error
+        end
+
       _ ->
         binding = Map.to_list(ctx.vars) ++ [assigns: ctx.assigns, breeze_value: value]
 
@@ -649,6 +762,9 @@ defmodule Breeze.Template do
       {:__breeze_helper__, module, name, arity, args} ->
         values = Enum.map(args, &eval_expr(&1, ctx))
         apply(module, :__breeze_eval_helper__, [name, arity, values])
+
+      {:__breeze_compiled__, module, id, _helpers} ->
+        apply(module, :__breeze_eval_expr__, [id, ctx.assigns, ctx.vars])
 
       _ ->
         binding = Map.to_list(ctx.vars) ++ [assigns: ctx.assigns]
@@ -721,7 +837,7 @@ defmodule Breeze.Template do
     cond do
       String.starts_with?(source, "<%=") ->
         {expr, rest} = take_between(source, "<%=", "%>")
-        node = {:expr, compile_expr(expr, env)}
+        node = {:expr, parse_expr(expr, env)}
         parse_nodes(rest, closing, env, [node | acc])
 
       String.starts_with?(source, "</") ->
@@ -822,7 +938,7 @@ defmodule Breeze.Template do
 
   defp parse_attribute("{" <> _rest = source, env) do
     {expr, rest} = take_braced(source)
-    {{:spread, compile_expr(expr, env)}, rest}
+    {{:spread, parse_expr(expr, env)}, rest}
   end
 
   defp parse_attribute(source, env) do
@@ -858,18 +974,17 @@ defmodule Breeze.Template do
   end
 
   defp build_attribute(":if", {:dynamic, expr}, env) do
-    {:directive, :if, compile_expr(expr, env)}
+    {:directive, :if, parse_expr(expr, env)}
   end
 
   defp build_attribute(":for", {:dynamic, expr}, env) do
     {pattern, enumerable} = split_for_expression(expr)
 
-    {:directive, :for,
-     {pattern, compile_for_pattern(pattern, env), compile_expr(enumerable, env)}}
+    {:directive, :for, {pattern, parse_expr(pattern, env), parse_expr(enumerable, env)}}
   end
 
   defp build_attribute(":let", {:dynamic, expr}, env) do
-    {:directive, :let, {String.trim(expr), compile_for_pattern(expr, env)}}
+    {:directive, :let, {String.trim(expr), parse_expr(expr, env)}}
   end
 
   defp build_attribute(":if", _other, _env) do
@@ -885,7 +1000,7 @@ defmodule Breeze.Template do
   end
 
   defp build_attribute(name, {:dynamic, expr}, env) do
-    {:dynamic, name, compile_expr(expr, env)}
+    {:dynamic, name, parse_expr(expr, env)}
   end
 
   defp build_attribute(name, {:static, value}, _env) do
@@ -918,7 +1033,7 @@ defmodule Breeze.Template do
         acc =
           acc
           |> maybe_push_text(plain)
-          |> then(&[{:expr, compile_expr(expr, env)} | &1])
+          |> then(&[{:expr, parse_expr(expr, env)} | &1])
 
         compile_text_segments(rest, env, acc)
     end
@@ -959,14 +1074,34 @@ defmodule Breeze.Template do
     end
   end
 
-  defp compile_for_pattern(pattern_string, env) do
-    pattern_ast = Code.string_to_quoted!(pattern_string, file: env.file, line: env.line)
-
+  defp compile_for_pattern(pattern_ast, env, opts) do
     case compile_simple_pattern(pattern_ast) do
       {:ok, pattern} ->
         {:__breeze_pattern__, pattern}
 
       :error ->
+        compile_runtime_pattern(pattern_ast, env, opts)
+    end
+  end
+
+  defp compile_runtime_pattern(pattern_ast, env, opts) do
+    case Keyword.get(opts, :module) do
+      module when is_atom(module) and module == env.module ->
+        id = Module.get_attribute(module, :__breeze_template_pattern_counter__) || 0
+        Module.put_attribute(module, :__breeze_template_pattern_counter__, id + 1)
+
+        vars = collect_pattern_vars(pattern_ast)
+        pinned_vars = collect_pinned_pattern_vars(pattern_ast)
+
+        Module.put_attribute(
+          module,
+          :__breeze_template_patterns__,
+          {id, pattern_ast, vars, pinned_vars}
+        )
+
+        {:__breeze_compiled_pattern__, module, id}
+
+      _ ->
         vars = collect_pattern_vars(pattern_ast)
         result_map = {:%{}, [], Enum.map(vars, fn name -> {name, {name, [], nil}} end)}
 
@@ -981,6 +1116,20 @@ defmodule Breeze.Template do
            ]
          ]}
     end
+  end
+
+  defp collect_pinned_pattern_vars(pattern_ast) do
+    {_ast, vars} =
+      Macro.prewalk(pattern_ast, MapSet.new(), fn
+        {:^, _meta, [{name, _var_meta, context}]} = node, vars
+        when is_atom(name) and is_atom(context) ->
+          {node, MapSet.put(vars, name)}
+
+        node, vars ->
+          {node, vars}
+      end)
+
+    vars |> MapSet.to_list() |> Enum.sort()
   end
 
   defp compile_simple_pattern({name, _meta, ctx}) when is_atom(name) and is_atom(ctx),
@@ -1091,14 +1240,96 @@ defmodule Breeze.Template do
 
   defp do_collect_vars(_ast, acc), do: acc
 
-  defp compile_expr(expr, env) do
-    expr = String.trim(expr)
-
+  defp parse_expr(expr, env) do
     expr
+    |> String.trim()
     |> Code.string_to_quoted!(file: env.file, line: env.line)
-    |> normalize_assign_refs()
-    |> wrap_local_helper_calls(env.module)
-    |> simplify_expr()
+  end
+
+  defp compile_expr(expr, env, opts) do
+    normalized =
+      expr
+      |> normalize_assign_refs()
+      |> wrap_local_helper_calls(env.module)
+
+    case normalized do
+      {:render_slot, meta, args} when is_list(args) ->
+        {:render_slot, meta, Enum.map(args, &compile_expr(&1, env, opts))}
+
+      _ ->
+        case simplify_expr(normalized) do
+          ^normalized -> compile_runtime_expr(normalized, env, opts)
+          simplified -> simplified
+        end
+    end
+  end
+
+  defp compile_runtime_expr(expr, env, opts) do
+    case Keyword.get(opts, :module) do
+      module when is_atom(module) and module == env.module ->
+        id = Module.get_attribute(module, :__breeze_template_expression_counter__) || 0
+        Module.put_attribute(module, :__breeze_template_expression_counter__, id + 1)
+
+        vars = collect_expression_vars(expr)
+        compiled_expr = put_compiled_assigns_context(expr)
+        Module.put_attribute(module, :__breeze_template_expressions__, {id, compiled_expr, vars})
+
+        helpers = expr_local_helper_captures(expr)
+        {:__breeze_compiled__, module, id, helpers}
+
+      _ ->
+        expr
+    end
+  end
+
+  defp collect_expression_vars(expr) do
+    expr
+    |> do_collect_expression_vars(MapSet.new())
+    |> MapSet.to_list()
+    |> Enum.sort()
+  end
+
+  defp do_collect_expression_vars({:__aliases__, _meta, _parts}, vars), do: vars
+
+  defp do_collect_expression_vars({:"::", _meta, [value, spec]}, vars) do
+    vars
+    |> then(&do_collect_expression_vars(value, &1))
+    |> then(&do_collect_bitstring_spec_vars(spec, &1))
+  end
+
+  defp do_collect_expression_vars({name, _meta, context}, vars)
+       when is_atom(name) and is_atom(context) and name not in [:_, :assigns] do
+    if name in @expression_pseudo_vars, do: vars, else: MapSet.put(vars, name)
+  end
+
+  defp do_collect_expression_vars({form, _meta, args}, vars) when is_list(args) do
+    vars = if is_atom(form), do: vars, else: do_collect_expression_vars(form, vars)
+    do_collect_expression_vars(args, vars)
+  end
+
+  defp do_collect_expression_vars({left, right}, vars) do
+    vars
+    |> then(&do_collect_expression_vars(left, &1))
+    |> then(&do_collect_expression_vars(right, &1))
+  end
+
+  defp do_collect_expression_vars(list, vars) when is_list(list) do
+    Enum.reduce(list, vars, &do_collect_expression_vars/2)
+  end
+
+  defp do_collect_expression_vars(_literal, vars), do: vars
+
+  defp do_collect_bitstring_spec_vars({name, _meta, nil}, vars)
+       when name in @bitstring_specifiers,
+       do: vars
+
+  defp do_collect_bitstring_spec_vars(spec, vars), do: do_collect_expression_vars(spec, vars)
+
+  defp put_compiled_assigns_context(expr) do
+    Macro.prewalk(expr, fn
+      {:assigns, meta, nil} -> {:assigns, meta, __MODULE__}
+      node -> node
+    end)
   end
 
   defp wrap_local_helper_calls(ast, module) do

--- a/lib/breeze/view.ex
+++ b/lib/breeze/view.ex
@@ -361,6 +361,12 @@ defmodule Breeze.View do
       Module.register_attribute(__MODULE__, :__slot__, accumulate: false)
       Module.register_attribute(__MODULE__, :__component_specs__, accumulate: true)
       Module.register_attribute(__MODULE__, :__template_helper_captures__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__breeze_template_expressions__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__breeze_template_expression_counter__, [])
+      Module.put_attribute(__MODULE__, :__breeze_template_expression_counter__, 0)
+      Module.register_attribute(__MODULE__, :__breeze_template_patterns__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__breeze_template_pattern_counter__, [])
+      Module.put_attribute(__MODULE__, :__breeze_template_pattern_counter__, 0)
       @on_definition Breeze.View
       @before_compile Breeze.View
     end
@@ -372,7 +378,7 @@ defmodule Breeze.View do
       raise "~H requires a variable named \"assigns\" to exist and be set to a map"
     end
 
-    template = Breeze.Template.compile!(source, __CALLER__)
+    template = Breeze.Template.compile!(source, __CALLER__, module: __CALLER__.module)
 
     template
     |> Breeze.Template.component_names()
@@ -407,6 +413,8 @@ defmodule Breeze.View do
 
     component_specs = pop_component_specs(env)
     helper_captures = pop_template_helper_captures(env)
+    template_expressions = pop_template_expressions(env)
+    template_patterns = pop_template_patterns(env)
     component_spec_names = Enum.map(component_specs, & &1.name)
     local_components = Enum.uniq(component_spec_names ++ local_component_names(env, components))
     public_components = Enum.filter(local_components, &Module.defines?(env.module, {&1, 1}, :def))
@@ -423,6 +431,12 @@ defmodule Breeze.View do
           end
         end
       end)
+
+    expression_definitions =
+      Enum.map(template_expressions, &template_expression_definition/1)
+
+    pattern_definitions =
+      Enum.map(template_patterns, &template_pattern_definition/1)
 
     local_component_definitions =
       Enum.map(local_components, fn component ->
@@ -473,6 +487,18 @@ defmodule Breeze.View do
 
     quote do
       unquote_splicing(helper_definitions)
+      unquote_splicing(expression_definitions)
+
+      def __breeze_eval_expr__(id, _assigns, _vars) do
+        raise ArgumentError, "unknown compiled Breeze template expression: #{inspect(id)}"
+      end
+
+      unquote_splicing(pattern_definitions)
+
+      def __breeze_match_pattern__(id, _value, _vars) do
+        raise ArgumentError, "unknown compiled Breeze template pattern: #{inspect(id)}"
+      end
+
       unquote_splicing(local_component_definitions)
       unquote_splicing(imported_component_definitions)
 
@@ -838,6 +864,73 @@ defmodule Breeze.View do
       |> Module.delete_attribute(:__template_helper_captures__)
       |> List.wrap()
       |> Enum.reverse()
+
+  defp pop_template_expressions(env) do
+    Module.delete_attribute(env.module, :__breeze_template_expression_counter__)
+
+    env.module
+    |> Module.delete_attribute(:__breeze_template_expressions__)
+    |> List.wrap()
+    |> Enum.reverse()
+  end
+
+  defp template_expression_definition({id, expr, vars}) do
+    assigns_var = Macro.var(:assigns, Breeze.Template)
+    vars_var = Macro.var(:vars, Breeze.Template)
+
+    bindings =
+      Enum.map(vars, fn name ->
+        variable = Macro.var(name, nil)
+
+        quote generated: true do
+          unquote(variable) = Map.get(unquote(vars_var), unquote(name))
+        end
+      end)
+
+    quote generated: true do
+      def __breeze_eval_expr__(unquote(id), unquote(assigns_var), unquote(vars_var)) do
+        unquote_splicing(bindings)
+        unquote(expr)
+      end
+    end
+  end
+
+  defp pop_template_patterns(env) do
+    Module.delete_attribute(env.module, :__breeze_template_pattern_counter__)
+
+    env.module
+    |> Module.delete_attribute(:__breeze_template_patterns__)
+    |> List.wrap()
+    |> Enum.reverse()
+  end
+
+  defp template_pattern_definition({id, pattern, vars, pinned_vars}) do
+    value_var = Macro.var(:value, Breeze.Template)
+    vars_var = Macro.var(:_vars, Breeze.Template)
+
+    bindings =
+      Enum.map(pinned_vars, fn name ->
+        variable = Macro.var(name, nil)
+
+        quote generated: true do
+          unquote(variable) = Map.get(unquote(vars_var), unquote(name))
+        end
+      end)
+
+    result =
+      {:%{}, [], Enum.map(vars, fn name -> {name, Macro.var(name, nil)} end)}
+
+    quote generated: true do
+      def __breeze_match_pattern__(unquote(id), unquote(value_var), unquote(vars_var)) do
+        unquote_splicing(bindings)
+
+        case unquote(value_var) do
+          unquote(pattern) -> {:ok, unquote(result)}
+          _ -> :error
+        end
+      end
+    end
+  end
 
   defp local_component_names(env, components) do
     Enum.filter(components, fn component ->

--- a/test/breeze/html_formatter_test.exs
+++ b/test/breeze/html_formatter_test.exs
@@ -69,6 +69,26 @@ defmodule Breeze.HTMLFormatterTest do
              """
   end
 
+  test "keeps complex expressions separate from runtime compiler instructions" do
+    source =
+      ~S|<box :if={not is_nil(@value) and @value > 1} label={"value-#{@value * 2}"}>{String.upcase(@name)}:{inspect({@value, [@name], %{ok: true}})}</box>|
+
+    formatted =
+      HTMLFormatter.format(source,
+        sigil: :H,
+        opening_delimiter: "\"\"\""
+      )
+
+    assert formatted =~ "String.upcase(@name)"
+    assert formatted =~ "@value * 2"
+    refute formatted =~ "__breeze_"
+
+    assert HTMLFormatter.format(formatted,
+             sigil: :H,
+             opening_delimiter: "\"\"\""
+           ) == formatted
+  end
+
   test "formats boolean and spread attributes" do
     source = "<box focusable id={@id} {@rest}>x</box>"
 

--- a/test/breeze/implicit/textarea_test.exs
+++ b/test/breeze/implicit/textarea_test.exs
@@ -243,6 +243,30 @@ defmodule Breeze.Implicit.TextareaTest do
              )
   end
 
+  test "animate keeps explicit lines ordered when scrolling to the cursor" do
+    box = %Box{content: "", style: %BackBreeze.Style{width: 10, height: 3}}
+    value = "one\ntwo\nthree\nfour"
+
+    assert {:ok, %Box{content: "two\nthree\nfour"},
+            overlays: [%{x: 4, y: 2, char: " ", visible?: true}]} =
+             Textarea.animate(
+               :root,
+               box,
+               [focused: true],
+               %{
+                 value: value,
+                 cursor: String.length(value),
+                 placeholder: nil,
+                 preferred_column: nil
+               },
+               %{
+                 layout: %{left: 0, top: 0, viewport_width: 10, viewport_height: 3},
+                 now: 0,
+                 last_interaction_at: nil
+               }
+             )
+  end
+
   test "animate wraps the cursor to the next visual row when the bordered content width is exactly filled" do
     box =
       %Box{

--- a/test/breeze/logger_test.exs
+++ b/test/breeze/logger_test.exs
@@ -132,6 +132,17 @@ defmodule Breeze.LoggerTest do
     assert after_config == before_config
   end
 
+  test "collector retains the newest entries in oldest-first order", %{collector: collector} do
+    assert :ok = Breeze.Logger.Collector.configure(self(), mode: :attach, max_entries: 3)
+
+    for index <- 1..5 do
+      GenServer.cast(collector, {:log, %{level: :info, line: "entry-#{index}"}})
+    end
+
+    assert Enum.map(Breeze.Logger.Collector.entries(), & &1.line) ==
+             ["entry-3", "entry-4", "entry-5"]
+  end
+
   @tag capture_log: true
   test "Breeze.IO.inspect pretty-prints through the logger and returns its input" do
     value = %{alpha: Enum.to_list(1..5), beta: %{enabled: true}}

--- a/test/breeze/remote_inspector_test.exs
+++ b/test/breeze/remote_inspector_test.exs
@@ -745,6 +745,41 @@ defmodule Breeze.RemoteInspectorSyncTest do
     refute_receive {:remote_inspector_snapshots, _update}, 30
   end
 
+  test "incremental logs retain the newest entries in oldest-first order" do
+    {:ok, pid} = Breeze.RemoteInspector.ensure_server()
+    on_exit(fn -> stop_local_process(pid) end)
+
+    Enum.each(1..1_005, fn index ->
+      Breeze.RemoteInspector.Server.publish_log_entry(pid, self(), %{
+        level: :info,
+        line: "entry-#{index}"
+      })
+    end)
+
+    key = {node(), inspect(self())}
+    entries = Breeze.RemoteInspector.Server.snapshot(pid).logs[key].entries
+
+    assert length(entries) == 1_000
+    assert hd(entries).line == "entry-6"
+    assert List.last(entries).line == "entry-1005"
+  end
+
+  test "incremental logs remain bounded by total bytes" do
+    {:ok, pid} = Breeze.RemoteInspector.ensure_server()
+    on_exit(fn -> stop_local_process(pid) end)
+
+    Enum.each(1..21, fn index ->
+      line = Integer.to_string(rem(index, 10)) <> String.duplicate("x", 99_999)
+      Breeze.RemoteInspector.Server.publish_log_entry(pid, self(), %{level: :info, line: line})
+    end)
+
+    key = {node(), inspect(self())}
+    entries = Breeze.RemoteInspector.Server.snapshot(pid).logs[key].entries
+
+    assert length(entries) == 20
+    assert String.starts_with?(hd(entries).line, "2")
+  end
+
   test "disconnecting a logs-only source sends an incremental deletion" do
     {:ok, pid} = Breeze.RemoteInspector.ensure_server()
     source_pid = spawn(fn -> Process.sleep(:infinity) end)

--- a/test/breeze/server/frame_test.exs
+++ b/test/breeze/server/frame_test.exs
@@ -29,4 +29,20 @@ defmodule Breeze.Server.FrameTest do
     assert payload =~ "\e[4;1Hchanged"
     assert payload =~ "\e[3;5Himage-command"
   end
+
+  test "rows missing from the previous frame compare as empty" do
+    assert Frame.build_payload(["same"], ["same", "new"], [], [], 10) ==
+             "\e[2;1Hnew\e[2;4H\e[K"
+  end
+
+  test "rows beyond the current frame remain ignored" do
+    assert Frame.build_payload(["same", "stale"], ["same"], [], [], 10) == ""
+  end
+
+  test "overlay repairs outside the current frame use an empty row" do
+    previous_overlay = %{x: 0, y: 3, height: 1, content: "old"}
+
+    assert Frame.build_payload(["only"], ["only"], [previous_overlay], [], 10) ==
+             "\e[4;1H\e[4;1H\e[K"
+  end
 end

--- a/test/breeze/template_test.exs
+++ b/test/breeze/template_test.exs
@@ -1,6 +1,10 @@
 defmodule Breeze.TemplateTest do
   use ExUnit.Case, async: true
 
+  defmodule ExpressionHelpers do
+    def decorate(value), do: "*#{value}*"
+  end
+
   defmodule InterpolationView do
     use Breeze.View
 
@@ -106,6 +110,36 @@ defmodule Breeze.TemplateTest do
     defp format_name(name), do: String.upcase(name)
   end
 
+  defmodule CompiledExpressionView do
+    use Breeze.View
+
+    alias String, as: Text
+    import ExpressionHelpers
+
+    def render(assigns) do
+      ~H|<box :if={@enabled and length(@items) > 0} data-count={length(@items)}>
+  {Enum.join(
+    [decorate(format_name(Text.upcase(@name))), Enum.join(Enum.map(@items, &(&1 * @factor)), ",")],
+    ":"
+  )}
+  <box :for={item <- @items}>{item * @factor}</box>
+  <box :for={binary <- @binaries}>{String.upcase(binary)}</box>
+</box>|
+    end
+
+    defp format_name(name), do: "[#{name}]"
+  end
+
+  defmodule PinnedPatternView do
+    use Breeze.View
+
+    def render(assigns) do
+      ~H|<box :for={expected <- @expected}>
+  <box :for={^expected <- @values}>{expected}</box>
+</box>|
+    end
+  end
+
   defmodule SlotView do
     use Breeze.View
 
@@ -181,9 +215,25 @@ defmodule Breeze.TemplateTest do
                "<box><box>a123</box><box>b123</box></box>"
     end
 
-    test "falls back to eval for unsupported :for patterns" do
+    test "compiles complex :for patterns into view matcher functions" do
       assert render(MapPatternForView, %{items: [%{label: "a"}, %{label: "b"}]}) ==
                "<box><box>a</box><box>b</box></box>"
+
+      {template, _assigns} = MapPatternForView.render(%{items: []})
+
+      assert [
+               {:element, "box", [], _outer_directives,
+                [
+                  {:element, "box", [],
+                   %{
+                     for:
+                       {"%{label: label}", {:__breeze_compiled_pattern__, MapPatternForView, _id},
+                        {:__breeze_assign__, :items}}
+                   }, _children}
+                ]}
+             ] = template.nodes
+
+      assert function_exported?(MapPatternForView, :__breeze_match_pattern__, 3)
     end
 
     test "supports dynamic/boolean/spread attributes" do
@@ -204,6 +254,29 @@ defmodule Breeze.TemplateTest do
 
     test "supports private helper calls inside templates" do
       assert render(PrivateHelperView, %{name: "ada"}) == "<box>ADA</box>"
+    end
+
+    test "executes non-trivial expressions as compiled view functions" do
+      assigns = %{enabled: true, items: [1, 2], factor: 2, name: "ada", binaries: ["a"]}
+
+      assert render(CompiledExpressionView, assigns) ==
+               ~s(<box data-count="2">*[ADA]*:2,4<box>2</box><box>4</box><box>A</box></box>)
+
+      assert render(CompiledExpressionView, %{assigns | enabled: false}) == ""
+
+      {template, _assigns} = CompiledExpressionView.render(assigns)
+
+      assert [
+               {:element, "box", _attrs,
+                %{if: {:__breeze_compiled__, CompiledExpressionView, _id, _helpers}}, _children}
+             ] = template.nodes
+
+      assert function_exported?(CompiledExpressionView, :__breeze_eval_expr__, 3)
+    end
+
+    test "compiled pattern matchers can use bindings from an outer directive" do
+      assert render(PinnedPatternView, %{expected: [2], values: [1, 2, 3]}) ==
+               "<box><box>2</box></box>"
     end
 
     test "supports named slots, :for on slots, and render_slot assigns" do


### PR DESCRIPTION
before parsing and runtime lowering happened together:

* template source
* parse and immediately lower expressions
* runtime template instructions

Breeze already optimized simple expressions such as assign access,
literals, field access, and known helper calls. Expressions outside
those optimized forms remained quoted Elixir AST.

Now we generate view functions such as:

```
  <box :for={item <- @Items}>{item * https://github.com/factor}</box>
```

generates a function in the view module conceptually like:

```
def __breeze_eval_expr__(0, assigns, vars) do
  item = Map.get(vars, :item)
  item * assigns.factor
end
```

The main saving is replacing this work on every render:

build binding list:

* interpret quoted AST
* return evaluator binding
* discard binding

with:

* lookup required variables
* call compiled BEAM function

That produced the measured improvements:

Single complex expression - before: 5.1µs, after: 0.3µs
1000rh ow expression loop -  before: 4049µs after:392 µs

The trade-off is a small increase in view compilation work and generated
module size That is generally preferable because templates compile once
but render repeatedly.