### PR TITLE
feat(Breeze.Blocks): add a checkbox function component

### DIFF
--- a/lib/breeze/blocks.ex
+++ b/lib/breeze/blocks.ex
@@ -138,7 +138,7 @@ defmodule Breeze.Blocks do
       list-values={@list_values}
       focusable
       class={@class}
-      style={Breeze.Blocks.inline_style(assigns)}
+      style={inline_style(assigns)}
       {@rest}
     >
       <box :if={@top_spacer > 0} class={"width-full height-#{@top_spacer} overflow-hidden"}>
@@ -1324,6 +1324,85 @@ defmodule Breeze.Blocks do
 
   defp normalize_button_focusable(value) when value in [false, "false"], do: false
   defp normalize_button_focusable(_value), do: true
+
+  attr :id, :string, required: true
+
+  attr :checked, :boolean,
+    default: nil,
+    doc: "Controlled checked state; omit it to let the checkbox retain its own state"
+
+  attr :disabled, :boolean, default: false
+  attr :class, :string, default: nil
+  attr :style, :any, default: nil
+  attr :rest, :global
+
+  slot :inner_block, required: true
+
+  def checkbox(assigns) do
+    checked = normalize_checkbox_checked(Map.get(assigns, :checked))
+    disabled? = normalize_checkbox_disabled(Map.get(assigns, :disabled, false))
+
+    assigns =
+      assigns
+      |> assign(checked: checked)
+      |> assign(checked_attr: if(is_nil(checked), do: nil, else: to_string(checked)))
+      |> assign(disabled: disabled?)
+      |> assign(unchecked_indicator: if(disabled?, do: "⟦ ⟧ ", else: "[ ] "))
+      |> assign(checked_indicator: if(disabled?, do: "⟦x⟧ ", else: "[x] "))
+
+    ~H"""
+    <box
+      id={@id}
+      implicit={Breeze.Implicit.Checkbox}
+      checkbox-checked={@checked_attr}
+      checkbox-disabled={@disabled}
+      focusable={!@disabled}
+      class={[
+      "inline height-1 overflow-hidden",
+      @disabled && "text-muted",
+      !@disabled && "focus:text-primary",
+      class_override(assigns)
+    ]}
+      style={Breeze.Blocks.inline_style(assigns)}
+      {@rest}
+    >
+      <box
+        checkbox-state="unchecked"
+        focus-with-owner
+        class="inline width-0 selected:width-4 focus:selected:width-0 height-1 overflow-hidden"
+      >
+        {@unchecked_indicator}
+      </box>
+      <box
+        checkbox-state="unchecked"
+        focus-with-owner
+        class="inline width-0 focus:selected:width-4 height-1 overflow-hidden focus:text-primary"
+      >
+        | |
+      </box>
+      <box
+        checkbox-state="checked"
+        focus-with-owner
+        class="inline width-0 selected:width-4 focus:selected:width-0 height-1 overflow-hidden"
+      >
+        {@checked_indicator}
+      </box>
+      <box
+        checkbox-state="checked"
+        focus-with-owner
+        class="inline width-0 focus:selected:width-4 height-1 overflow-hidden focus:text-primary"
+      >
+        |x|
+      </box>
+      <box focus-with-owner class="inline focus:text-primary">{render_slot(@inner_block)}</box>
+    </box>
+    """
+  end
+
+  defp normalize_checkbox_checked(nil), do: nil
+  defp normalize_checkbox_checked(value), do: value in [true, "true", "1", ""]
+
+  defp normalize_checkbox_disabled(value), do: value in [true, "true", "1", ""]
 
   attr :id, :string, required: true
   attr :class, :string, default: nil

--- a/lib/breeze/implicit/checkbox.ex
+++ b/lib/breeze/implicit/checkbox.ex
@@ -1,0 +1,67 @@
+defmodule Breeze.Implicit.Checkbox do
+  @moduledoc false
+
+  @behaviour Breeze.Implicit
+
+  def init(_children, root_attrs, last_state) do
+    checked =
+      case Map.get(root_attrs, :"checkbox-checked") do
+        nil -> Map.get(last_state, :checked, false)
+        value -> normalize_boolean(value, false)
+      end
+
+    disabled =
+      root_attrs
+      |> Map.get(:"checkbox-disabled")
+      |> normalize_boolean(false)
+
+    {:ok, %{checked: checked, disabled: disabled}}
+  end
+
+  def handle_event(_, _, %{disabled: true} = state), do: {:noreply, state}
+
+  def handle_event(_, %{"key" => " "}, state), do: toggle(state)
+
+  def handle_event(_, %{"mouse" => %{"button" => "left", "action" => "press"}}, state),
+    do: toggle(state)
+
+  def handle_event(_, _, state), do: {:noreply, state}
+
+  def handle_modifiers(:root, _flags, state) do
+    state
+    |> selected_modifiers()
+    |> maybe_add_disabled_style(state)
+  end
+
+  def handle_modifiers(:child, flags, state) do
+    flags
+    |> indicator_modifiers(state)
+    |> maybe_add_disabled_style(state)
+  end
+
+  defp toggle(state) do
+    checked = !state.checked
+    {{:change, %{value: checked}}, %{state | checked: checked}}
+  end
+
+  defp selected_modifiers(%{checked: true}), do: [selected: true]
+  defp selected_modifiers(_state), do: []
+
+  defp indicator_modifiers(flags, state) do
+    case Keyword.get(flags, :"checkbox-state") do
+      "checked" when state.checked -> [selected: true]
+      "unchecked" when not state.checked -> [selected: true]
+      _ -> []
+    end
+  end
+
+  defp maybe_add_disabled_style(modifiers, %{disabled: true}) do
+    modifiers ++ [style: "text-muted"]
+  end
+
+  defp maybe_add_disabled_style(modifiers, _state), do: modifiers
+
+  defp normalize_boolean(value, _default) when value in [true, "true", "1", ""], do: true
+  defp normalize_boolean(value, _default) when value in [false, "false", "0"], do: false
+  defp normalize_boolean(_value, default), do: default
+end

--- a/storybook/checkbox.story.exs
+++ b/storybook/checkbox.story.exs
@@ -1,0 +1,61 @@
+defmodule Breeze.Storybook.Stories.Blocks.CheckboxStory do
+  use Breeze.Storybook.Story
+
+  def story do
+    %{
+      id: "checkbox",
+      title: "Checkbox",
+      description: "Two-state checkbox with mouse and keyboard activation.",
+      notes: [
+        "A first left click focuses and toggles the checkbox.",
+        "Press Space to toggle the focused checkbox.",
+        "Disabled controls use ⟦ ⟧ or ⟦x⟧ in addition to muted styling.",
+        "The checked value is stored in story-local state through br-change."
+      ],
+      source:
+        ~s|<.checkbox id="mouse" checked={@mouse} br-change="mouse_changed">Mouse</.checkbox>|
+    }
+  end
+
+  def mount(_opts, term) do
+    {:ok,
+     term
+     |> assign(mouse: true, inspector: false)
+     |> focus("storybook-checkbox-mouse")}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <box class="w-full bg-panel">
+      <box class="text-muted">Click once or press Space to toggle.</box>
+      <box class="pt-1 h-2">
+        <.checkbox id="storybook-checkbox-mouse" checked={@mouse} br-change="storybook_mouse_changed">
+          Mouse input
+        </.checkbox>
+      </box>
+      <box class="h-1">
+        <.checkbox
+          id="storybook-checkbox-inspector"
+          checked={@inspector}
+          br-change="storybook_inspector_changed"
+        >
+          Inspector
+        </.checkbox>
+      </box>
+      <box class="h-1">
+        <.checkbox id="storybook-checkbox-disabled" checked disabled>Unavailable</.checkbox>
+      </box>
+    </box>
+    """
+  end
+
+  def handle_event("storybook_mouse_changed", %{value: value}, term) do
+    {:noreply, assign(term, mouse: value)}
+  end
+
+  def handle_event("storybook_inspector_changed", %{value: value}, term) do
+    {:noreply, assign(term, inspector: value)}
+  end
+
+  def handle_event(_, _, term), do: {:noreply, term}
+end

--- a/test/breeze/implicit/checkbox_test.exs
+++ b/test/breeze/implicit/checkbox_test.exs
@@ -1,0 +1,258 @@
+defmodule Breeze.Implicit.CheckboxTest do
+  use ExUnit.Case, async: true
+
+  import Breeze.TestSupport.ProcessHelpers, only: [start_child_server: 1]
+
+  alias Breeze.ChildServer
+  alias Breeze.Implicit.Checkbox
+
+  defmodule CheckboxView do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def mount(_opts, term), do: {:ok, term |> assign(checked: false) |> focus("other")}
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-30 height-3">
+        <box class="height-1">
+          <.button id="other">Other</.button>
+        </box>
+        <box class="height-1">
+          <.checkbox id="mouse" checked={@checked} br-change="mouse_changed">Mouse</.checkbox>
+        </box>
+      </box>
+      """
+    end
+
+    def handle_event("mouse_changed", %{value: value}, term) do
+      {:noreply, assign(term, checked: value)}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule UncontrolledCheckboxView do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def mount(_opts, term), do: {:ok, focus(term, "mouse")}
+
+    def render(assigns) do
+      ~H"""
+      <.checkbox id="mouse">Mouse</.checkbox>
+      """
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
+  defmodule DisabledCheckboxView do
+    use Breeze.View
+    import Breeze.Blocks
+
+    def mount(_opts, term), do: {:ok, focus(term, "other")}
+
+    def render(assigns) do
+      ~H"""
+      <box class="width-30 height-3">
+        <box id="other" focusable class="height-1">Other</box>
+        <box class="height-1">
+          <.checkbox id="mouse" disabled br-change="mouse_changed">Mouse</.checkbox>
+        </box>
+      </box>
+      """
+    end
+
+    def handle_event("mouse_changed", %{value: value}, term) do
+      {:noreply, assign(term, changed_to: value)}
+    end
+
+    def handle_event(_, _, term), do: {:noreply, term}
+    def handle_info(_, term), do: {:noreply, term}
+  end
+
+  describe "init/3" do
+    test "starts unchecked and enabled" do
+      assert {:ok, %{checked: false, disabled: false}} = Checkbox.init([], %{}, %{})
+    end
+
+    test "adopts a controlled checked value over its previous state" do
+      assert {:ok, %{checked: false}} =
+               Checkbox.init([], %{:"checkbox-checked" => "false"}, %{checked: true})
+
+      assert {:ok, %{checked: true}} =
+               Checkbox.init([], %{:"checkbox-checked" => "true"}, %{checked: false})
+    end
+
+    test "retains its previous value when checked is uncontrolled" do
+      assert {:ok, %{checked: true}} = Checkbox.init([], %{}, %{checked: true})
+    end
+  end
+
+  describe "handle_event/3" do
+    test "Space toggles and emits the boolean value" do
+      state = %{checked: false, disabled: false}
+
+      assert {{:change, %{value: true}}, %{checked: true}} =
+               Checkbox.handle_event(:input, %{"key" => " "}, state)
+    end
+
+    test "Enter does not toggle" do
+      state = %{checked: false, disabled: false}
+      assert {:noreply, ^state} = Checkbox.handle_event(:input, %{"key" => "Enter"}, state)
+    end
+
+    test "the first left press toggles regardless of prior focus" do
+      state = %{checked: false, disabled: false}
+
+      event = %{
+        "mouse" => %{"button" => "left", "action" => "press"},
+        "target" => "mouse",
+        "focused" => "other"
+      }
+
+      assert {{:change, %{value: true}}, %{checked: true}} =
+               Checkbox.handle_event(:input, event, state)
+    end
+
+    test "disabled checkboxes ignore keyboard and mouse activation" do
+      state = %{checked: false, disabled: true}
+      mouse = %{"mouse" => %{"button" => "left", "action" => "press"}}
+
+      assert {:noreply, ^state} = Checkbox.handle_event(:input, %{"key" => " "}, state)
+      assert {:noreply, ^state} = Checkbox.handle_event(:input, mouse, state)
+    end
+  end
+
+  test "checked state selects the root and matching indicator" do
+    assert [selected: true] =
+             Checkbox.handle_modifiers(:root, [], %{checked: true, disabled: false})
+
+    assert [] = Checkbox.handle_modifiers(:root, [], %{checked: false, disabled: false})
+
+    assert [selected: true] =
+             Checkbox.handle_modifiers(:child, [{:"checkbox-state", "checked"}], %{
+               checked: true,
+               disabled: false
+             })
+
+    assert [] =
+             Checkbox.handle_modifiers(:child, [{:"checkbox-state", "unchecked"}], %{
+               checked: true,
+               disabled: false
+             })
+  end
+
+  test "disabled state mutes the root and every owned child" do
+    state = %{checked: false, disabled: true}
+
+    assert [style: "text-muted"] = Checkbox.handle_modifiers(:root, [], state)
+
+    assert [selected: true, style: "text-muted"] =
+             Checkbox.handle_modifiers(
+               :child,
+               [{:"checkbox-state", "unchecked"}],
+               state
+             )
+
+    assert [style: "text-muted"] = Checkbox.handle_modifiers(:child, [], state)
+  end
+
+  test "a first click focuses and toggles the rendered checkbox" do
+    terminal = %Termite.Terminal{size: %{width: 30, height: 5}}
+    {:ok, pid} = start_child_server(view: CheckboxView, terminal: terminal)
+
+    assert {:ok, _acc, box} = ChildServer.render(pid, terminal: terminal)
+    assert strip_ansi(box.content) =~ "[ ] Mouse"
+
+    assert {:noreply, "mouse", true} = click(pid, "mouse")
+
+    assert %{focused: "mouse", assigns: %{checked: true}} = ChildServer.metadata(pid)
+    assert %{"mouse" => {Checkbox, %{checked: true}}} = ChildServer.metadata(pid).implicit_state
+
+    assert {:ok, _acc, box} = ChildServer.render(pid, terminal: terminal)
+    content = strip_ansi(box.content)
+    assert content =~ "|x| Mouse"
+    refute content =~ "[x] Mouse"
+
+    assert {:noreply, "mouse", true} = click(pid, "mouse")
+    assert %{assigns: %{checked: false}} = ChildServer.metadata(pid)
+  end
+
+  test "focus uses bar delimiters as a non-color cue" do
+    terminal = %Termite.Terminal{size: %{width: 20, height: 3}}
+    {:ok, pid} = start_child_server(view: UncontrolledCheckboxView, terminal: terminal)
+
+    assert {:ok, _acc, box} = ChildServer.render(pid, terminal: terminal)
+    content = strip_ansi(box.content)
+
+    assert content =~ "| | Mouse"
+    refute content =~ "[ ] Mouse"
+  end
+
+  test "Space toggles a rendered checkbox while Enter does not" do
+    terminal = %Termite.Terminal{size: %{width: 30, height: 5}}
+    {:ok, pid} = start_child_server(view: CheckboxView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = ChildServer.render(pid, terminal: terminal)
+    assert {:noreply, "mouse", true} = ChildServer.set_focus(pid, "mouse")
+
+    assert {:noreply, "mouse", true} = ChildServer.dispatch_input(pid, " ")
+    assert %{assigns: %{checked: true}} = ChildServer.metadata(pid)
+
+    assert {:noreply, "mouse", false} = ChildServer.dispatch_input(pid, "Enter")
+    assert %{assigns: %{checked: true}} = ChildServer.metadata(pid)
+  end
+
+  test "an uncontrolled checkbox retains its implicit state" do
+    terminal = %Termite.Terminal{size: %{width: 20, height: 3}}
+    {:ok, pid} = start_child_server(view: UncontrolledCheckboxView, terminal: terminal)
+
+    assert {:ok, _acc, _box} = ChildServer.render(pid, terminal: terminal)
+    assert {:noreply, "mouse", true} = ChildServer.dispatch_input(pid, " ")
+    assert {:ok, _acc, box} = ChildServer.render(pid, terminal: terminal)
+
+    assert strip_ansi(box.content) =~ "|x| Mouse"
+  end
+
+  test "a disabled checkbox cannot receive focus or toggle" do
+    terminal = %Termite.Terminal{size: %{width: 30, height: 5}}
+
+    {:ok, pid} =
+      start_child_server(
+        view: DisabledCheckboxView,
+        terminal: terminal,
+        theme: Breeze.Theme.builtin(:nebula)
+      )
+
+    assert {:ok, acc, box} = ChildServer.render(pid, terminal: terminal)
+    refute "mouse" in acc.focusables
+    assert box.content =~ ~r/\e\[[0-9;]*38;2;125;163;200m⟦ ⟧ Mouse/
+
+    assert {:noreply, "other", false} = click(pid, "mouse")
+
+    assert %{focused: "other", assigns: assigns} = ChildServer.metadata(pid)
+    refute Map.has_key?(assigns, :changed_to)
+
+    assert %{"mouse" => {Checkbox, %{checked: false, disabled: true}}} =
+             ChildServer.metadata(pid).implicit_state
+  end
+
+  defp click(pid, id) do
+    bounds = :sys.get_state(pid).mouse_targets[id]
+
+    ChildServer.dispatch_input(pid, %{
+      "mouse" => %{
+        "button" => "left",
+        "action" => "press",
+        "x" => div(bounds.left + bounds.right, 2),
+        "y" => div(bounds.top + bounds.bottom, 2)
+      }
+    })
+  end
+
+  defp strip_ansi(content), do: Regex.replace(~r/\e\[[0-9;]*m/u, content, "")
+end

--- a/test/breeze_storybook/registry_test.exs
+++ b/test/breeze_storybook/registry_test.exs
@@ -5,6 +5,7 @@ defmodule Breeze.Storybook.RegistryTest do
 
   @block_story_ids %{
     button: "button",
+    checkbox: "checkbox",
     dropdown: "dropdown",
     flash_group: "flash",
     input: "input",

--- a/test/breeze_storybook/view_test.exs
+++ b/test/breeze_storybook/view_test.exs
@@ -47,13 +47,31 @@ defmodule Breeze.Storybook.RenderingTest do
     assert :sys.get_state(child).assigns.selected == "lib"
   end
 
+  test "checkbox story renders checked, unchecked, and disabled controls" do
+    terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
+
+    {:ok, pid} =
+      start_child_server(
+        view: Breeze.Storybook,
+        terminal: terminal,
+        start_opts: [directory: "storybook", file: "checkbox.story.exs"]
+      )
+
+    assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, terminal: terminal)
+    plain_content = Regex.replace(~r/\e\[[0-9;]*m/u, box.content, "")
+
+    assert plain_content =~ "[x] Mouse input"
+    assert plain_content =~ "[ ] Inspector"
+    assert plain_content =~ "⟦x⟧ Unavailable"
+  end
+
   test "dropdown story renders a single visible closed indicator" do
     terminal = %Termite.Terminal{size: %{width: 80, height: 24}}
 
     {:ok, pid} = start_child_server(view: Breeze.Storybook, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "dropdown")
 
     assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, terminal: terminal)
 
@@ -114,7 +132,7 @@ defmodule Breeze.Storybook.DetailRenderingTest do
     {:ok, pid} = start_child_server(view: Breeze.Storybook, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "dropdown")
 
     assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, terminal: terminal)
 
@@ -131,7 +149,7 @@ defmodule Breeze.Storybook.DetailRenderingTest do
     {:ok, pid} = start_child_server(view: Breeze.Storybook, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "dropdown")
 
     assert {:noreply, "storybook-preview::storybook-dropdown", true} =
              Breeze.ChildServer.set_focus(
@@ -643,6 +661,7 @@ defmodule Breeze.Storybook.InteractionLayoutTest do
   end
 
   for {name, file, focus_id, open?} <- [
+        {"focused checkbox", "checkbox.story.exs", "storybook-checkbox-mouse", false},
         {"open dropdown", "dropdown.story.exs", "storybook-dropdown", true},
         {"focused list", "list.story.exs", "storybook-list-muted", false}
       ] do
@@ -836,7 +855,7 @@ defmodule Breeze.Storybook.NavigationTest do
 
     assert {:ok, _acc, box} = Breeze.ChildServer.render(pid, terminal: terminal)
     plain_content = Regex.replace(~r/\e\[[0-9;]*m/u, box.content, "")
-    assert plain_content =~ "Preview: Dropdown"
+    assert plain_content =~ "Preview: Checkbox"
 
     assert {:noreply, "storybook-nav", true} =
              Breeze.ChildServer.dispatch_input(pid, %{"ctrlKey" => true, "key" => "ArrowUp"})
@@ -912,6 +931,12 @@ defmodule Breeze.Storybook.PreviewNavigationTest do
     send(pid, {reader, {:data, "\e[B"}})
 
     wait_until(fn ->
+      :sys.get_state(view_pid).assigns.current_story_id == "checkbox"
+    end)
+
+    send(pid, {reader, {:data, "\e[B"}})
+
+    wait_until(fn ->
       :sys.get_state(view_pid).assigns.current_story_id == "dropdown"
     end)
 
@@ -967,7 +992,7 @@ defmodule Breeze.Storybook.PreviewFocusNavigationTest do
     {:ok, pid} = start_child_server(view: Breeze.Storybook, terminal: terminal)
 
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
-    assert {:noreply, "storybook-nav", true} = Breeze.ChildServer.dispatch_input(pid, "ArrowDown")
+    select_story!(pid, "dropdown")
     assert {:ok, _acc, _box} = Breeze.ChildServer.render(pid, terminal: terminal)
 
     assert {:noreply, "storybook-preview::storybook-dropdown", true} =


### PR DESCRIPTION
The checkbox component has separate indicators depending on the state of the element.

Normal: [x] Mouse input
Focused: | | Inspector
Disabled: ⟦x⟧ Unavailable

This allows the checkbox to be used correctly even in situations where colors are limited.