### PR TITLE
feat!: standardize mouse event payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ defmodule Demo do
     """
   end
 
-  def handle_event(_, %{"key" => "ArrowUp"}, term), do:
+  def handle_event(:input, %{"key" => "ArrowUp"}, term), do:
     {:noreply, assign(term, counter: term.assigns.counter + 1)}
 
-  def handle_event(_, %{"key" => "ArrowDown"}, term), do:
+  def handle_event(:input, %{"key" => "ArrowDown"}, term), do:
     {:noreply, assign(term, counter: term.assigns.counter - 1)}
 
   def handle_event(_, _, term), do: {:noreply, term}

--- a/examples/mouse.exs
+++ b/examples/mouse.exs
@@ -96,19 +96,19 @@ defmodule MouseExample do
     dt = event_delta(term.assigns.last_event_at, now)
     seq = term.assigns.event_seq + 1
     target = Map.get(event, "target", "none")
-    repeat = Map.get(mouse, :repeat, 1)
+    repeat = Map.get(mouse, "repeat", 1)
 
     entry = %{
       seq: pad(seq, 4),
       dt: pad(dt, 4),
-      button_action: "#{mouse.button}/#{mouse.action}",
-      xy: "#{mouse.x},#{mouse.y}",
+      button_action: "#{mouse["button"]}/#{mouse["action"]}",
+      xy: "#{mouse["x"]},#{mouse["y"]}",
       row_col: "#{Map.get(event, "row", "-")},#{Map.get(event, "col", "-")}",
       target: target,
       repeat: to_string(repeat),
-      modifiers: mouse.modifiers |> Enum.map_join("+", &to_string/1) |> blank_dash(),
+      modifiers: mouse_modifiers(mouse),
       summary:
-        "##{seq} +#{dt}ms #{mouse.button}/#{mouse.action} x=#{mouse.x} y=#{mouse.y} target=#{target} repeat=#{repeat}"
+        "##{seq} +#{dt}ms #{mouse["button"]}/#{mouse["action"]} x=#{mouse["x"]} y=#{mouse["y"]} target=#{target} repeat=#{repeat}"
     }
 
     term
@@ -120,19 +120,26 @@ defmodule MouseExample do
     )
   end
 
-  defp update_mouse_counts(term, %{button: :left, action: :press}) do
+  defp update_mouse_counts(term, %{"button" => "left", "action" => "press"}) do
     assign(term, clicks: term.assigns.clicks + 1)
   end
 
-  defp update_mouse_counts(term, %{button: :wheel_up}) do
+  defp update_mouse_counts(term, %{"button" => "wheel_up"}) do
     assign(term, wheel_up: term.assigns.wheel_up + 1)
   end
 
-  defp update_mouse_counts(term, %{button: :wheel_down}) do
+  defp update_mouse_counts(term, %{"button" => "wheel_down"}) do
     assign(term, wheel_down: term.assigns.wheel_down + 1)
   end
 
   defp update_mouse_counts(term, _mouse), do: term
+
+  defp mouse_modifiers(mouse) do
+    [{"shiftKey", "shift"}, {"altKey", "alt"}, {"ctrlKey", "ctrl"}]
+    |> Enum.filter(fn {key, _label} -> Map.get(mouse, key) == true end)
+    |> Enum.map_join("+", &elem(&1, 1))
+    |> blank_dash()
+  end
 
   defp event_delta(nil, _now), do: 0
   defp event_delta(last, now), do: max(now - last, 0)

--- a/lib/breeze/child_server.ex
+++ b/lib/breeze/child_server.ex
@@ -1681,7 +1681,9 @@ defmodule Breeze.ChildServer do
 
   defp mouse_child_focus(_focused, _child_id, current_focused, false), do: current_focused
 
-  defp live_mouse_focus_event?(%{"mouse" => %{button: :left, action: :press}}), do: true
+  defp live_mouse_focus_event?(%{"mouse" => %{"button" => "left", "action" => "press"}}),
+    do: true
+
   defp live_mouse_focus_event?(_event), do: false
 
   defp translate_mouse_event_for_child(term, child_id, %{"mouse" => mouse} = event) do
@@ -1689,15 +1691,15 @@ defmodule Breeze.ChildServer do
       %{left: left, top: top} ->
         mouse =
           mouse
-          |> Map.put(:x, max(mouse.x - left, 1))
-          |> Map.put(:y, max(mouse.y - top, 1))
+          |> Map.put("x", max(mouse["x"] - left, 0))
+          |> Map.put("y", max(mouse["y"] - top, 0))
 
         event
         |> Map.put("mouse", mouse)
-        |> Map.drop(["target", "row", "col"])
+        |> Map.drop(["target", "focused", "row", "col"])
 
       nil ->
-        Map.drop(event, ["target", "row", "col"])
+        Map.drop(event, ["target", "focused", "row", "col"])
     end
   end
 
@@ -2085,10 +2087,7 @@ defmodule Breeze.ChildServer do
     end
   end
 
-  defp mouse_target(term, %{x: x, y: y}) do
-    x = x - 1
-    y = y - 1
-
+  defp mouse_target(term, %{"x" => x, "y" => y}) do
     term.mouse_targets
     |> Enum.map(fn {id, bounds} -> {id, mouse_target_bounds(term, bounds)} end)
     |> Enum.filter(fn {_id, bounds} ->
@@ -2181,18 +2180,18 @@ defmodule Breeze.ChildServer do
   defp term_height(%{terminal: %Termite.Terminal{size: %{height: height}}}), do: height
   defp term_height(_term), do: nil
 
-  defp mouse_row(term, target, %{y: y}) do
+  defp mouse_row(term, target, %{"y" => y}) do
     bounds = Map.fetch!(term.mouse_targets, target)
     box = Map.get(term.rendered_boxes, target)
     top_inset = border_inset(box, :top)
-    max(y - 1 - bounds.top - top_inset, 0)
+    max(y - bounds.top - top_inset, 0)
   end
 
-  defp mouse_col(term, target, %{x: x}) do
+  defp mouse_col(term, target, %{"x" => x}) do
     bounds = Map.fetch!(term.mouse_targets, target)
     box = Map.get(term.rendered_boxes, target)
     left_inset = border_inset(box, :left)
-    max(x - 1 - bounds.left - left_inset, 0)
+    max(x - bounds.left - left_inset, 0)
   end
 
   defp border_inset(%BackBreeze.Box{style: %{border: border}}, side) do
@@ -2201,7 +2200,7 @@ defmodule Breeze.ChildServer do
 
   defp border_inset(_, _side), do: 0
 
-  defp mouse_focus_target(target, %{button: :left, action: :press}, term) do
+  defp mouse_focus_target(target, %{"button" => "left", "action" => "press"}, term) do
     cond do
       target in term.focusables ->
         target

--- a/lib/breeze/implicit.ex
+++ b/lib/breeze/implicit.ex
@@ -43,14 +43,17 @@ defmodule Breeze.Implicit do
   ## Events
 
   `handle_event/3` receives a reserved event-kind argument, the event payload,
-  and the current implicit state. Breeze adds the target's `Breeze.Viewport` to
-  the payload as `"element"` when one is available.
+  and the current implicit state. Input payloads use string keys. Breeze adds
+  the target's `Breeze.Viewport` to the payload as `"element"` when one is
+  available.
 
   Every reply stores the returned state. `{:noreply, state}` stops there.
   `{{:change, event}, state}` and `{{:submit, event}, state}` route `event` through
-  the root element's `br-change` or `br-submit` handler. A change reply may also
-  contain `focus: id` (or `focus: nil`) as its third element. Finally,
-  `{{:delegate, id}, state}` sends the original event to another implicit.
+  the root element's `br-change` or `br-submit` handler. The event payload may
+  be any term; Breeze's built-in implicits currently use atom-keyed maps. A
+  change reply may also contain `focus: id` (or `focus: nil`) as its third
+  element. Finally, `{{:delegate, id}, state}` sends the original input event to
+  another implicit.
 
   ## Render modifiers
 
@@ -98,6 +101,12 @@ defmodule Breeze.Implicit do
   @typedoc "The kind of input event dispatched to an implicit."
   @type event_type :: :input
 
+  @typedoc "A string-keyed terminal input payload supplied to an implicit."
+  @type input_event :: %{optional(String.t()) => term()}
+
+  @typedoc "An unrestricted named-event payload emitted by an implicit."
+  @type event_payload :: term()
+
   @typedoc "An option returned while initializing implicit state."
   @type init_option ::
           {:rerender_every, pos_integer()}
@@ -119,9 +128,9 @@ defmodule Breeze.Implicit do
   @typedoc "A valid return value from `c:handle_event/3`."
   @type event_reply ::
           {:noreply, state()}
-          | {{:change, map()}, state()}
-          | {{:change, map()}, state(), [event_option()]}
-          | {{:submit, map()}, state()}
+          | {{:change, event_payload()}, state()}
+          | {{:change, event_payload()}, state(), [event_option()]}
+          | {{:submit, event_payload()}, state()}
           | {{:delegate, String.t()}, state()}
   @typedoc "A style, scroll, or state modifier returned during rendering."
   @type modifier ::
@@ -160,7 +169,7 @@ defmodule Breeze.Implicit do
   @doc """
   Handles an event captured by the implicit and returns its next state and action.
   """
-  @callback handle_event(event_type(), map(), state()) :: event_reply()
+  @callback handle_event(event_type(), input_event(), state()) :: event_reply()
 
   @doc """
   Returns renderer modifiers for the implicit root or one of its children.

--- a/lib/breeze/implicit/common.ex
+++ b/lib/breeze/implicit/common.ex
@@ -42,7 +42,7 @@ defmodule Breeze.Implicit.Common do
 
   def root_scroll_modifier(state), do: [scroll_y: state.offset]
 
-  def wheel_repeat(%{repeat: repeat}) when is_integer(repeat) and repeat > 0, do: repeat
+  def wheel_repeat(%{"repeat" => repeat}) when is_integer(repeat) and repeat > 0, do: repeat
   def wheel_repeat(_mouse), do: 1
 
   def bool_option(attrs, key, default, opts \\ []) do

--- a/lib/breeze/implicit/dropdown.ex
+++ b/lib/breeze/implicit/dropdown.ex
@@ -38,7 +38,7 @@ defmodule Breeze.Implicit.Dropdown do
 
   def handle_event(
         _,
-        %{"mouse" => %{button: :left, action: :press}, "target" => target},
+        %{"mouse" => %{"button" => "left", "action" => "press"}, "target" => target},
         %{open?: true} = state
       ) do
     case clicked_item_index(state, target) do
@@ -47,7 +47,11 @@ defmodule Breeze.Implicit.Dropdown do
     end
   end
 
-  def handle_event(_, %{"mouse" => %{button: :left, action: :press}}, %{open?: false} = state) do
+  def handle_event(
+        _,
+        %{"mouse" => %{"button" => "left", "action" => "press"}},
+        %{open?: false} = state
+      ) do
     {:noreply, open(state)}
   end
 

--- a/lib/breeze/implicit/list.ex
+++ b/lib/breeze/implicit/list.ex
@@ -112,7 +112,11 @@ defmodule Breeze.Implicit.List do
 
   def handle_event(
         _,
-        %{"mouse" => %{button: :left, action: :press}, "row" => row, "element" => element},
+        %{
+          "mouse" => %{"button" => "left", "action" => "press"},
+          "row" => row,
+          "element" => element
+        },
         state
       )
       when is_integer(row) and row >= 0 do
@@ -129,13 +133,21 @@ defmodule Breeze.Implicit.List do
     end
   end
 
-  def handle_event(_, %{"mouse" => %{button: :wheel_down} = mouse, "element" => element}, state) do
+  def handle_event(
+        _,
+        %{"mouse" => %{"button" => "wheel_down"} = mouse, "element" => element},
+        state
+      ) do
     viewport = Viewport.from_dimensions(element)
     offset = Viewport.clamp_scroll_y(state.offset + Common.wheel_repeat(mouse), viewport)
     {:noreply, %{state | offset: offset}}
   end
 
-  def handle_event(_, %{"mouse" => %{button: :wheel_up} = mouse, "element" => element}, state) do
+  def handle_event(
+        _,
+        %{"mouse" => %{"button" => "wheel_up"} = mouse, "element" => element},
+        state
+      ) do
     viewport = Viewport.from_dimensions(element)
     offset = Viewport.clamp_scroll_y(state.offset - Common.wheel_repeat(mouse), viewport)
     {:noreply, %{state | offset: offset}}

--- a/lib/breeze/implicit/scroll.ex
+++ b/lib/breeze/implicit/scroll.ex
@@ -68,7 +68,11 @@ defmodule Breeze.Implicit.Scroll do
     {:noreply, put_offset(state, offset_y, viewport)}
   end
 
-  def handle_event(_, %{"mouse" => %{button: :wheel_down} = mouse, "element" => element}, state) do
+  def handle_event(
+        _,
+        %{"mouse" => %{"button" => "wheel_down"} = mouse, "element" => element},
+        state
+      ) do
     viewport = Viewport.from_dimensions(element)
     current_offset_y = effective_offset_y(state, viewport)
 
@@ -81,7 +85,11 @@ defmodule Breeze.Implicit.Scroll do
     {:noreply, put_offset(state, offset_y, viewport)}
   end
 
-  def handle_event(_, %{"mouse" => %{button: :wheel_up} = mouse, "element" => element}, state) do
+  def handle_event(
+        _,
+        %{"mouse" => %{"button" => "wheel_up"} = mouse, "element" => element},
+        state
+      ) do
     viewport = Viewport.from_dimensions(element)
     current_offset_y = effective_offset_y(state, viewport)
 

--- a/lib/breeze/implicit/tabs.ex
+++ b/lib/breeze/implicit/tabs.ex
@@ -76,7 +76,11 @@ defmodule Breeze.Implicit.Tabs do
     {{:delegate, target}, state}
   end
 
-  def handle_event(_, %{"mouse" => %{button: :left, action: :press}, "target" => target}, state)
+  def handle_event(
+        _,
+        %{"mouse" => %{"button" => "left", "action" => "press"}, "target" => target},
+        state
+      )
       when is_binary(target) do
     case clicked_value(state, target) do
       nil ->

--- a/lib/breeze/implicit/tree.ex
+++ b/lib/breeze/implicit/tree.ex
@@ -123,7 +123,7 @@ defmodule Breeze.Implicit.Tree do
   def handle_event(
         _,
         %{
-          "mouse" => %{button: :left, action: :press},
+          "mouse" => %{"button" => "left", "action" => "press"},
           "row" => row,
           "col" => col,
           "element" => element
@@ -134,11 +134,19 @@ defmodule Breeze.Implicit.Tree do
     handle_tree_click(row + state.offset, col, element, state)
   end
 
-  def handle_event(_, %{"mouse" => %{button: :wheel_down} = mouse, "element" => element}, state) do
+  def handle_event(
+        _,
+        %{"mouse" => %{"button" => "wheel_down"} = mouse, "element" => element},
+        state
+      ) do
     scroll_by_mouse(state, element, Common.wheel_repeat(mouse))
   end
 
-  def handle_event(_, %{"mouse" => %{button: :wheel_up} = mouse, "element" => element}, state) do
+  def handle_event(
+        _,
+        %{"mouse" => %{"button" => "wheel_up"} = mouse, "element" => element},
+        state
+      ) do
     scroll_by_mouse(state, element, -Common.wheel_repeat(mouse))
   end
 

--- a/lib/breeze/inspector.ex
+++ b/lib/breeze/inspector.ex
@@ -164,7 +164,7 @@ defmodule Breeze.Inspector do
   end
 
   @doc false
-  def hover_at(state, %{x: x, y: y}) do
+  def hover_at(state, %{"x" => x, "y" => y}) do
     if inside_panel?(state, x, y) do
       state
     else
@@ -178,7 +178,7 @@ defmodule Breeze.Inspector do
   end
 
   @doc false
-  def select_at(state, %{x: x, y: y}) do
+  def select_at(state, %{"x" => x, "y" => y}) do
     if inside_panel?(state, x, y) do
       state
     else
@@ -317,8 +317,7 @@ defmodule Breeze.Inspector do
     |> Enum.filter(fn {_id, bounds} ->
       is_integer(bounds[:left]) and is_integer(bounds[:right]) and
         is_integer(bounds[:top]) and is_integer(bounds[:bottom]) and
-        x - 1 >= bounds.left and x - 1 <= bounds.right and
-        y - 1 >= bounds.top and y - 1 <= bounds.bottom
+        x >= bounds.left and x <= bounds.right and y >= bounds.top and y <= bounds.bottom
     end)
     |> Enum.sort_by(fn {_id, bounds} ->
       area = (bounds.right - bounds.left + 1) * (bounds.bottom - bounds.top + 1)
@@ -332,8 +331,6 @@ defmodule Breeze.Inspector do
       false
     else
       screen = Map.get(state.terminal, :size, %{width: 0, height: 0})
-      row = y - 1
-      col = x - 1
 
       panel_top =
         case panel_position(state) do
@@ -343,7 +340,7 @@ defmodule Breeze.Inspector do
 
       panel_bottom = panel_top + @panel_height - 1
 
-      row >= panel_top and row <= panel_bottom and col >= 0 and col < screen.width
+      y >= panel_top and y <= panel_bottom and x >= 0 and x < screen.width
     end
   end
 

--- a/lib/breeze/mouse.ex
+++ b/lib/breeze/mouse.ex
@@ -3,32 +3,30 @@ defmodule Breeze.Mouse do
 
   import Bitwise
 
+  @type button :: String.t()
+  @type action :: String.t()
   @type event :: %{
-          button: :left | :middle | :right | :release | :wheel_up | :wheel_down,
-          action: :press | :release | :move,
-          x: pos_integer(),
-          y: pos_integer(),
-          modifiers: [:shift | :alt | :ctrl]
+          required(String.t()) => button() | action() | non_neg_integer() | boolean()
         }
 
   @spec decode(binary()) :: {:ok, event()} | :error
   def decode("\e[<" <> rest) do
     with [raw_code, raw_x, raw_tail] <- String.split(rest, ";", parts: 3),
          {code, ""} <- Integer.parse(raw_code),
-         {x, ""} <- Integer.parse(raw_x),
+         {x, ""} when x > 0 <- Integer.parse(raw_x),
          tail_size when tail_size > 0 <- byte_size(raw_tail),
          raw_y_size = tail_size - 1,
          <<raw_y::binary-size(^raw_y_size), suffix>> <- raw_tail,
-         {y, ""} <- Integer.parse(raw_y),
+         {y, ""} when y > 0 <- Integer.parse(raw_y),
          true <- suffix in [?M, ?m] do
-      {:ok,
-       %{
-         button: button(code),
-         action: action(code, suffix),
-         x: x,
-         y: y,
-         modifiers: modifiers(code)
-       }}
+      event = %{
+        "button" => button(code),
+        "action" => action(code, suffix),
+        "x" => x - 1,
+        "y" => y - 1
+      }
+
+      {:ok, Map.merge(event, modifier_flags(code))}
     else
       _ -> :error
     end
@@ -39,41 +37,36 @@ defmodule Breeze.Mouse do
   defp button(code) do
     cond do
       (code &&& 64) != 0 -> wheel_button(code)
-      (code &&& 3) == 3 -> :release
-      (code &&& 3) == 0 -> :left
-      (code &&& 3) == 1 -> :middle
-      true -> :right
+      (code &&& 3) == 3 -> "release"
+      (code &&& 3) == 0 -> "left"
+      (code &&& 3) == 1 -> "middle"
+      true -> "right"
     end
   end
 
-  defp modifiers(code) do
-    []
-    |> maybe_add_modifier(code, 4, :shift)
-    |> maybe_add_modifier(code, 8, :alt)
-    |> maybe_add_modifier(code, 16, :ctrl)
+  defp modifier_flags(code) do
+    %{}
+    |> maybe_put_modifier("shiftKey", (code &&& 4) != 0)
+    |> maybe_put_modifier("altKey", (code &&& 8) != 0)
+    |> maybe_put_modifier("ctrlKey", (code &&& 16) != 0)
   end
 
-  defp maybe_add_modifier(modifiers, code, mask, modifier) do
-    if (code &&& mask) != 0 do
-      modifiers ++ [modifier]
-    else
-      modifiers
-    end
-  end
+  defp maybe_put_modifier(event, _key, false), do: event
+  defp maybe_put_modifier(event, key, true), do: Map.put(event, key, true)
 
   defp action(code, suffix) do
     cond do
-      (code &&& 32) != 0 -> :move
-      suffix == ?m -> :release
-      true -> :press
+      (code &&& 32) != 0 -> "move"
+      suffix == ?m -> "release"
+      true -> "press"
     end
   end
 
   defp wheel_button(code) do
     case code &&& 3 do
-      0 -> :wheel_up
-      1 -> :wheel_down
-      _ -> :release
+      0 -> "wheel_up"
+      1 -> "wheel_down"
+      _ -> "release"
     end
   end
 end

--- a/lib/breeze/server/input.ex
+++ b/lib/breeze/server/input.ex
@@ -18,6 +18,8 @@ defmodule Breeze.Server.Input do
     %{state | input: struct!(state.input, Keyword.merge(@pipeline_defaults, overrides))}
   end
 
+  @mouse_modifier_keys ["shiftKey", "altKey", "ctrlKey"]
+
   def enqueue(state, decoded), do: update_in(state.input.queued_input, &:queue.in(decoded, &1))
 
   def schedule_flush(%{input: %{flush_scheduled?: true}} = state, _message), do: state
@@ -56,8 +58,8 @@ defmodule Breeze.Server.Input do
 
   def raw_printable_key?(_key), do: false
 
-  defp process_batched_input({:mouse, %{button: button} = event}, state, handlers)
-       when button in [:wheel_down, :wheel_up] do
+  defp process_batched_input({:mouse, %{"button" => button} = event}, state, handlers)
+       when button in ["wheel_down", "wheel_up"] do
     {event, state} = coalesce_wheel_events_from_queue(event, state, 1)
     handlers.handle_mouse.(event, state)
   end
@@ -107,22 +109,22 @@ defmodule Breeze.Server.Input do
 
   defp coalesce_wheel_events_from_queue(event, state, repeat) do
     case queue_out(state.input.queued_input) do
-      {{:value, {:mouse, %{button: button} = next_event}}, queue} ->
-        if button == event.button and wheel_match?(event, next_event) do
+      {{:value, {:mouse, %{"button" => button} = next_event}}, queue} ->
+        if button == event["button"] and wheel_match?(event, next_event) do
           coalesce_wheel_events_from_queue(
             event,
             put_in(state.input.queued_input, queue),
             repeat + 1
           )
         else
-          {Map.put(event, :repeat, repeat), state}
+          {Map.put(event, "repeat", repeat), state}
         end
 
       {{:value, _next}, _queue} ->
-        {Map.put(event, :repeat, repeat), state}
+        {Map.put(event, "repeat", repeat), state}
 
       {:empty, _queue} ->
-        {Map.put(event, :repeat, repeat), state}
+        {Map.put(event, "repeat", repeat), state}
     end
   end
 
@@ -161,9 +163,17 @@ defmodule Breeze.Server.Input do
   defp printable_key_text(key) when is_binary(key), do: key
 
   defp wheel_match?(left, right) do
-    left.action == right.action and left.x == right.x and left.y == right.y and
-      left.modifiers == right.modifiers
+    left["action"] == right["action"] and left["x"] == right["x"] and
+      left["y"] == right["y"] and mouse_modifiers_match?(left, right)
   end
+
+  defp mouse_modifiers_match?(left, right) do
+    Enum.all?(@mouse_modifier_keys, fn key ->
+      modifier_active?(left, key) == modifier_active?(right, key)
+    end)
+  end
+
+  defp modifier_active?(event, key), do: Map.get(event, key) in [true, "true"]
 
   defp queue_out(queue), do: :queue.out(queue)
 

--- a/lib/breeze/server/inspector.ex
+++ b/lib/breeze/server/inspector.ex
@@ -3,11 +3,11 @@ defmodule Breeze.Server.Inspector do
 
   def picks_mouse?(state), do: Breeze.Inspector.picks_mouse?(state)
 
-  def select_target(state, %{button: :left, action: :press} = event) do
+  def select_target(state, %{"button" => "left", "action" => "press"} = event) do
     Breeze.Inspector.select_at(state, event)
   end
 
-  def select_target(state, %{action: :move} = event) do
+  def select_target(state, %{"action" => "move"} = event) do
     Breeze.Inspector.hover_at(state, event)
   end
 

--- a/lib/breeze/test.ex
+++ b/lib/breeze/test.ex
@@ -101,8 +101,8 @@ defmodule Breeze.Test do
     ChildServer.dispatch_input(session.pid, key)
   end
 
-  @doc "Dispatches a named event and payload directly to the view."
-  @spec event(t(), term(), map()) :: term()
+  @doc "Dispatches a named event and unrestricted payload directly to the view."
+  @spec event(t(), Breeze.View.event_name(), Breeze.View.named_event_payload()) :: term()
   def event(%__MODULE__{} = session, change, event) do
     ChildServer.dispatch_event(session.pid, change, event)
   end

--- a/lib/breeze/view.ex
+++ b/lib/breeze/view.ex
@@ -62,18 +62,19 @@ defmodule Breeze.View do
   ## Handling events
 
   Events that come from the terminal or an implicit are handled in the
-  optional `handle_event/3` callback:
+  optional `handle_event/3` callback. Terminal input uses the reserved `:input`
+  event name and a string-keyed payload:
 
   ```elixir
-  def handle_event(_, %{"key" => "ArrowUp"}, term) do
+  def handle_event(:input, %{"key" => "ArrowUp"}, term) do
     {:noreply, assign(term, counter: term.assigns.counter + 1)}
   end
 
-  def handle_event(_, %{"key" => "ArrowDown"}, term) do
+  def handle_event(:input, %{"key" => "ArrowDown"}, term) do
     {:noreply, assign(term, counter: term.assigns.counter - 1)}
   end
 
-  def handle_event(_, %{"key" => "q"}, term) do
+  def handle_event(:input, %{"key" => "q"}, term) do
     {:stop, term}
   end
 
@@ -84,6 +85,53 @@ defmodule Breeze.View do
 
   For convenience, keys are converted to a more friendly representation for example,
   instead of sending "\eA" which is provided by the terminal, we convert it to "ArrowUp".
+
+  Modified keys add JS-style boolean fields to the same string-keyed map:
+
+  ```elixir
+  %{"key" => "Backspace", "ctrlKey" => true}
+  ```
+
+  Mouse input is nested under `"mouse"`. Button and action names are strings,
+  coordinates are zero-based positions in the receiving view's coordinate
+  space, and active modifiers use the same JS-style fields as keyboard input:
+
+  ```elixir
+  %{
+    "mouse" => %{
+      "button" => "left",
+      "action" => "press",
+      "x" => 12,
+      "y" => 7,
+      "shiftKey" => true
+    },
+    "target" => "save",
+    "focused" => "url",
+    "row" => 1,
+    "col" => 4
+  }
+  ```
+
+  `"target"`, `"focused"`, `"row"`, and `"col"` are added when the pointer
+  intersects a rendered target. `"focused"` contains the focus target from
+  before the event is dispatched. Row and column are zero-based positions inside
+  the target. Root-view coordinates are screen-relative; live-child coordinates
+  are translated into the child's coordinate space.
+  Repeated wheel events may contain a positive integer `"repeat"` inside the
+  `"mouse"` map.
+
+  Events emitted by Breeze implicits use the string handler name configured by
+  `br-change` or `br-submit`. Built-in implicits currently emit atom-keyed maps:
+
+  ```elixir
+  def handle_event("selection_changed", %{value: value, index: index}, term) do
+    {:noreply, assign(term, selected: value, selected_index: index)}
+  end
+  ```
+
+  A named event's payload is otherwise unrestricted. Custom implicits and
+  callers dispatching events directly may use any term, including maps, structs,
+  lists, or scalar values.
 
   If `handle_event/3` is not implemented, events that reach the view are
   ignored. If it is implemented, normal Elixir function clause matching
@@ -362,11 +410,17 @@ defmodule Breeze.View do
   @typedoc "Assigns passed to a view or function component."
   @type assigns :: Breeze.Component.assigns()
 
-  @typedoc "A view event name."
-  @type event_name :: term()
+  @typedoc "The reserved terminal-input name or an application-defined named event."
+  @type event_name :: :input | String.t()
 
-  @typedoc "A decoded terminal or implicit event payload."
-  @type event :: map()
+  @typedoc "A string-keyed terminal input payload."
+  @type input_event :: %{optional(String.t()) => term()}
+
+  @typedoc "An unrestricted payload for an application-defined named event."
+  @type named_event_payload :: term()
+
+  @typedoc "A decoded terminal input or named event payload."
+  @type event :: input_event() | named_event_payload()
 
   @typedoc "Compiled template output returned by the `~H` sigil."
   @type rendered :: Breeze.Component.rendered()
@@ -387,7 +441,7 @@ defmodule Breeze.View do
   @doc "Renders a view or component from its assigns."
   @callback render(assigns()) :: rendered()
 
-  @doc "Handles a terminal or implicit event."
+  @doc "Handles `:input` with a string-keyed payload or a named event with any payload."
   @callback handle_event(event_name(), event(), Breeze.Term.t()) :: reply()
 
   @doc "Handles a message sent to the view process."

--- a/test/breeze/child_server_test.exs
+++ b/test/breeze/child_server_test.exs
@@ -139,8 +139,22 @@ defmodule Breeze.ChildServerTest do
 
     assert {:noreply, nil, true} =
              Breeze.ChildServer.dispatch_input(pid, %{
-               "mouse" => %{button: :left, action: :press, x: 3, y: 4, modifiers: []}
+               "mouse" => %{
+                 "button" => "left",
+                 "action" => "press",
+                 "x" => 2,
+                 "y" => 3
+               }
              })
+
+    assert :sys.get_state(pid).assigns.clicks == [
+             %{
+               "button" => "left",
+               "action" => "press",
+               "x" => 2,
+               "y" => 3
+             }
+           ]
 
     assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, [])
     assert box.content == "1"
@@ -203,7 +217,12 @@ defmodule Breeze.ChildServerTest do
 
     assert {:noreply, "left", false} =
              Breeze.ChildServer.dispatch_input(wheel_pid, %{
-               "mouse" => %{button: :wheel_down, action: :press, x: 14, y: 2, modifiers: []}
+               "mouse" => %{
+                 "button" => "wheel_down",
+                 "action" => "press",
+                 "x" => 13,
+                 "y" => 1
+               }
              })
 
     assert %{focused: "left"} = Breeze.ChildServer.metadata(wheel_pid)
@@ -218,7 +237,12 @@ defmodule Breeze.ChildServerTest do
 
     assert {:noreply, "right", true} =
              Breeze.ChildServer.dispatch_input(pid, %{
-               "mouse" => %{button: :left, action: :press, x: 11, y: 2, modifiers: []}
+               "mouse" => %{
+                 "button" => "left",
+                 "action" => "press",
+                 "x" => 10,
+                 "y" => 1
+               }
              })
 
     assert %{assigns: %{last_target: "right", event_focused: ^previously_focused}} =
@@ -226,7 +250,12 @@ defmodule Breeze.ChildServerTest do
 
     assert {:noreply, "right", true} =
              Breeze.ChildServer.dispatch_input(pid, %{
-               "mouse" => %{button: :left, action: :press, x: 11, y: 2, modifiers: []}
+               "mouse" => %{
+                 "button" => "left",
+                 "action" => "press",
+                 "x" => 10,
+                 "y" => 1
+               }
              })
 
     assert %{assigns: %{last_target: "right", event_focused: "right"}} =
@@ -244,7 +273,12 @@ defmodule Breeze.ChildServerTest do
 
     assert {:noreply, "full", true} =
              Breeze.ChildServer.dispatch_input(pid, %{
-               "mouse" => %{button: :left, action: :press, x: 12, y: 2, modifiers: []}
+               "mouse" => %{
+                 "button" => "left",
+                 "action" => "press",
+                 "x" => 11,
+                 "y" => 1
+               }
              })
 
     assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, terminal: terminal)

--- a/test/breeze/implicit/dropdown_test.exs
+++ b/test/breeze/implicit/dropdown_test.exs
@@ -287,12 +287,17 @@ defmodule Breeze.Implicit.DropdownTest do
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
     bounds = :sys.get_state(pid).mouse_targets["method"]
-    x = div(bounds.left + bounds.right, 2) + 1
-    y = div(bounds.top + bounds.bottom, 2) + 1
+    x = div(bounds.left + bounds.right, 2)
+    y = div(bounds.top + bounds.bottom, 2)
 
     assert {:noreply, "method", true} =
              Breeze.ChildServer.dispatch_input(pid, %{
-               "mouse" => %{button: :left, action: :press, x: x, y: y, modifiers: []}
+               "mouse" => %{
+                 "button" => "left",
+                 "action" => "press",
+                 "x" => x,
+                 "y" => y
+               }
              })
 
     assert %{implicit_state: %{"method" => {Dropdown, %{open?: true}}}} =
@@ -300,7 +305,12 @@ defmodule Breeze.Implicit.DropdownTest do
 
     assert {:noreply, "method", true} =
              Breeze.ChildServer.dispatch_input(pid, %{
-               "mouse" => %{button: :left, action: :press, x: x, y: y, modifiers: []}
+               "mouse" => %{
+                 "button" => "left",
+                 "action" => "press",
+                 "x" => x,
+                 "y" => y
+               }
              })
 
     assert %{implicit_state: %{"method" => {Dropdown, %{open?: false}}}} =
@@ -313,33 +323,31 @@ defmodule Breeze.Implicit.DropdownTest do
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
     trigger_bounds = :sys.get_state(pid).mouse_targets["method"]
-    trigger_x = div(trigger_bounds.left + trigger_bounds.right, 2) + 1
-    trigger_y = div(trigger_bounds.top + trigger_bounds.bottom, 2) + 1
+    trigger_x = div(trigger_bounds.left + trigger_bounds.right, 2)
+    trigger_y = div(trigger_bounds.top + trigger_bounds.bottom, 2)
 
     assert {:noreply, "method", true} =
              Breeze.ChildServer.dispatch_input(pid, %{
                "mouse" => %{
-                 button: :left,
-                 action: :press,
-                 x: trigger_x,
-                 y: trigger_y,
-                 modifiers: []
+                 "button" => "left",
+                 "action" => "press",
+                 "x" => trigger_x,
+                 "y" => trigger_y
                }
              })
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
     item_bounds = :sys.get_state(pid).mouse_targets["method-item-2"]
-    item_x = div(item_bounds.left + item_bounds.right, 2) + 1
-    item_y = div(item_bounds.top + item_bounds.bottom, 2) + 1
+    item_x = div(item_bounds.left + item_bounds.right, 2)
+    item_y = div(item_bounds.top + item_bounds.bottom, 2)
 
     assert {:noreply, "method", true} =
              Breeze.ChildServer.dispatch_input(pid, %{
                "mouse" => %{
-                 button: :left,
-                 action: :press,
-                 x: item_x,
-                 y: item_y,
-                 modifiers: []
+                 "button" => "left",
+                 "action" => "press",
+                 "x" => item_x,
+                 "y" => item_y
                }
              })
 
@@ -361,20 +369,19 @@ defmodule Breeze.Implicit.DropdownTest do
     state = :sys.get_state(pid)
     item_bounds = state.mouse_targets["choice-item-1"]
     covered_bounds = state.mouse_targets["covered"]
-    x = max(item_bounds.left, covered_bounds.left) + 1
-    y = max(item_bounds.top, covered_bounds.top) + 1
+    x = max(item_bounds.left, covered_bounds.left)
+    y = max(item_bounds.top, covered_bounds.top)
 
-    assert x - 1 <= min(item_bounds.right, covered_bounds.right)
-    assert y - 1 <= min(item_bounds.bottom, covered_bounds.bottom)
+    assert x <= min(item_bounds.right, covered_bounds.right)
+    assert y <= min(item_bounds.bottom, covered_bounds.bottom)
 
     assert {:noreply, "choice", true} =
              Breeze.ChildServer.dispatch_input(pid, %{
                "mouse" => %{
-                 button: :left,
-                 action: :press,
-                 x: x,
-                 y: y,
-                 modifiers: []
+                 "button" => "left",
+                 "action" => "press",
+                 "x" => x,
+                 "y" => y
                }
              })
 

--- a/test/breeze/implicit/list_test.exs
+++ b/test/breeze/implicit/list_test.exs
@@ -137,7 +137,7 @@ defmodule Breeze.Implicit.ListTest do
         Implicit.List.handle_event(
           :ignore,
           %{
-            "mouse" => %{button: :left, action: :press},
+            "mouse" => %{"button" => "left", "action" => "press"},
             "row" => 2,
             "element" => viewport
           },
@@ -165,7 +165,7 @@ defmodule Breeze.Implicit.ListTest do
       assert {:noreply, next_state} =
                Implicit.List.handle_event(
                  :ignore,
-                 %{"mouse" => %{button: :wheel_down}, "element" => viewport},
+                 %{"mouse" => %{"button" => "wheel_down"}, "element" => viewport},
                  state
                )
 
@@ -190,7 +190,10 @@ defmodule Breeze.Implicit.ListTest do
       assert {:noreply, next_state} =
                Implicit.List.handle_event(
                  :ignore,
-                 %{"mouse" => %{button: :wheel_down, repeat: 3}, "element" => viewport},
+                 %{
+                   "mouse" => %{"button" => "wheel_down", "repeat" => 3},
+                   "element" => viewport
+                 },
                  state
                )
 

--- a/test/breeze/implicit/scroll_test.exs
+++ b/test/breeze/implicit/scroll_test.exs
@@ -190,7 +190,7 @@ defmodule Breeze.Implicit.ScrollTest do
       assert {:noreply, next_state} =
                Scroll.handle_event(
                  :input,
-                 %{"mouse" => %{button: :wheel_down}, "element" => viewport},
+                 %{"mouse" => %{"button" => "wheel_down"}, "element" => viewport},
                  state
                )
 
@@ -205,7 +205,10 @@ defmodule Breeze.Implicit.ScrollTest do
       assert {:noreply, next_state} =
                Scroll.handle_event(
                  :input,
-                 %{"mouse" => %{button: :wheel_down, repeat: 3}, "element" => viewport},
+                 %{
+                   "mouse" => %{"button" => "wheel_down", "repeat" => 3},
+                   "element" => viewport
+                 },
                  state
                )
 

--- a/test/breeze/implicit/tabs_test.exs
+++ b/test/breeze/implicit/tabs_test.exs
@@ -160,7 +160,10 @@ defmodule Breeze.Implicit.TabsTest do
       assert {{:change, %{value: "details", index: 1}}, next_state} =
                Tabs.handle_event(
                  nil,
-                 %{"mouse" => %{button: :left, action: :press}, "target" => "tabs-tab-details"},
+                 %{
+                   "mouse" => %{"button" => "left", "action" => "press"},
+                   "target" => "tabs-tab-details"
+                 },
                  state
                )
 
@@ -176,12 +179,17 @@ defmodule Breeze.Implicit.TabsTest do
       state = :sys.get_state(pid)
 
       bounds = state.mouse_targets["tabs-tab-details"]
-      x = div(bounds.left + bounds.right, 2) + 1
-      y = div(bounds.top + bounds.bottom, 2) + 1
+      x = div(bounds.left + bounds.right, 2)
+      y = div(bounds.top + bounds.bottom, 2)
 
       assert {_status, "tabs", _changed} =
                Breeze.ChildServer.dispatch_input(pid, %{
-                 "mouse" => %{button: :left, action: :press, x: x, y: y, modifiers: []}
+                 "mouse" => %{
+                   "button" => "left",
+                   "action" => "press",
+                   "x" => x,
+                   "y" => y
+                 }
                })
 
       assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, terminal: terminal)

--- a/test/breeze/implicit/tree_test.exs
+++ b/test/breeze/implicit/tree_test.exs
@@ -153,7 +153,7 @@ defmodule Breeze.Implicit.TreeTest do
       {:noreply, scrolled} =
         Implicit.Tree.handle_event(
           :ignore,
-          %{"mouse" => %{button: :wheel_down}, "element" => element},
+          %{"mouse" => %{"button" => "wheel_down"}, "element" => element},
           state
         )
 

--- a/test/breeze/inspector_test.exs
+++ b/test/breeze/inspector_test.exs
@@ -432,7 +432,7 @@ defmodule Breeze.InspectorTest do
         inspector_state: %{visible?: true, selected_id: "field"}
       })
 
-    click = %{x: 4, y: 3}
+    click = %{"x" => 3, "y" => 2}
 
     state = Inspector.select_at(state, click)
     assert state.inspector_state.selected_id == "nested"
@@ -450,7 +450,7 @@ defmodule Breeze.InspectorTest do
         inspector_state: %{visible?: true, selected_id: "field", hovered_id: "nested"}
       })
 
-    bottom_panel_event = %{x: 10, y: 24}
+    bottom_panel_event = %{"x" => 9, "y" => 23}
 
     assert Inspector.hover_at(state, bottom_panel_event).inspector_state.hovered_id == "nested"
     assert Inspector.select_at(state, bottom_panel_event).inspector_state.selected_id == "field"
@@ -462,7 +462,7 @@ defmodule Breeze.InspectorTest do
         %{state | inspector_state: %{state.inspector_state | hovered_id: "nested"}}
       end)
 
-    top_panel_event = %{x: 10, y: 1}
+    top_panel_event = %{"x" => 9, "y" => 0}
 
     assert Inspector.hover_at(top_docked, top_panel_event).inspector_state.hovered_id == "nested"
     assert Inspector.select_at(top_docked, top_panel_event).inspector_state.selected_id == "field"

--- a/test/breeze/live_view_core_test.exs
+++ b/test/breeze/live_view_core_test.exs
@@ -244,7 +244,7 @@ defmodule Breeze.LiveView.CoreTest do
     assert {:noreply, "anchor", true} =
              ChildServer.dispatch_input(
                root_pid,
-               wheel_event(:wheel_down, targets["scroll-child::scroll"])
+               wheel_event("wheel_down", targets["scroll-child::scroll"])
              )
 
     assert ChildServer.metadata(root_pid).focused == "anchor"
@@ -283,7 +283,7 @@ defmodule Breeze.LiveView.CoreTest do
       end)
 
     {x, y} = mouse_center(bounds)
-    send(pid, {reader, {:data, "\e[<65;#{x};#{y}M"}})
+    send(pid, {reader, {:data, "\e[<65;#{x + 1};#{y + 1}M"}})
 
     offset_y =
       wait_until(fn ->

--- a/test/breeze/mouse_test.exs
+++ b/test/breeze/mouse_test.exs
@@ -5,22 +5,58 @@ defmodule Breeze.MouseTest do
 
   test "decodes sgr left click press" do
     assert Mouse.decode("\e[<0;12;7M") ==
-             {:ok, %{button: :left, action: :press, x: 12, y: 7, modifiers: []}}
+             {:ok,
+              %{
+                "button" => "left",
+                "action" => "press",
+                "x" => 11,
+                "y" => 6
+              }}
   end
 
   test "decodes sgr release" do
     assert Mouse.decode("\e[<0;12;7m") ==
-             {:ok, %{button: :left, action: :release, x: 12, y: 7, modifiers: []}}
+             {:ok,
+              %{
+                "button" => "left",
+                "action" => "release",
+                "x" => 11,
+                "y" => 6
+              }}
   end
 
   test "decodes sgr motion with modifiers" do
-    assert Mouse.decode("\e[<36;5;3M") ==
-             {:ok, %{button: :left, action: :move, x: 5, y: 3, modifiers: [:shift]}}
+    assert Mouse.decode("\e[<60;5;3M") ==
+             {:ok,
+              %{
+                "button" => "left",
+                "action" => "move",
+                "x" => 4,
+                "y" => 2,
+                "shiftKey" => true,
+                "altKey" => true,
+                "ctrlKey" => true
+              }}
   end
 
   test "decodes sgr wheel scroll" do
     assert Mouse.decode("\e[<65;20;4M") ==
-             {:ok, %{button: :wheel_down, action: :press, x: 20, y: 4, modifiers: []}}
+             {:ok,
+              %{
+                "button" => "wheel_down",
+                "action" => "press",
+                "x" => 19,
+                "y" => 3
+              }}
+  end
+
+  test "normalizes the top-left sgr position to zero" do
+    assert {:ok, %{"x" => 0, "y" => 0}} = Mouse.decode("\e[<0;1;1M")
+  end
+
+  test "rejects non-positive sgr coordinates" do
+    assert Mouse.decode("\e[<0;0;1M") == :error
+    assert Mouse.decode("\e[<0;1;0M") == :error
   end
 
   test "rejects non mouse input" do

--- a/test/breeze_storybook/view_test.exs
+++ b/test/breeze_storybook/view_test.exs
@@ -622,11 +622,10 @@ defmodule Breeze.Storybook.ScrollInteractionLayoutTest do
     assert {:noreply, "storybook-nav", true} =
              Breeze.ChildServer.dispatch_input(pid, %{
                "mouse" => %{
-                 button: :wheel_down,
-                 action: :press,
-                 x: preview_bounds.left + div(preview_bounds.width, 2) + 1,
-                 y: preview_bounds.top + 3,
-                 modifiers: []
+                 "button" => "wheel_down",
+                 "action" => "press",
+                 "x" => preview_bounds.left + div(preview_bounds.width, 2),
+                 "y" => preview_bounds.top + 2
                }
              })
 
@@ -659,11 +658,10 @@ defmodule Breeze.Storybook.ScrollInteractionLayoutTest do
     assert {:noreply, "storybook-nav", true} =
              Breeze.ChildServer.dispatch_input(pid, %{
                "mouse" => %{
-                 button: :wheel_down,
-                 action: :press,
-                 x: preview_bounds.left + div(preview_bounds.width, 2) + 1,
-                 y: preview_bounds.top + 4,
-                 modifiers: []
+                 "button" => "wheel_down",
+                 "action" => "press",
+                 "x" => preview_bounds.left + div(preview_bounds.width, 2),
+                 "y" => preview_bounds.top + 3
                }
              })
 

--- a/test/support/live_view_case.ex
+++ b/test/support/live_view_case.ex
@@ -105,16 +105,15 @@ defmodule Breeze.TestSupport.LiveViewHelpers do
 
     %{
       "mouse" => %{
-        button: button,
-        action: :press,
-        modifiers: [],
-        x: x,
-        y: y
+        "button" => button,
+        "action" => "press",
+        "x" => x,
+        "y" => y
       }
     }
   end
 
   def mouse_center(bounds) do
-    {div(bounds.left + bounds.right, 2) + 1, div(bounds.top + bounds.bottom, 2) + 1}
+    {div(bounds.left + bounds.right, 2), div(bounds.top + bounds.bottom, 2)}
   end
 end


### PR DESCRIPTION
Use string keys and values for mouse buttons and actions. Replace the modifier list with JS-style shiftKey, altKey, and ctrlKey flags, matching the existing keyboard event format.

Document terminal input as string-keyed while allowing named events to carry unrestricted payloads.

BREAKING CHANGE: Mouse event handlers must match string keys and string button/action values. The modifiers list is replaced by optional shiftKey, altKey, and ctrlKey boolean fields.