### PR TITLE
feat(Breeze.RemoteInspector): add custom pages

### DIFF
--- a/lib/breeze/input_router.ex
+++ b/lib/breeze/input_router.ex
@@ -14,6 +14,7 @@ defmodule Breeze.InputRouter do
     :reader,
     :server_pid,
     :child_view_supervisor,
+    :remote_inspector_supervisor,
     :halt_fun,
     :theme_probe,
     :iex_shell_proxy,
@@ -56,12 +57,14 @@ defmodule Breeze.InputRouter do
       maybe_complete_initial_theme_probe(terminal, Keyword.get(opts, :theme))
 
     {:ok, child_view_supervisor} = Breeze.ChildViewSupervisor.start_link()
+    remote_inspector_supervisor = maybe_start_remote_inspector_supervisor(opts)
 
     server_opts =
       opts
       |> Keyword.put(:terminal, terminal)
       |> Keyword.put(:input_router, self())
       |> put_internal(:child_view_supervisor, child_view_supervisor)
+      |> put_internal(:remote_inspector_supervisor, remote_inspector_supervisor)
 
     {:ok, server_pid} = Breeze.Server.start_app_link(server_opts)
     Process.monitor(server_pid)
@@ -71,6 +74,7 @@ defmodule Breeze.InputRouter do
       reader: reader,
       server_pid: server_pid,
       child_view_supervisor: child_view_supervisor,
+      remote_inspector_supervisor: remote_inspector_supervisor,
       halt_fun: Keyword.get_lazy(opts, :halt_fun, &default_halt_fun/0),
       alt_screen?: alt_screen?,
       enhanced_keyboard?: enhanced_keyboard?,
@@ -146,11 +150,21 @@ defmodule Breeze.InputRouter do
 
   @impl true
   def terminate(_reason, state) do
+    Breeze.RemoteInspector.Supervisor.stop(state.remote_inspector_supervisor)
     Breeze.ChildViewSupervisor.stop(state.child_view_supervisor)
     IExShellProxy.stop(state.iex_shell_proxy)
     SilentGroupLeader.stop(state.silent_group_leader)
     state.halt_fun.()
     :ok
+  end
+
+  defp maybe_start_remote_inspector_supervisor(opts) do
+    inspector = %{inspector: Keyword.get(opts, :inspector, false)}
+
+    if Breeze.Inspector.enabled?(inspector) and Breeze.Inspector.remote?(inspector) do
+      {:ok, supervisor} = Breeze.RemoteInspector.Supervisor.start_link()
+      supervisor
+    end
   end
 
   defp stop_global_key?(key, state),

--- a/lib/breeze/inspector.ex
+++ b/lib/breeze/inspector.ex
@@ -25,6 +25,10 @@ defmodule Breeze.Inspector do
 
       inspector: [toggle_key: "F9", move_key: "F10", remote: false]
 
+  Applications can also register custom pages for the remote inspector:
+
+      inspector: [pages: [MyApp.InspectorPage]]
+
   The supported options are:
 
     * `:toggle_key` - key used to show or hide the inspector. Defaults to
@@ -32,6 +36,7 @@ defmodule Breeze.Inspector do
     * `:move_key` - key used to move the local panel. Defaults to `"PageUp"`.
     * `:remote` - publishes snapshots for the remote inspector. Defaults to
       `true`.
+    * `:pages` - a list of page modules published to the remote inspector.
 
   ## Available information
 
@@ -96,6 +101,14 @@ defmodule Breeze.Inspector do
 
   @doc false
   def remote?(state), do: Keyword.get(config(state), :remote, true)
+
+  @doc false
+  def pages(state) do
+    state
+    |> config()
+    |> Keyword.get(:pages, [])
+    |> Breeze.RemoteInspector.Pages.build()
+  end
 
   @doc false
   def panel_position(state),
@@ -221,6 +234,7 @@ defmodule Breeze.Inspector do
       },
       render_tree?: not is_nil(rendered_field(state, :render_tree, :rendered_render_tree)),
       render_tree_kinds: render_tree_kinds(state),
+      pages: pages(state),
       toggle_key: toggle_key(state),
       move_key: move_key(state),
       panel_position: panel_position(state),

--- a/lib/breeze/remote_inspector.ex
+++ b/lib/breeze/remote_inspector.ex
@@ -79,7 +79,7 @@ defmodule Breeze.RemoteInspector do
 
   def register_app(pid) when is_pid(pid) do
     ensure_registry_started()
-    :pg.join(@app_group, pid)
+    :ok = :pg.join(@app_group, pid)
   end
 
   def app_members do
@@ -160,6 +160,23 @@ defmodule Breeze.RemoteInspector do
         true -> remote_server_pid()
         _ -> nil
       end
+  end
+
+  @doc false
+  def connect_app_to_inspector do
+    case default_inspector_node(node()) do
+      nil ->
+        :disabled
+
+      target when target == node() ->
+        :disabled
+
+      _target ->
+        case ensure_remote_server_pid() do
+          pid when is_pid(pid) -> {:ok, pid}
+          _ -> :retry
+        end
+    end
   end
 
   defp maybe_connect_default_inspector_node do

--- a/lib/breeze/remote_inspector/app_connector.ex
+++ b/lib/breeze/remote_inspector/app_connector.ex
@@ -1,0 +1,110 @@
+defmodule Breeze.RemoteInspector.AppConnector do
+  @moduledoc false
+
+  use GenServer
+
+  @retry_interval 250
+
+  def start_link(app_pid, opts \\ []) when is_pid(app_pid) and is_list(opts) do
+    GenServer.start_link(__MODULE__, {app_pid, opts})
+  end
+
+  def child_spec({app_pid, opts}) do
+    %{
+      id: {__MODULE__, app_pid},
+      start: {__MODULE__, :start_link, [app_pid, opts]},
+      restart: :transient,
+      type: :worker
+    }
+  end
+
+  @impl true
+  def init({app_pid, opts}) do
+    state = %{
+      app_pid: app_pid,
+      app_ref: Process.monitor(app_pid),
+      inspector_ref: nil,
+      resolver: Keyword.get(opts, :resolver, &Breeze.RemoteInspector.connect_app_to_inspector/0),
+      retry_interval: Keyword.get(opts, :retry_interval, @retry_interval),
+      snapshot_reader:
+        Keyword.get(opts, :snapshot_reader, &Breeze.Server.Diagnostics.inspector_snapshot/1),
+      publisher: Keyword.get(opts, :publisher, &Breeze.RemoteInspector.Server.publish/3)
+    }
+
+    {:ok, state, {:continue, :connect}}
+  end
+
+  @impl true
+  def handle_continue(:connect, state), do: connect(state)
+
+  @impl true
+  def handle_info(:connect, state), do: connect(state)
+
+  def handle_info(
+        {:DOWN, app_ref, :process, app_pid, _reason},
+        %{app_ref: app_ref, app_pid: app_pid} = state
+      ) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info(
+        {:DOWN, inspector_ref, :process, _pid, _reason},
+        %{inspector_ref: inspector_ref} = state
+      )
+      when is_reference(inspector_ref) do
+    connect(%{state | inspector_ref: nil})
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  defp connect(state) do
+    case resolve(state.resolver) do
+      {:ok, inspector_pid} when is_pid(inspector_pid) ->
+        case publish_current_snapshot(inspector_pid, state) do
+          :ok ->
+            inspector_ref = Process.monitor(inspector_pid)
+            {:noreply, %{state | inspector_ref: inspector_ref}}
+
+          :retry ->
+            retry_connect(state)
+        end
+
+      :disabled ->
+        {:stop, :normal, state}
+
+      _retry ->
+        retry_connect(state)
+    end
+  end
+
+  defp retry_connect(state) do
+    Process.send_after(self(), :connect, state.retry_interval)
+    {:noreply, state}
+  end
+
+  defp resolve(resolver), do: retry_on_failure(resolver)
+
+  defp publish_current_snapshot(inspector_pid, state) do
+    retry_on_failure(fn ->
+      snapshot = state.snapshot_reader.(state.app_pid)
+      publish_snapshot(snapshot, inspector_pid, state)
+    end)
+  end
+
+  defp publish_snapshot(snapshot, inspector_pid, state) when is_map(snapshot) do
+    case state.publisher.(inspector_pid, state.app_pid, snapshot) do
+      :ok -> :ok
+      _failure -> :retry
+    end
+  end
+
+  defp publish_snapshot(_snapshot, _inspector_pid, _state), do: :retry
+
+  defp retry_on_failure(fun) do
+    fun.()
+  rescue
+    _error -> :retry
+  catch
+    _kind, _reason -> :retry
+  end
+end

--- a/lib/breeze/remote_inspector/page.ex
+++ b/lib/breeze/remote_inspector/page.ex
@@ -1,0 +1,148 @@
+defmodule Breeze.RemoteInspector.Page do
+  @moduledoc """
+  Behaviour for custom remote inspector pages.
+
+  An inspected application registers pages with its server:
+
+      Breeze.Server.start_link(
+        view: MyApp.View,
+        inspector: [pages: [MyApp.TimelinePage]]
+      )
+
+  App-registered pages are published with the inspector snapshot and shown
+  while that app is the active source. The page module must also be available
+  to the inspector node. If it is missing, the tab remains visible and reports
+  which package needs to be added to the inspector project.
+
+  Register page modules directly in the inspector configuration:
+
+      inspector: [
+        pages: [
+          MyApp.TimelinePage,
+          MyApp.ToolsPage
+        ]
+      ]
+
+  Each page defines its display label and optional initial assigns through
+  `page/0`. Assigns accept a map or keyword list:
+
+      def page do
+        [label: "Runtime tools", assigns: %{mode: :compact, limit: 200}]
+      end
+
+  `render/1` receives the standard `:breeze` assigns, the active source server
+  PID, page-specific assigns, and page state. Pages can explicitly request
+  optional source details with `request/3`:
+
+      {:ok, snapshot} = Breeze.RemoteInspector.Page.request(assigns, :snapshot)
+
+      {:ok, tree} =
+        Breeze.RemoteInspector.Page.request(assigns, :render_tree,
+          kind: :rendered,
+          limit: 200
+        )
+
+  This keeps the default page contract small and avoids coupling every page to
+  the inspector's internal caches.
+
+  Interactive pages can return `{:noreply, state}` from `handle_event/3` or
+  `handle_info/2`. That state is scoped to the page id and inspected source,
+  then merged into future render assigns. Asynchronous page messages should
+  use `message/2` so replies retain that source:
+
+      send(inspector_pid, Breeze.RemoteInspector.Page.message(assigns, result))
+
+  Use this module to define a page with Breeze template support:
+
+      defmodule MyApp.TimelinePage do
+        use Breeze.RemoteInspector.Page
+
+        def page, do: [label: "Timeline"]
+
+        def render(assigns) do
+          ~H"<box>Timeline</box>"
+        end
+      end
+  """
+
+  @callback page() :: keyword() | map()
+  @callback render(map()) :: any()
+  @callback handle_event(term(), map(), map()) :: {:noreply, map()} | :noreply
+  @callback handle_info(term(), map()) :: {:noreply, map()} | :noreply
+
+  @optional_callbacks handle_event: 3, handle_info: 2
+
+  @type detail :: :snapshot | :render_tree | :stats
+
+  @doc """
+  Returns the active source server PID from page assigns.
+  """
+  @spec source_server_pid(map()) :: pid() | nil
+  def source_server_pid(assigns) when is_map(assigns) do
+    case Map.get(assigns, :source_server_pid) do
+      pid when is_pid(pid) -> pid
+      _pid -> nil
+    end
+  end
+
+  @doc """
+  Wraps an asynchronous message for this page and inspected source.
+  """
+  @spec message(map(), term()) :: {:remote_inspector_page, term(), term()}
+  def message(assigns, message) when is_map(assigns) do
+    page_ref = Map.get(assigns, :page_ref, Map.get(assigns, :id))
+    {:remote_inspector_page, page_ref, message}
+  end
+
+  @doc """
+  Requests optional details from the active source application.
+
+  Supported requests are `:snapshot`, `:render_tree`, and `:stats`.
+  """
+  @spec request(map(), detail(), keyword()) :: {:ok, term()} | {:error, term()}
+  def request(assigns, detail, opts \\ [])
+
+  def request(assigns, :snapshot, _opts) do
+    request_source(assigns, &Breeze.Server.Diagnostics.inspector_snapshot/1)
+  end
+
+  def request(assigns, :render_tree, opts) when is_list(opts) do
+    request_source(assigns, &Breeze.Server.inspector_render_tree(&1, opts))
+  end
+
+  def request(assigns, :stats, _opts) do
+    request_source(assigns, &Breeze.Server.Diagnostics.stats/1)
+  end
+
+  def request(_assigns, detail, _opts), do: {:error, {:unsupported_request, detail}}
+
+  @doc """
+  Requests source details and raises if they are unavailable.
+  """
+  @spec request!(map(), detail(), keyword()) :: term()
+  def request!(assigns, detail, opts \\ []) do
+    case request(assigns, detail, opts) do
+      {:ok, value} -> value
+      {:error, reason} -> raise "remote inspector page request failed: #{inspect(reason)}"
+    end
+  end
+
+  defp request_source(assigns, fun) do
+    case source_server_pid(assigns) do
+      pid when is_pid(pid) ->
+        {:ok, fun.(pid)}
+
+      _pid ->
+        {:error, :no_active_source}
+    end
+  catch
+    :exit, reason -> {:error, {:source_exit, reason}}
+  end
+
+  defmacro __using__(_opts) do
+    quote do
+      use Breeze.Component
+      @behaviour Breeze.RemoteInspector.Page
+    end
+  end
+end

--- a/lib/breeze/remote_inspector/page_host.ex
+++ b/lib/breeze/remote_inspector/page_host.ex
@@ -1,0 +1,253 @@
+defmodule Breeze.RemoteInspector.PageHost do
+  @moduledoc false
+
+  use Breeze.Component
+
+  alias Breeze.RemoteInspector.Pages
+  alias Breeze.Template
+
+  def pages(active) do
+    active
+    |> active_pages()
+    |> Pages.validate_discovered()
+  end
+
+  def normalize_tab(panel_tab, custom_pages) do
+    available = Pages.reserved_ids() ++ Enum.map(custom_pages, & &1.id)
+    if panel_tab in available, do: panel_tab, else: "overview"
+  end
+
+  def context(assigns, active) do
+    context(assigns, active, active_source(assigns))
+  end
+
+  def context(assigns, active, scope) do
+    %{
+      source_server_pid: source_server_pid(active),
+      breeze: Map.get(assigns, :breeze, %{}),
+      page_states: Map.get(assigns, :custom_page_states, %{}),
+      page_state_scope: scope
+    }
+  end
+
+  def page_assigns(page, context) do
+    state =
+      context
+      |> Map.get(:page_states, %{})
+      |> Map.get(page_state_key(context, page.id), %{})
+
+    page_data =
+      page
+      |> Map.get(:assigns, %{})
+      |> Map.merge(state)
+
+    host_data =
+      context
+      |> Map.drop([:page_states, :page_state_scope])
+      |> Map.merge(%{
+        id: page.id,
+        label: page.label,
+        page: page,
+        page_ref: {Map.get(context, :page_state_scope), page.id}
+      })
+
+    Map.merge(page_data, host_data)
+  end
+
+  attr :page, :map, required: true
+  attr :context, :map, required: true
+
+  def render(assigns) do
+    page_assigns = page_assigns(assigns.page, assigns.context)
+    page_error = Map.get(page_assigns, :custom_page_error)
+
+    if page_error do
+      page_message(page_assigns, page_error)
+    else
+      render_page(assigns.page, page_assigns)
+    end
+  end
+
+  defp render_page(page, page_assigns) do
+    case safe_page_call(fn -> render_available_page(page, page_assigns) end) do
+      {:ok, rendered} -> rendered
+      {:error, reason} -> page_message(page_assigns, page_failure_message(reason))
+    end
+  end
+
+  defp render_available_page(page, page_assigns) do
+    if callback_exported?(page.module, :render, 1) do
+      page.module
+      |> apply(:render, [page_assigns])
+      |> normalize_render(page_assigns)
+    else
+      page_message(
+        page_assigns,
+        "remote inspector page #{inspect(page.module)} is unavailable on this " <>
+          "inspector node; start the inspector from a project that includes the page's package"
+      )
+    end
+  end
+
+  def delegate_event(event, payload, term, active) do
+    scope = active_source(term.assigns)
+
+    case custom_page_by_id(active, Map.get(term.assigns, :panel_tab)) do
+      nil -> {:noreply, term}
+      page -> invoke_callback(page, term, active, scope, :handle_event, [event, payload])
+    end
+  end
+
+  def delegate_info({scope, page_id}, message, term) when is_binary(page_id) do
+    active = source_entry(term.assigns, scope)
+
+    case custom_page_by_id(active, page_id) do
+      nil -> {:noreply, term}
+      page -> invoke_callback(page, term, active, scope, :handle_info, [message])
+    end
+  end
+
+  def delegate_info(page_id, message, term) when is_binary(page_id) do
+    delegate_info({active_source(term.assigns), page_id}, message, term)
+  end
+
+  def delegate_info(_page_ref, _message, term), do: {:noreply, term}
+
+  defp active_pages(%{snapshot: %{pages: pages}}) when is_list(pages), do: pages
+  defp active_pages(_active), do: []
+
+  defp source_server_pid(%{snapshot: %{source: %{server_pid: pid}}}) when is_pid(pid), do: pid
+  defp source_server_pid(%{source: %{pid: pid}}) when is_pid(pid), do: pid
+  defp source_server_pid(_active), do: nil
+
+  defp active_source(assigns) do
+    Map.get(assigns, :active_source) ||
+      Map.get(assigns, :latest_source) ||
+      Map.get(assigns, :source_server_pid)
+  end
+
+  defp page_state_key(context, page_id) do
+    {Map.get(context, :page_state_scope), page_id}
+  end
+
+  defp custom_page_by_id(active, page_id) when is_binary(page_id) do
+    active
+    |> pages()
+    |> Enum.find(&(&1.id == page_id))
+  end
+
+  defp custom_page_by_id(_active, _page_id), do: nil
+
+  defp invoke_callback(page, term, active, scope, callback, args) do
+    result =
+      safe_page_call(fn ->
+        call_page_callback(page, term, active, scope, callback, args)
+      end)
+
+    case result do
+      {:ok, reply} ->
+        reply
+
+      {:error, reason} ->
+        callback_error(term, page, scope, page_failure_message(reason))
+    end
+  end
+
+  defp call_page_callback(page, term, active, scope, callback, args) do
+    if callback_exported?(page.module, callback, length(args) + 1) do
+      assigns = page_assigns(page, context(term.assigns, active, scope))
+
+      page.module
+      |> apply(callback, args ++ [assigns])
+      |> normalize_callback_reply(term, page, scope)
+    else
+      {:noreply, term}
+    end
+  end
+
+  defp normalize_callback_reply({:noreply, state}, term, page, scope) when is_map(state) do
+    {:noreply, put_page_state(term, page.id, scope, state)}
+  end
+
+  defp normalize_callback_reply(:noreply, term, _page, _scope), do: {:noreply, term}
+
+  defp normalize_callback_reply(reply, term, page, scope) do
+    callback_error(
+      term,
+      page,
+      scope,
+      "remote inspector page returned an invalid callback result: #{inspect(reply)}"
+    )
+  end
+
+  defp callback_error(term, page, scope, message) do
+    {:noreply, put_page_error(term, page.id, scope, message)}
+  end
+
+  defp put_page_error(term, page_id, scope, message) do
+    key = {scope, page_id}
+
+    current =
+      term.assigns
+      |> Map.get(:custom_page_states, %{})
+      |> Map.get(key, %{})
+
+    put_page_state(term, page_id, scope, Map.put(current, :custom_page_error, message))
+  end
+
+  defp put_page_state(term, page_id, scope, state) do
+    key = {scope, page_id}
+
+    custom_page_states =
+      term.assigns
+      |> Map.get(:custom_page_states, %{})
+      |> Map.put(key, state)
+
+    assign(term, custom_page_states: custom_page_states)
+  end
+
+  defp source_entry(%{snapshots: snapshots}, scope), do: Map.get(snapshots, scope)
+  defp source_entry(_assigns, _scope), do: nil
+
+  defp callback_exported?(module, callback, arity) do
+    Code.ensure_loaded?(module) and function_exported?(module, callback, arity)
+  end
+
+  defp safe_page_call(fun) do
+    {:ok, fun.()}
+  rescue
+    error -> {:error, Exception.message(error)}
+  catch
+    kind, reason -> {:error, inspect({kind, reason})}
+  end
+
+  defp page_failure_message(reason), do: "remote inspector page failed: #{reason}"
+
+  defp normalize_render({%Template{} = template, assigns}, _page_assigns) do
+    {template, assigns}
+  end
+
+  defp normalize_render(%Template{} = template, page_assigns) do
+    {template, page_assigns}
+  end
+
+  defp normalize_render(content, page_assigns) do
+    page_content(
+      Map.put(page_assigns, :content, Template.render_to_string(content, page_assigns))
+    )
+  end
+
+  defp page_content(assigns) do
+    ~H"""
+    <box class="width-full height-full padding-top-1 overflow-hidden">{@content}</box>
+    """
+  end
+
+  defp page_message(assigns, message) do
+    assigns = Map.put(assigns, :message, message)
+
+    ~H"""
+    <box class="width-full height-full padding-top-1 overflow-hidden text-error">{@message}</box>
+    """
+  end
+end

--- a/lib/breeze/remote_inspector/pages.ex
+++ b/lib/breeze/remote_inspector/pages.ex
@@ -1,0 +1,136 @@
+defmodule Breeze.RemoteInspector.Pages do
+  @moduledoc false
+
+  @reserved_ids ~w(logs tree overview layout theme implicit)
+  @page_keys [:label, :assigns]
+
+  def reserved_ids, do: @reserved_ids
+
+  def build(pages) when is_list(pages) do
+    pages
+    |> Enum.map(&build_page/1)
+    |> Enum.uniq_by(& &1.module)
+  end
+
+  def build(other) do
+    raise ArgumentError,
+          "expected :pages to be a list of page modules, got: #{inspect(other)}"
+  end
+
+  def validate_discovered(descriptors) when is_list(descriptors) do
+    descriptors
+    |> Enum.flat_map(&validate_descriptor/1)
+    |> Enum.uniq_by(& &1.module)
+  end
+
+  def validate_discovered(_descriptors), do: []
+
+  defp build_page(other) when not is_atom(other) do
+    raise ArgumentError, "expected a page module, got: #{inspect(other)}"
+  end
+
+  defp build_page(module) do
+    unless Code.ensure_loaded?(module) and function_exported?(module, :render, 1) do
+      raise ArgumentError, "expected #{inspect(module)} to define render/1"
+    end
+
+    unless function_exported?(module, :page, 0) do
+      raise ArgumentError, "expected #{inspect(module)} to define page/0"
+    end
+
+    page = module |> apply(:page, []) |> page!(module)
+
+    %{
+      id: page_id(module),
+      label: page_label!(page, module),
+      module: module,
+      assigns: assigns!(page, module)
+    }
+  end
+
+  defp page!(page, module) when is_list(page) do
+    if Keyword.keyword?(page) do
+      page |> Map.new() |> page!(module)
+    else
+      page_error!(module)
+    end
+  end
+
+  defp page!(page, module) when is_map(page) do
+    case Map.keys(page) -- @page_keys do
+      [] ->
+        page
+
+      unknown ->
+        raise ArgumentError,
+              "unknown #{inspect(module)}.page/0 keys: #{inspect(Enum.sort(unknown))}"
+    end
+  end
+
+  defp page!(_page, module), do: page_error!(module)
+
+  defp page_error!(module) do
+    raise ArgumentError, "expected #{inspect(module)}.page/0 to return a keyword list or map"
+  end
+
+  defp page_label!(page, module) do
+    case Map.fetch(page, :label) do
+      {:ok, label} when is_binary(label) ->
+        case String.trim(label) do
+          "" -> label_error!(module)
+          label -> label
+        end
+
+      _label ->
+        label_error!(module)
+    end
+  end
+
+  defp label_error!(module) do
+    raise ArgumentError, "expected #{inspect(module)}.page/0 to define a non-empty :label"
+  end
+
+  defp assigns!(page, module) do
+    case Map.get(page, :assigns, %{}) do
+      value when is_map(value) ->
+        value
+
+      value when is_list(value) ->
+        if Keyword.keyword?(value), do: Map.new(value), else: assigns_error!(module)
+
+      _value ->
+        assigns_error!(module)
+    end
+  end
+
+  defp assigns_error!(module) do
+    raise ArgumentError, "expected :assigns for #{inspect(module)} to be a keyword list or map"
+  end
+
+  defp validate_descriptor(%{label: label, module: module} = descriptor)
+       when is_atom(module) and is_binary(label) do
+    if String.trim(label) != "" do
+      [
+        %{
+          id: page_id(module),
+          label: String.trim(label),
+          module: module,
+          assigns: discovered_assigns(descriptor)
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp validate_descriptor(_descriptor), do: []
+
+  defp discovered_assigns(descriptor) do
+    case Map.get(descriptor, :assigns, %{}) do
+      value when is_map(value) -> value
+      _value -> %{}
+    end
+  end
+
+  defp page_id(module), do: "page:#{module}"
+end

--- a/lib/breeze/remote_inspector/supervisor.ex
+++ b/lib/breeze/remote_inspector/supervisor.ex
@@ -1,0 +1,31 @@
+defmodule Breeze.RemoteInspector.Supervisor do
+  @moduledoc false
+
+  use DynamicSupervisor
+
+  def start_link(opts \\ []) do
+    DynamicSupervisor.start_link(__MODULE__, :ok, opts)
+  end
+
+  def start_connector(supervisor, app_pid, opts \\ [])
+      when is_pid(supervisor) and is_pid(app_pid) and is_list(opts) do
+    DynamicSupervisor.start_child(
+      supervisor,
+      {Breeze.RemoteInspector.AppConnector, {app_pid, opts}}
+    )
+  end
+
+  def stop(supervisor) when is_pid(supervisor) do
+    if Process.alive?(supervisor), do: DynamicSupervisor.stop(supervisor, :normal)
+    :ok
+  catch
+    :exit, _reason -> :ok
+  end
+
+  def stop(_supervisor), do: :ok
+
+  @impl true
+  def init(:ok) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+end

--- a/lib/breeze/remote_inspector/view.ex
+++ b/lib/breeze/remote_inspector/view.ex
@@ -5,9 +5,11 @@ defmodule Breeze.RemoteInspector.View do
   import Breeze.Blocks
   import Breeze.RemoteInspector.Logs, only: [logs_tab: 1]
   alias BackBreeze.TextSpan
-  alias Breeze.RemoteInspector.Logs
+  alias Breeze.RemoteInspector.{Logs, PageHost}
 
   @render_tree_limit 600
+  @tab_changed_event {:breeze_remote_inspector, "tab_changed"}
+  @render_tree_changed_event {:breeze_remote_inspector, "render_tree_changed"}
 
   def global_keybindings do
     [
@@ -36,6 +38,7 @@ defmodule Breeze.RemoteInspector.View do
        render_tree_kind: "rendered",
        render_tree_expanded: %{},
        render_trees: %{},
+       custom_page_states: %{},
        screen: term.terminal.size
      )
      |> put_tree_keybindings()
@@ -46,8 +49,8 @@ defmodule Breeze.RemoteInspector.View do
     active = active_entry(assigns)
     active_source = active_source(assigns)
     render_tree_kind = render_tree_kind(assigns)
-    panel_tab = Map.get(assigns, :panel_tab, "overview")
     breeze = assigns |> Map.get(:breeze, %{}) |> Map.put_new(:keybindings, [])
+    assigns = Map.put(assigns, :breeze, breeze)
     now = System.system_time(:millisecond)
     active_render_tree = active_render_tree(assigns, active_source, active, render_tree_kind)
     inspected_screen = if(active, do: Map.get(active.snapshot, :screen), else: nil)
@@ -55,6 +58,10 @@ defmodule Breeze.RemoteInspector.View do
     logs = Map.get(assigns, :logs, %{})
     log_sources = Logs.build_sources(logs, Map.get(assigns, :log_sources, %{}))
     log_source = Logs.source(logs, active_source)
+    custom_pages = PageHost.pages(active)
+    panel_tab = PageHost.normalize_tab(Map.get(assigns, :panel_tab, "overview"), custom_pages)
+    assigns = Map.put(assigns, :panel_tab, panel_tab)
+    custom_page_context = PageHost.context(assigns, active)
 
     assigns =
       Map.merge(assigns, %{
@@ -117,6 +124,8 @@ defmodule Breeze.RemoteInspector.View do
         active_log_status_text: Logs.status_line(logs, log_source, now),
         active_log_count: Logs.count(logs, log_source),
         active_log_content: Logs.content(log_sources, log_source),
+        custom_pages: custom_pages,
+        custom_page_context: custom_page_context,
         render_tree_kind: render_tree_kind,
         breeze: breeze,
         panel_tab: panel_tab
@@ -145,7 +154,7 @@ defmodule Breeze.RemoteInspector.View do
               id="remote-inspector-tabs"
               selected={@panel_tab}
               highlight="primary"
-              br-change="tab_changed"
+              br-change={{:breeze_remote_inspector, "tab_changed"}}
               class="width-full height-full border-rounded bg"
               item_class="width-10"
             >
@@ -214,6 +223,9 @@ defmodule Breeze.RemoteInspector.View do
                   active_implicit_text={@active_implicit_text}
                   active_implicit_detail_text={@active_implicit_detail_text}
                 />
+              </:tab>
+              <:tab :for={page <- @custom_pages} value={page.id} label={page.label}>
+                <.custom_page page={page} context={@custom_page_context}/>
               </:tab>
             </.tabs>
           </box>
@@ -336,7 +348,7 @@ defmodule Breeze.RemoteInspector.View do
         collapsed_prefix="▸"
         expanded_prefix="▾"
         virtual
-        br-change="render_tree_changed"
+        br-change={{:breeze_remote_inspector, "render_tree_changed"}}
         class="width-full height-full bg"
       />
       <box :if={is_nil(@active) or @nodes == []} class="width-full text-muted">
@@ -550,6 +562,13 @@ defmodule Breeze.RemoteInspector.View do
     """
   end
 
+  attr :page, :map, required: true
+  attr :context, :map, required: true
+
+  def custom_page(assigns) do
+    PageHost.render(assigns)
+  end
+
   attr :title, :string, required: true
   slot :inner_block, required: true
 
@@ -614,11 +633,15 @@ defmodule Breeze.RemoteInspector.View do
     {:noreply, assign_logs(term, logs)}
   end
 
+  def handle_info({:remote_inspector_page, page_ref, message}, term) do
+    PageHost.delegate_info(page_ref, message, term)
+  end
+
   def handle_info(:resize, term) do
     {:noreply, assign(term, screen: term.terminal.size)}
   end
 
-  def handle_event("tab_changed", %{value: value}, term) do
+  def handle_event(@tab_changed_event, %{value: value}, term) do
     {:noreply,
      term
      |> assign(panel_tab: value)
@@ -626,7 +649,7 @@ defmodule Breeze.RemoteInspector.View do
      |> refresh_active_render_tree(force: value == "tree")}
   end
 
-  def handle_event("tab_changed", %{"value" => value}, term) do
+  def handle_event(@tab_changed_event, %{"value" => value}, term) do
     {:noreply,
      term
      |> assign(panel_tab: value)
@@ -634,7 +657,7 @@ defmodule Breeze.RemoteInspector.View do
      |> refresh_active_render_tree(force: value == "tree")}
   end
 
-  def handle_event("render_tree_changed", payload, term) do
+  def handle_event(@render_tree_changed_event, payload, term) do
     selected = payload_value(payload, :value)
     expanded = normalize_expanded(payload_value(payload, :expanded))
     active_source = active_source(term.assigns)
@@ -674,7 +697,10 @@ defmodule Breeze.RemoteInspector.View do
   end
 
   def handle_event(_, %{"key" => "q"}, term), do: quit(%{"key" => "q"}, term)
-  def handle_event(_, _, term), do: {:noreply, term}
+
+  def handle_event(event, payload, term) do
+    PageHost.delegate_event(event, payload, term, active_entry(term.assigns))
+  end
 
   defp active_source(assigns),
     do: Map.get(assigns, :active_source) || Map.get(assigns, :latest_source)
@@ -682,6 +708,8 @@ defmodule Breeze.RemoteInspector.View do
   defp active_entry(%{snapshots: snapshots, latest_source: latest_source} = assigns) do
     Map.get(snapshots, active_source(assigns) || latest_source)
   end
+
+  defp active_entry(_assigns), do: nil
 
   defp assign_snapshot_state(term, snapshots, latest_source) do
     active_source = normalize_active_source(term.assigns.active_source, snapshots, latest_source)

--- a/lib/breeze/server.ex
+++ b/lib/breeze/server.ex
@@ -67,6 +67,7 @@ defmodule Breeze.Server do
     :input_router,
     :child_view_supervisor,
     :owns_child_view_supervisor?,
+    :remote_inspector_supervisor,
     :view_pid,
     :view,
     :start_opts,
@@ -222,6 +223,19 @@ defmodule Breeze.Server do
     end
   end
 
+  defp remote_inspector_supervisor(false, _internal_opts), do: nil
+
+  defp remote_inspector_supervisor(true, internal_opts) do
+    case Keyword.get(internal_opts, :remote_inspector_supervisor) do
+      supervisor when is_pid(supervisor) ->
+        supervisor
+
+      _supervisor ->
+        {:ok, supervisor} = Breeze.RemoteInspector.Supervisor.start_link()
+        supervisor
+    end
+  end
+
   defp logger_collector(config, _runtime_opts, _attempts) when config in [false, nil],
     do: {:ok, nil}
 
@@ -276,6 +290,9 @@ defmodule Breeze.Server do
 
     remote_inspector_enabled? =
       inspector_enabled? and Breeze.Inspector.remote?(%{inspector: inspector_config})
+
+    remote_inspector_supervisor =
+      remote_inspector_supervisor(remote_inspector_enabled?, internal_opts)
 
     logger_config =
       if Keyword.has_key?(opts, :logger) do
@@ -346,6 +363,7 @@ defmodule Breeze.Server do
         input_router: Keyword.get(opts, :input_router),
         child_view_supervisor: child_view_supervisor,
         owns_child_view_supervisor?: owns_child_view_supervisor?,
+        remote_inspector_supervisor: remote_inspector_supervisor,
         view_pid: view_pid,
         view: view,
         start_opts: start_opts,
@@ -376,8 +394,15 @@ defmodule Breeze.Server do
 
     state = maybe_start_reloader(state)
 
-    if Breeze.Inspector.enabled?(state) and Breeze.Inspector.remote?(state),
-      do: Breeze.RemoteInspector.register_app(self())
+    if remote_inspector_enabled? do
+      :ok = Breeze.RemoteInspector.register_app(self())
+
+      {:ok, _connector} =
+        Breeze.RemoteInspector.Supervisor.start_connector(
+          state.remote_inspector_supervisor,
+          self()
+        )
+    end
 
     {:ok, render_base(state)}
   end
@@ -1900,6 +1925,8 @@ defmodule Breeze.Server do
 
     if state.owns_child_view_supervisor?,
       do: Breeze.ChildViewSupervisor.stop(state.child_view_supervisor)
+
+    Breeze.RemoteInspector.Supervisor.stop(state.remote_inspector_supervisor)
 
     :ok
   end

--- a/lib/breeze/view.ex
+++ b/lib/breeze/view.ex
@@ -23,8 +23,8 @@ defmodule Breeze.View do
   ```
 
   `use Breeze.View` declares the `Breeze.View` behaviour. The callbacks are
-  optional because the same module is also used to define component-only
-  modules, but a root view must implement `render/1`.
+  optional, but a root view must implement `render/1`. Modules that only define
+  reusable components can use `Breeze.Component` instead.
 
   ## Initial state
 

--- a/mix.exs
+++ b/mix.exs
@@ -88,6 +88,7 @@ defmodule Breeze.MixProject do
         "Development tools": [
           Breeze.IO,
           Breeze.Inspector,
+          Breeze.RemoteInspector.Page,
           Breeze.Server.Diagnostics,
           Breeze.Logger,
           Breeze.Logger.Collector,

--- a/test/breeze/input_router/state_test.exs
+++ b/test/breeze/input_router/state_test.exs
@@ -1,0 +1,7 @@
+defmodule Breeze.InputRouter.StateTest do
+  use ExUnit.Case, async: true
+
+  test "input router state remains a flat map" do
+    assert map_size(%Breeze.InputRouter{}) <= 32
+  end
+end

--- a/test/breeze/input_router_test.exs
+++ b/test/breeze/input_router_test.exs
@@ -333,6 +333,8 @@ defmodule Breeze.InputRouterTest do
     server = router_state.server_pid
     supervisor = router_state.child_view_supervisor
 
+    assert is_nil(router_state.remote_inspector_supervisor)
+
     server_state =
       wait_until(fn ->
         state = :sys.get_state(server)
@@ -344,6 +346,7 @@ defmodule Breeze.InputRouterTest do
 
     assert server_state.child_view_supervisor == supervisor
     refute server_state.owns_child_view_supervisor?
+    assert is_nil(server_state.remote_inspector_supervisor)
 
     supervised_pids =
       supervisor

--- a/test/breeze/inspector_test.exs
+++ b/test/breeze/inspector_test.exs
@@ -47,6 +47,18 @@ defmodule Breeze.InspectorTest do
     end
   end
 
+  defmodule AppInspectorPage do
+    use Breeze.RemoteInspector.Page
+
+    def page, do: [label: "Runtime tools"]
+
+    def render(assigns) do
+      ~H"""
+      <box>App tools</box>
+      """
+    end
+  end
+
   test "toggle uses configured keys and clears hover state while re-syncing selection" do
     state =
       base_state(%{
@@ -93,6 +105,24 @@ defmodule Breeze.InspectorTest do
     assert snapshot.selected.actual_id == "field"
     assert snapshot.selected.focus_meta == %{group: :form}
     assert snapshot.hovered.actual_id == "nested"
+  end
+
+  test "snapshot publishes pages registered by the app inspector configuration" do
+    snapshot =
+      base_state(%{
+        inspector: [pages: [AppInspectorPage]]
+      })
+      |> Inspector.snapshot()
+
+    page_id = page_id(AppInspectorPage)
+
+    assert [
+             %{
+               id: ^page_id,
+               label: "Runtime tools",
+               module: AppInspectorPage
+             }
+           ] = snapshot.pages
   end
 
   test "snapshot falls back to the first explicit id before anonymous inspector nodes" do
@@ -515,4 +545,6 @@ defmodule Breeze.InspectorTest do
       overrides
     )
   end
+
+  defp page_id(module), do: "page:#{module}"
 end

--- a/test/breeze/remote_inspector_test.exs
+++ b/test/breeze/remote_inspector_test.exs
@@ -30,6 +30,20 @@ defmodule Breeze.RemoteInspectorTest do
     def handle_call(:inspector_snapshot, _from, snapshot) do
       {:reply, snapshot, snapshot}
     end
+
+    def handle_call({:inspector_render_tree, opts}, _from, snapshot) do
+      selected_id = Keyword.get(opts, :selected_id, Map.get(snapshot, :selected_id))
+
+      {:reply,
+       %{
+         kind: Keyword.get(opts, :kind, :rendered),
+         nodes: [%{id: "root", label: "<box#root>", children: []}],
+         selected_id: selected_id,
+         expanded: Keyword.get(opts, :expanded, []),
+         limit: Keyword.get(opts, :limit, 600),
+         truncated?: false
+       }, snapshot}
+    end
   end
 
   defmodule SelectCaptureServer do
@@ -69,6 +83,21 @@ defmodule Breeze.RemoteInspectorTest do
     end
   end
 
+  defmodule SnapshotCaptureServer do
+    use GenServer
+
+    def start_link(parent) do
+      GenServer.start_link(__MODULE__, parent)
+    end
+
+    def init(parent), do: {:ok, parent}
+
+    def handle_cast({:snapshot, source_pid, snapshot}, parent) do
+      send(parent, {:captured_snapshot, source_pid, snapshot})
+      {:noreply, parent}
+    end
+  end
+
   defmodule ThemeTabView do
     use Breeze.View
     import Breeze.RemoteInspector.View, only: [theme_tab: 1]
@@ -96,6 +125,554 @@ defmodule Breeze.RemoteInspectorTest do
 
     def handle_event(_, _, term), do: {:noreply, term}
     def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule CustomInspectorPage do
+    use Breeze.RemoteInspector.Page
+
+    def page,
+      do: [label: "Debugger", assigns: [note: "configured", static: "extra"]]
+
+    def render(assigns) do
+      snapshot = Breeze.RemoteInspector.Page.request!(assigns, :snapshot)
+
+      render_tree =
+        Breeze.RemoteInspector.Page.request!(assigns, :render_tree,
+          selected_id: snapshot.selected_id
+        )
+
+      lean_context? =
+        Enum.all?(
+          [:active, :active_source, :snapshot, :selected, :hovered, :snapshots, :render_tree],
+          &(not Map.has_key?(assigns, &1))
+        )
+
+      assigns =
+        Map.merge(assigns, %{
+          requested_snapshot: snapshot,
+          requested_render_tree: render_tree,
+          lean_context?: lean_context?
+        })
+
+      ~H"""
+      <box id="custom-inspector-page" class="width-full height-full">
+        page={@id} selected={selected_id(@requested_snapshot)} note={@note} static={@static} tree={tree_selected(@requested_render_tree)} terminal={@breeze.terminal.height} lean={@lean_context?}
+      </box>
+      """
+    end
+
+    defp selected_id(%{selected_id: selected_id}), do: selected_id || "-"
+    defp selected_id(_snapshot), do: "-"
+    defp tree_selected(%{selected_id: selected_id}), do: selected_id || "-"
+    defp tree_selected(_tree), do: "-"
+  end
+
+  defmodule InteractiveInspectorPage do
+    use Breeze.RemoteInspector.Page
+
+    def page, do: [label: "Chat"]
+
+    def render(assigns) do
+      assigns = Map.merge(%{prompt: "-", info: "-", count: 0}, assigns)
+
+      ~H"""
+      <box id="interactive-inspector-page">prompt={@prompt} info={@info} count={@count}</box>
+      """
+    end
+
+    def handle_event("prompt_changed", payload, assigns) do
+      value = Map.get(payload, :value) || Map.get(payload, "value")
+
+      {:noreply,
+       %{
+         prompt: value,
+         info: Map.get(assigns, :info, "-"),
+         count: Map.get(assigns, :count, 0) + 1
+       }}
+    end
+
+    def handle_event(event, payload, assigns)
+        when event in ["tab_changed", "render_tree_changed"] do
+      value = Map.get(payload, :value) || Map.get(payload, "value")
+
+      {:noreply,
+       %{
+         prompt: "#{event}:#{value}",
+         info: Map.get(assigns, :info, "-"),
+         count: Map.get(assigns, :count, 0) + 1
+       }}
+    end
+
+    def handle_event(_event, _payload, _assigns), do: :noreply
+
+    def handle_info({:done, value}, assigns) do
+      {:noreply,
+       %{
+         prompt: Map.get(assigns, :prompt, "-"),
+         info: value,
+         count: Map.get(assigns, :count, 0)
+       }}
+    end
+  end
+
+  defmodule FailingInspectorPage do
+    use Breeze.RemoteInspector.Page
+
+    def page, do: [label: "Failure"]
+
+    def render(_assigns), do: raise("render exploded")
+
+    def handle_event("throw", _payload, _assigns), do: throw(:callback_exploded)
+  end
+
+  defmodule InvalidInspectorPage do
+    use Breeze.RemoteInspector.Page
+
+    def page, do: [label: "Invalid", unknown: true]
+    def render(assigns), do: ~H"<box>Invalid</box>"
+  end
+
+  defmodule MissingPageDeclaration do
+    use Breeze.Component
+
+    def render(assigns), do: ~H"<box>Missing declaration</box>"
+  end
+
+  defmodule MissingPageLabel do
+    use Breeze.RemoteInspector.Page
+
+    def page, do: [assigns: %{ready?: true}]
+    def render(assigns), do: ~H"<box>Missing label</box>"
+  end
+
+  test "remote inspector pages use module identity and page-owned metadata" do
+    page_id = page_id(CustomInspectorPage)
+
+    assert [
+             %{
+               id: ^page_id,
+               label: "Debugger",
+               module: CustomInspectorPage,
+               assigns: %{note: "configured", static: "extra"}
+             }
+           ] =
+             Breeze.RemoteInspector.Pages.build([
+               CustomInspectorPage,
+               CustomInspectorPage
+             ])
+  end
+
+  test "remote inspector page declarations reject unsupported shapes" do
+    assert_raise ArgumentError, ~r/expected :pages to be a list/, fn ->
+      Breeze.RemoteInspector.Pages.build(CustomInspectorPage)
+    end
+
+    assert_raise ArgumentError, ~r/unknown .*\.page\/0 keys: \[:unknown\]/, fn ->
+      Breeze.RemoteInspector.Pages.build([InvalidInspectorPage])
+    end
+
+    assert_raise ArgumentError, ~r/expected a page module/, fn ->
+      Breeze.RemoteInspector.Pages.build([{CustomInspectorPage, assigns: %{}}])
+    end
+
+    assert_raise ArgumentError, ~r/expected .* to define page\/0/, fn ->
+      Breeze.RemoteInspector.Pages.build([MissingPageDeclaration])
+    end
+
+    assert_raise ArgumentError, ~r/page\/0 to define a non-empty :label/, fn ->
+      Breeze.RemoteInspector.Pages.build([MissingPageLabel])
+    end
+  end
+
+  test "page state cannot replace host-owned context" do
+    scope = {:app@host, "#PID<0.1.0>"}
+    page_id = page_id(CustomInspectorPage)
+
+    page = %{
+      id: page_id,
+      label: "Tools",
+      module: CustomInspectorPage,
+      assigns: %{
+        source_server_pid: :static_source,
+        breeze: :static_breeze,
+        id: "static-id",
+        page_ref: :static_ref,
+        value: :static
+      }
+    }
+
+    context = %{
+      source_server_pid: self(),
+      breeze: %{terminal: %{height: 40}},
+      page_state_scope: scope,
+      page_states: %{
+        {scope, page_id} => %{
+          source_server_pid: :state_source,
+          breeze: :state_breeze,
+          id: "state-id",
+          label: "State label",
+          page: :state_page,
+          page_ref: :state_ref,
+          value: :state
+        }
+      }
+    }
+
+    assigns = Breeze.RemoteInspector.PageHost.page_assigns(page, context)
+
+    assert assigns.source_server_pid == self()
+    assert assigns.breeze == context.breeze
+    assert assigns.id == page_id
+    assert assigns.label == "Tools"
+    assert assigns.page == page
+    assert assigns.page_ref == {scope, page_id}
+    assert assigns.value == :state
+  end
+
+  test "app-discovered pages stay visible when their module is unavailable locally" do
+    missing_page = Module.concat([MissingRemoteInspectorPage])
+    page_id = page_id(missing_page)
+
+    descriptor = %{
+      label: "Timeline",
+      module: missing_page,
+      assigns: %{}
+    }
+
+    assert [
+             %{
+               id: ^page_id,
+               label: "Timeline",
+               module: ^missing_page,
+               assigns: %{}
+             }
+           ] = Breeze.RemoteInspector.Pages.validate_discovered([descriptor])
+
+    key = {:app@host, "#PID<0.1.0>"}
+
+    output =
+      Breeze.Renderer.render_to_string(
+        Breeze.RemoteInspector.View,
+        %{
+          snapshots: %{
+            key => %{
+              source: %{node: :app@host, pid: self()},
+              snapshot:
+                inspector_snapshot(self(), "button")
+                |> Map.put(:pages, [descriptor]),
+              updated_at: 1_000,
+              alive?: true
+            }
+          },
+          latest_source: key,
+          active_source: key,
+          panel_tab: page_id,
+          render_tree_kind: "rendered",
+          render_trees: %{},
+          render_tree_expanded: %{},
+          custom_page_states: %{},
+          breeze: %{terminal: %{width: 140, height: 40}},
+          screen: %{width: 140, height: 32}
+        },
+        theme: true,
+        terminal: %Termite.Terminal{size: %{width: 140, height: 40}}
+      )
+
+    assert output =~ "Timeline"
+    assert output =~ "is unavailable on this inspector node"
+  end
+
+  test "page render and callback failures are isolated and reported" do
+    scope = {:app@host, "#PID<0.1.0>"}
+    [page] = Breeze.RemoteInspector.Pages.build([FailingInspectorPage])
+
+    active = %{
+      snapshot:
+        inspector_snapshot(self(), "button")
+        |> Map.put(:pages, [page])
+    }
+
+    term = %Breeze.Term{
+      view: Breeze.RemoteInspector.View,
+      assigns: %{
+        active_source: scope,
+        panel_tab: page.id,
+        custom_page_states: %{}
+      }
+    }
+
+    output =
+      Breeze.Renderer.render_to_string(
+        Breeze.RemoteInspector.PageHost,
+        %{
+          page: page,
+          context: Breeze.RemoteInspector.PageHost.context(term.assigns, active, scope)
+        },
+        theme: true,
+        terminal: %Termite.Terminal{size: %{width: 80, height: 24}}
+      )
+
+    assert output =~ "remote inspector page failed: render exploded"
+
+    assert {:noreply, term} =
+             Breeze.RemoteInspector.PageHost.delegate_event("throw", %{}, term, active)
+
+    assert term.assigns.custom_page_states[{scope, page.id}].custom_page_error ==
+             "remote inspector page failed: {:throw, :callback_exploded}"
+  end
+
+  test "app connector retries and publishes the current snapshot without app interaction" do
+    snapshot = %{root_view: InspectorAppView, selected_id: "button"}
+    {:ok, app_pid} = FakeInspectorServer.start_link(snapshot)
+    {:ok, inspector_pid} = SnapshotCaptureServer.start_link(self())
+    {:ok, resolver_state} = Agent.start_link(fn -> :retry end)
+    {:ok, supervisor} = Breeze.RemoteInspector.Supervisor.start_link()
+
+    {:ok, connector_pid} =
+      Breeze.RemoteInspector.Supervisor.start_connector(supervisor, app_pid,
+        retry_interval: 5,
+        resolver: fn -> Agent.get(resolver_state, & &1) end
+      )
+
+    connector_ref = Process.monitor(connector_pid)
+
+    assert connector_pid in supervised_pids(supervisor)
+
+    refute_receive {:captured_snapshot, ^app_pid, _snapshot}, 20
+
+    Agent.update(resolver_state, fn _state -> {:ok, inspector_pid} end)
+
+    assert_receive {:captured_snapshot, ^app_pid, ^snapshot}, 200
+
+    GenServer.stop(app_pid)
+    assert_receive {:DOWN, ^connector_ref, :process, ^connector_pid, :normal}, 200
+
+    GenServer.stop(inspector_pid)
+    Agent.stop(resolver_state)
+    Breeze.RemoteInspector.Supervisor.stop(supervisor)
+  end
+
+  test "app connector retries failed initial snapshot reads and publications" do
+    snapshot = %{root_view: InspectorAppView, selected_id: "button"}
+    {:ok, app_pid} = FakeInspectorServer.start_link(snapshot)
+    {:ok, inspector_pid} = SnapshotCaptureServer.start_link(self())
+    {:ok, attempts} = Agent.start_link(fn -> %{reads: 0, publications: 0} end)
+    {:ok, supervisor} = Breeze.RemoteInspector.Supervisor.start_link()
+
+    snapshot_reader = fn pid ->
+      attempt =
+        Agent.get_and_update(attempts, fn state ->
+          attempt = state.reads + 1
+          {attempt, %{state | reads: attempt}}
+        end)
+
+      if attempt == 1 do
+        exit({:timeout, :inspector_snapshot})
+      else
+        Breeze.Server.Diagnostics.inspector_snapshot(pid)
+      end
+    end
+
+    publisher = fn target_pid, source_pid, current_snapshot ->
+      attempt =
+        Agent.get_and_update(attempts, fn state ->
+          attempt = state.publications + 1
+          {attempt, %{state | publications: attempt}}
+        end)
+
+      if attempt == 1 do
+        exit(:publication_failed)
+      else
+        Breeze.RemoteInspector.Server.publish(target_pid, source_pid, current_snapshot)
+      end
+    end
+
+    {:ok, connector_pid} =
+      Breeze.RemoteInspector.Supervisor.start_connector(supervisor, app_pid,
+        retry_interval: 5,
+        resolver: fn -> {:ok, inspector_pid} end,
+        snapshot_reader: snapshot_reader,
+        publisher: publisher
+      )
+
+    connector_ref = Process.monitor(connector_pid)
+
+    assert_receive {:captured_snapshot, ^app_pid, ^snapshot}, 200
+    assert Agent.get(attempts, & &1) == %{reads: 3, publications: 2}
+
+    GenServer.stop(app_pid)
+    assert_receive {:DOWN, ^connector_ref, :process, ^connector_pid, :normal}, 200
+
+    GenServer.stop(inspector_pid)
+    Agent.stop(attempts)
+    Breeze.RemoteInspector.Supervisor.stop(supervisor)
+  end
+
+  test "remote inspector renders registered pages with active snapshot context" do
+    {:ok, source_pid} = FakeInspectorServer.start_link(%{selected_id: "button"})
+    on_exit(fn -> stop_process(source_pid) end)
+    key = {:app@host, inspect(source_pid)}
+    pages = Breeze.RemoteInspector.Pages.build([CustomInspectorPage])
+    [page] = pages
+
+    output =
+      Breeze.Renderer.render_to_string(
+        Breeze.RemoteInspector.View,
+        %{
+          snapshots: %{
+            key => %{
+              source: %{node: :app@host, pid: source_pid},
+              snapshot:
+                inspector_snapshot(source_pid, "button")
+                |> Map.put(:pages, pages),
+              updated_at: 1_000,
+              alive?: true
+            }
+          },
+          latest_source: key,
+          active_source: key,
+          panel_tab: page.id,
+          render_tree_kind: "rendered",
+          render_trees: %{
+            key => %{
+              nodes: [%{id: "root", label: "<box#root>", children: []}],
+              selected_id: "button",
+              expanded: [],
+              limit: 600,
+              truncated?: false
+            }
+          },
+          render_tree_expanded: %{},
+          custom_page_states: %{},
+          breeze: %{terminal: %{width: 140, height: 40}},
+          screen: %{width: 140, height: 32}
+        },
+        theme: true,
+        terminal: %Termite.Terminal{size: %{width: 140, height: 40}}
+      )
+
+    assert output =~ "Debugger"
+    assert output =~ "page=#{page.id}"
+    assert output =~ "selected=button"
+    assert output =~ "note=configured"
+    assert output =~ "static=extra"
+    assert output =~ "tree=button"
+    assert output =~ "terminal=40"
+    assert output =~ "lean=true"
+  end
+
+  test "remote inspector pages can handle events and asynchronous messages" do
+    key = {:app@host, "#PID<0.1.0>"}
+    other_key = {:other@host, "#PID<0.2.0>"}
+    pages = Breeze.RemoteInspector.Pages.build([InteractiveInspectorPage])
+    [page] = pages
+    page_id = page.id
+
+    term = %Breeze.Term{
+      view: Breeze.RemoteInspector.View,
+      assigns: %{
+        snapshots: %{
+          key => %{
+            source: %{node: :app@host, pid: self()},
+            snapshot:
+              inspector_snapshot(self(), "button")
+              |> Map.put(:pages, pages),
+            updated_at: 1_000,
+            alive?: true
+          },
+          other_key => %{
+            source: %{node: :other@host, pid: self()},
+            snapshot: inspector_snapshot(self(), "other-button"),
+            updated_at: 900,
+            alive?: true
+          }
+        },
+        latest_source: key,
+        active_source: key,
+        panel_tab: page_id,
+        render_tree_kind: "rendered",
+        render_trees: %{},
+        render_tree_expanded: %{},
+        custom_page_states: %{},
+        screen: %{width: 100, height: 32}
+      }
+    }
+
+    assert {:noreply, term} =
+             Breeze.RemoteInspector.View.handle_event(
+               "prompt_changed",
+               %{value: "hello"},
+               term
+             )
+
+    assert term.assigns.custom_page_states[{key, page_id}].prompt == "hello"
+    assert term.assigns.custom_page_states[{key, page_id}].count == 1
+
+    assert {:noreply, term} =
+             Breeze.RemoteInspector.View.handle_event(
+               "render_tree_changed",
+               %{value: "button", expanded: []},
+               term
+             )
+
+    assert term.assigns.panel_tab == page_id
+
+    assert term.assigns.custom_page_states[{key, page_id}].prompt ==
+             "render_tree_changed:button"
+
+    assert term.assigns.custom_page_states[{key, page_id}].count == 2
+
+    assert {:noreply, term} =
+             Breeze.RemoteInspector.View.handle_event(
+               "tab_changed",
+               %{value: "inner"},
+               term
+             )
+
+    assert term.assigns.panel_tab == page_id
+    assert term.assigns.custom_page_states[{key, page_id}].prompt == "tab_changed:inner"
+    assert term.assigns.custom_page_states[{key, page_id}].count == 3
+
+    page_assigns =
+      Breeze.RemoteInspector.PageHost.page_assigns(
+        page,
+        Breeze.RemoteInspector.PageHost.context(term.assigns, term.assigns.snapshots[key])
+      )
+
+    message = Breeze.RemoteInspector.Page.message(page_assigns, {:done, "ok"})
+    term = %{term | assigns: Map.put(term.assigns, :active_source, other_key)}
+
+    assert {:noreply, term} =
+             Breeze.RemoteInspector.View.handle_info(message, term)
+
+    assert term.assigns.custom_page_states[{key, page_id}].prompt == "tab_changed:inner"
+    assert term.assigns.custom_page_states[{key, page_id}].info == "ok"
+    refute Map.has_key?(term.assigns.custom_page_states, {other_key, page_id})
+  end
+
+  test "registered pages explicitly request render tree data" do
+    {:ok, source_pid} = SelectCaptureServer.start_link(self())
+
+    on_exit(fn ->
+      if Process.alive?(source_pid), do: GenServer.stop(source_pid)
+    end)
+
+    assert {:ok, tree} =
+             Breeze.RemoteInspector.Page.request(
+               %{source_server_pid: source_pid},
+               :render_tree,
+               kind: :rendered,
+               selected_id: "child",
+               expanded: ["root"],
+               limit: 200
+             )
+
+    assert tree.selected_id == "child"
+    assert_receive {:inspector_render_tree, opts}, 500
+    assert Keyword.get(opts, :kind) == :rendered
+    assert Keyword.get(opts, :selected_id) == "child"
+    assert Keyword.get(opts, :expanded) == ["root"]
+    assert Keyword.get(opts, :limit) == 200
   end
 
   test "remote inspector view renders rich snapshot details" do
@@ -322,6 +899,51 @@ defmodule Breeze.RemoteInspectorTest do
     assert tree_output =~ "38;2;4;5;6"
   end
 
+  test "remote inspector host events use tagged names" do
+    key = {:app@host, inspect(self())}
+    terminal = %Termite.Terminal{size: %{width: 100, height: 32}}
+
+    snapshot =
+      self()
+      |> inspector_snapshot("button")
+      |> Map.put(:render_tree, %{id: "root", label: "<box#root>", children: []})
+
+    {acc, _box} =
+      Breeze.Renderer.render(
+        Breeze.RemoteInspector.View,
+        %{
+          snapshots: %{
+            key => %{
+              source: %{node: :app@host, pid: self()},
+              snapshot: snapshot,
+              updated_at: 1_000,
+              alive?: true
+            }
+          },
+          logs: %{},
+          log_sources: %{},
+          latest_source: key,
+          active_source: key,
+          panel_tab: "tree",
+          render_tree_kind: "rendered",
+          render_tree_expanded: %{},
+          render_trees: %{},
+          custom_page_states: %{},
+          screen: terminal.size
+        },
+        theme: true,
+        terminal: terminal
+      )
+
+    events = Breeze.RenderState.bootstrap(%Breeze.Term{}, acc).events
+
+    assert events["remote-inspector-tabs"] ==
+             %{change: {:breeze_remote_inspector, "tab_changed"}}
+
+    assert events["remote-inspector-render-tree"] ==
+             %{change: {:breeze_remote_inspector, "render_tree_changed"}}
+  end
+
   test "remote inspector tab changes accept implicit tab payloads" do
     term = %Breeze.Term{
       view: Breeze.RemoteInspector.View,
@@ -337,14 +959,14 @@ defmodule Breeze.RemoteInspectorTest do
 
     assert {:noreply, %{assigns: %{panel_tab: "layout"}}} =
              Breeze.RemoteInspector.View.handle_event(
-               "tab_changed",
+               {:breeze_remote_inspector, "tab_changed"},
                %{value: "layout"},
                term
              )
 
     assert {:noreply, %{assigns: %{panel_tab: "tree"}, local_keybindings: tree_keybindings}} =
              Breeze.RemoteInspector.View.handle_event(
-               "tab_changed",
+               {:breeze_remote_inspector, "tab_changed"},
                %{value: "tree"},
                term
              )
@@ -353,14 +975,14 @@ defmodule Breeze.RemoteInspectorTest do
 
     assert {:noreply, %{assigns: %{panel_tab: "focus"}}} =
              Breeze.RemoteInspector.View.handle_event(
-               "tab_changed",
+               {:breeze_remote_inspector, "tab_changed"},
                %{"value" => "focus"},
                term
              )
 
     assert {:noreply, %{assigns: %{panel_tab: "layout"}, local_keybindings: []}} =
              Breeze.RemoteInspector.View.handle_event(
-               "tab_changed",
+               {:breeze_remote_inspector, "tab_changed"},
                %{"value" => "layout"},
                %{term | local_keybindings: tree_keybindings}
              )
@@ -428,7 +1050,7 @@ defmodule Breeze.RemoteInspectorTest do
 
     assert {:noreply, term} =
              Breeze.RemoteInspector.View.handle_event(
-               "render_tree_changed",
+               {:breeze_remote_inspector, "render_tree_changed"},
                %{value: "child", expanded: ["root"]},
                term
              )
@@ -534,7 +1156,7 @@ defmodule Breeze.RemoteInspectorTest do
 
     assert {:noreply, ^term} =
              Breeze.RemoteInspector.View.handle_event(
-               "render_tree_changed",
+               {:breeze_remote_inspector, "render_tree_changed"},
                %{value: "child", expanded: ["root"], offset: 12},
                term
              )
@@ -673,6 +1295,32 @@ defmodule Breeze.RemoteInspectorTest do
     assert Breeze.RemoteInspector.default_distribution_name(:app,
              view: Breeze.RemoteInspector.View
            ) == :breeze
+  end
+
+  defp inspector_snapshot(pid, selected_id) do
+    %{
+      root_view: InspectorAppView,
+      source: %{node: :app@host, server_pid: pid, view_pid: pid},
+      theme: nil,
+      counts: %{elements: 1, focusables: 1, mouse_targets: 1, children: 0},
+      focus: %{active_scope: nil, focusables: [selected_id], focus_memory: %{}},
+      selected: nil,
+      hovered: nil,
+      selected_id: selected_id,
+      hovered_id: nil,
+      focused: selected_id,
+      last_render_at: 1_000,
+      last_interaction_at: 900,
+      render_tree?: true
+    }
+  end
+
+  defp page_id(module), do: "page:#{module}"
+
+  defp supervised_pids(supervisor) do
+    supervisor
+    |> DynamicSupervisor.which_children()
+    |> Enum.map(fn {_id, pid, _type, _modules} -> pid end)
   end
 
   defp stop_process(pid) when is_pid(pid) do
@@ -815,13 +1463,16 @@ defmodule Breeze.RemoteInspectorSyncTest do
     {:ok, app_pid} =
       FakeInspectorServer.start_link(%{root_view: InspectorAppView, selected_id: "button"})
 
+    {:ok, supervisor} = Breeze.RemoteInspector.Supervisor.start_link()
     :ok = Breeze.RemoteInspector.register_app(app_pid)
+    {:ok, _connector} = Breeze.RemoteInspector.Supervisor.start_connector(supervisor, app_pid)
 
     {:ok, inspector_pid} = Breeze.RemoteInspector.ensure_server()
 
     on_exit(fn ->
       stop_local_process(app_pid)
       stop_local_process(inspector_pid)
+      Breeze.RemoteInspector.Supervisor.stop(supervisor)
     end)
 
     wait_until(fn ->


### PR DESCRIPTION
Allow applications to register custom pages that are published with inspector snapshots and rendered as tabs in the remote inspector. Pages can maintain source-scoped state, handle events and messages, and request snapshots, render trees, or runtime statistics from the inspected application.

Page rendering and callback failures are isolated so they do not affect the inspector. App connectors run under a dedicated conditional supervisor, allowing inspectors to receive the current snapshot on connection and reconnect cleanly.