### PR TITLE
feat(Breeze.Theme): ensure there is enough contrast for system theme

### DIFF
--- a/lib/breeze/input_router.ex
+++ b/lib/breeze/input_router.ex
@@ -7,8 +7,6 @@ defmodule Breeze.InputRouter do
   alias Breeze.InputCapture
   alias Breeze.Theme.Probe, as: ThemeProbe
 
-  @theme_probe_drain_timeout_ms 1_000
-
   defstruct [
     :terminal,
     :reader,
@@ -343,11 +341,14 @@ defmodule Breeze.InputRouter do
   defp start_theme_probe_drain(state, probe) do
     cancel_theme_probe_timer(probe)
 
+    # Keep consuming straggling OSC replies for one more response window. This
+    # prevents terminal replies becoming keyboard input without leaving an
+    # unsupported runtime probe pending for a full extra second.
     timer =
       Process.send_after(
         self(),
         {:theme_probe_drain_timeout, probe.key, probe.ref},
-        @theme_probe_drain_timeout_ms
+        ThemeProbe.runtime_palette_probe_timeout_ms()
       )
 
     %{state | theme_probe: %{probe | status: :draining, timer: timer}}

--- a/lib/breeze/theme.ex
+++ b/lib/breeze/theme.ex
@@ -94,6 +94,8 @@ defmodule Breeze.Theme do
     * `:solarized_light` and `:solarized_dark` as variant aliases
   """
 
+  alias Breeze.Theme.Contrast
+
   @enforce_keys [:defaults, :palette, :extras]
   defstruct name: nil,
             mode: :custom,
@@ -115,6 +117,9 @@ defmodule Breeze.Theme do
   }
   @palette_aliases %{fg: :text}
   @palette_keys ~w(muted primary secondary warning error success accent surface panel)a
+  @minimum_text_contrast 4.5
+  @minimum_muted_contrast 3.0
+  @minimum_ui_contrast 3.0
   @known_key_lookup (Map.keys(@default_aliases) ++
                        Map.values(@default_aliases) ++
                        Map.keys(@palette_aliases) ++
@@ -302,7 +307,10 @@ defmodule Breeze.Theme do
   Builds a theme from the terminal palette.
 
   Falls back to `system16/1` while retaining the system-theme request when a
-  complete palette is not yet available.
+  complete palette is not yet available. Complete RGB palettes retain their
+  probed hue and chroma while Oklab lightness is adjusted when needed: body and
+  semantic text target `4.5:1` across generated surfaces, while deliberately
+  subdued text and borders target `3:1`.
   """
   @spec system(keyword()) :: t()
   def system(opts \\ []) do
@@ -312,12 +320,14 @@ defmodule Breeze.Theme do
       )
 
     if system_palette_available?(terminal_palette) do
+      neutrals = system_neutrals(terminal_palette)
+
       %__MODULE__{
         name: Keyword.get(opts, :name, "system"),
         mode: :system,
         dark: Keyword.get(opts, :dark, infer_dark(terminal_palette)),
-        defaults: system_defaults(terminal_palette),
-        palette: system_palette(terminal_palette),
+        defaults: system_defaults(neutrals),
+        palette: system_palette(terminal_palette, neutrals),
         extras: %{},
         variables: Keyword.get(opts, :variables, %{}) |> Map.put(:palette_probe_status, :ready),
         terminal_palette: terminal_palette
@@ -344,33 +354,23 @@ defmodule Breeze.Theme do
   def new(true, opts), do: default(opts)
   def new(:system16, opts), do: system16(opts)
   def new(:system, opts), do: system(opts)
+  def new(%__MODULE__{} = theme, []), do: theme
 
-  def new(%__MODULE__{} = theme, opts) do
-    case theme.mode do
-      :system ->
-        system(
-          name: theme.name,
-          dark: theme.dark,
-          variables: theme.variables,
-          palette:
-            Keyword.get(opts, :palette, theme.terminal_palette) ||
-              terminal_palette_from_terminal(opts[:terminal])
-        )
+  def new(%__MODULE__{mode: mode} = theme, opts) when mode in [:system, :system16] do
+    refreshed_palette =
+      opts
+      |> Keyword.get(:palette)
+      |> Kernel.||(terminal_palette_from_terminal(opts[:terminal]))
+      |> normalize_terminal_palette()
 
-      :system16 ->
-        system16(
-          name: theme.name,
-          dark: theme.dark,
-          variables: theme.variables,
-          palette:
-            Keyword.get(opts, :palette, theme.terminal_palette) ||
-              terminal_palette_from_terminal(opts[:terminal])
-        )
-
-      :custom ->
-        theme
+    if is_nil(refreshed_palette) or refreshed_palette == theme.terminal_palette do
+      theme
+    else
+      refresh_system_theme(theme, refreshed_palette)
     end
   end
+
+  def new(%__MODULE__{} = theme, _opts), do: theme
 
   def new(theme, opts) when is_list(theme) do
     if Keyword.keyword?(theme), do: theme |> Map.new() |> new(opts), else: default(opts)
@@ -465,6 +465,16 @@ defmodule Breeze.Theme do
     mix(left, right, max(0.0, min(weight * 1.0, 1.0)))
   end
 
+  @doc """
+  Returns the contrast ratio between two RGB or hexadecimal colors.
+
+  The result uses the WCAG relative-luminance calculation and ranges from
+  `1.0` (identical luminance) to `21.0` (black against white). Terminal color
+  indexes cannot be measured without their RGB palette, so they return `nil`.
+  """
+  @spec contrast_ratio(color(), color()) :: float() | nil
+  defdelegate contrast_ratio(left, right), to: Contrast, as: :ratio
+
   @doc "Lightens a color by blending it toward white."
   @spec lighten(color(), float()) :: color()
   def lighten(color, amount) when is_number(amount) do
@@ -526,19 +536,16 @@ defmodule Breeze.Theme do
   defp normalize_mode("custom"), do: :custom
   defp normalize_mode(_), do: nil
 
-  defp system_defaults(terminal_palette) do
-    background =
-      terminal_palette_lookup(terminal_palette, :background) ||
-        terminal_palette_lookup(terminal_palette, 0) || {0, 0, 0}
-
-    foreground =
-      terminal_palette_lookup(terminal_palette, :foreground) ||
-        terminal_palette_lookup(terminal_palette, 7) || {255, 255, 255}
+  defp system_defaults(%{background: background, foreground: foreground} = neutrals) do
+    backgrounds = [background, neutrals.surface, neutrals.panel]
 
     %{
       foreground_color: foreground,
       background_color: background,
-      border_color: mix(foreground, background, 0.35)
+      border_color:
+        foreground
+        |> mix(background, 0.35)
+        |> Contrast.adjust(backgrounds, @minimum_ui_contrast)
     }
   end
 
@@ -578,9 +585,13 @@ defmodule Breeze.Theme do
     }
   end
 
-  defp system_palette(terminal_palette) do
-    background = system_defaults(terminal_palette).background_color
-    foreground = system_defaults(terminal_palette).foreground_color
+  defp system_palette(terminal_palette, %{
+         background: background,
+         foreground: foreground,
+         surface: surface,
+         panel: panel
+       }) do
+    backgrounds = [background, surface, panel]
 
     primary =
       terminal_palette_lookup(terminal_palette, 4) ||
@@ -607,16 +618,57 @@ defmodule Breeze.Theme do
         terminal_palette_lookup(terminal_palette, 13) || primary
 
     %{
-      muted: mix(foreground, background, 0.55),
-      primary: primary,
-      secondary: secondary,
-      warning: warning,
-      error: error,
-      success: success,
-      accent: accent,
-      surface: mix(background, foreground, 0.08),
-      panel: mix(background, foreground, 0.14)
+      muted:
+        foreground
+        |> mix(background, 0.55)
+        |> Contrast.adjust(backgrounds, @minimum_muted_contrast),
+      primary: Contrast.adjust(primary, backgrounds, @minimum_text_contrast),
+      secondary: Contrast.adjust(secondary, backgrounds, @minimum_text_contrast),
+      warning: Contrast.adjust(warning, backgrounds, @minimum_text_contrast),
+      error: Contrast.adjust(error, backgrounds, @minimum_text_contrast),
+      success: Contrast.adjust(success, backgrounds, @minimum_text_contrast),
+      accent: Contrast.adjust(accent, backgrounds, @minimum_text_contrast),
+      surface: surface,
+      panel: panel
     }
+  end
+
+  defp system_neutrals(terminal_palette) do
+    background =
+      terminal_palette_lookup(terminal_palette, :background) ||
+        terminal_palette_lookup(terminal_palette, 0) || {0, 0, 0}
+
+    foreground =
+      terminal_palette_lookup(terminal_palette, :foreground) ||
+        terminal_palette_lookup(terminal_palette, 7) || {255, 255, 255}
+
+    contrast_target = Contrast.preferred_target(background)
+
+    surface =
+      background
+      |> mix(foreground, 0.08)
+      |> Contrast.keep_contrast_side(contrast_target, background, @minimum_text_contrast)
+
+    panel =
+      background
+      |> mix(foreground, 0.14)
+      |> Contrast.keep_contrast_side(contrast_target, background, @minimum_text_contrast)
+
+    %{
+      background: background,
+      foreground:
+        Contrast.adjust(foreground, [background, surface, panel], @minimum_text_contrast),
+      surface: surface,
+      panel: panel
+    }
+  end
+
+  defp refresh_system_theme(%__MODULE__{mode: :system} = theme, palette) do
+    system(name: theme.name, dark: theme.dark, variables: theme.variables, palette: palette)
+  end
+
+  defp refresh_system_theme(%__MODULE__{mode: :system16} = theme, palette) do
+    system16(name: theme.name, dark: theme.dark, variables: theme.variables, palette: palette)
   end
 
   defp tone_mix(left, right, weight, fallback) do

--- a/lib/breeze/theme/contrast.ex
+++ b/lib/breeze/theme/contrast.ex
@@ -1,0 +1,323 @@
+defmodule Breeze.Theme.Contrast do
+  @moduledoc false
+
+  # Internal contrast measurement and color correction for terminal-derived
+  # themes. Contrast uses WCAG's sRGB relative luminance. Corrections search
+  # Oklab lightness, reducing chroma at a fixed hue when needed to stay in the
+  # sRGB gamut.
+  #
+  # References:
+  # * https://www.w3.org/TR/WCAG22/#dfn-contrast-ratio
+  # * https://www.w3.org/TR/WCAG22/#dfn-relative-luminance
+  # * https://www.w3.org/TR/css-color-4/#ok-lab
+  # * https://www.w3.org/TR/css-color-4/#color-conversion-code
+  # * https://bottosson.github.io/posts/oklab/
+
+  @type rgb :: {0..255, 0..255, 0..255}
+  @type color :: non_neg_integer() | rgb() | String.t()
+  @contrast_iterations 10
+  @gamut_search_iterations 8
+
+  # Terminal RGB channels have only 256 possible values, so calculate the
+  # WCAG sRGB linearization once at compile time rather than inside each search.
+  @linear_channels List.to_tuple(
+                     for channel <- 0..255 do
+                       encoded = channel / 255
+
+                       if encoded <= 0.04045 do
+                         encoded / 12.92
+                       else
+                         :math.pow((encoded + 0.055) / 1.055, 2.4)
+                       end
+                     end
+                   )
+
+  @doc """
+  Returns the WCAG contrast ratio between two RGB or hexadecimal colors.
+
+  Results range from `1.0` for identical luminance to `21.0` for black against
+  white. Terminal color indexes cannot be measured without an RGB palette and
+  return `nil`.
+  """
+  @spec ratio(color(), color()) :: float() | nil
+  def ratio(left, right) do
+    with {:ok, left} <- to_rgb(left),
+         {:ok, right} <- to_rgb(right) do
+      ratio_rgb(left, right)
+    else
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Adjusts a color's Oklab lightness until it meets `minimum` contrast.
+
+  The returned RGB color satisfies the requested ratio against every
+  background when either black or white can do so. Otherwise the original
+  color is returned.
+  """
+  @spec adjust(color(), [color()], number()) :: color()
+  def adjust(color, backgrounds, minimum) when is_list(backgrounds) and is_number(minimum) do
+    with {:ok, rgb} <- to_rgb(color),
+         {:ok, backgrounds} <- to_rgb_colors(backgrounds) do
+      background_luminances = Enum.map(backgrounds, &relative_luminance/1)
+      adjust_rgb(rgb, background_luminances, minimum, color)
+    else
+      _ -> color
+    end
+  end
+
+  defp adjust_rgb(rgb, background_luminances, minimum, fallback) do
+    if contrast_satisfied?(rgb, background_luminances, minimum) do
+      rgb
+    else
+      rgb
+      |> contrast_candidates(background_luminances, minimum)
+      |> Enum.min_by(&elem(&1, 0), fn -> {0, fallback} end)
+      |> elem(1)
+    end
+  end
+
+  @doc "Returns whichever of black or white has greater contrast with a color."
+  @spec preferred_target(rgb()) :: rgb()
+  def preferred_target(background) do
+    background_luminance = relative_luminance(background)
+
+    if ratio_luminances(0.0, background_luminance) >= ratio_luminances(1.0, background_luminance) do
+      {0, 0, 0}
+    else
+      {255, 255, 255}
+    end
+  end
+
+  @doc """
+  Keeps a generated surface on the contrast-safe side of a target color.
+
+  When `color` is too close to `target`, it is moved toward the known-safe
+  `anchor` by the minimum RGB blend needed to reach `minimum`.
+  """
+  @spec keep_contrast_side(rgb(), rgb(), rgb(), number()) :: rgb()
+  def keep_contrast_side(color, target, anchor, minimum) do
+    target_luminance = relative_luminance(target)
+
+    if ratio_with_luminance(color, target_luminance) >= minimum do
+      color
+    else
+      weight =
+        anchor_weight(color, target_luminance, anchor, minimum, 0.0, 1.0, @contrast_iterations)
+
+      mix(color, anchor, weight)
+    end
+  end
+
+  defp anchor_weight(_color, _target_luminance, _anchor, _minimum, _low, high, 0), do: high
+
+  defp anchor_weight(color, target_luminance, anchor, minimum, low, high, attempts) do
+    weight = (low + high) / 2
+
+    if ratio_with_luminance(mix(color, anchor, weight), target_luminance) >= minimum do
+      anchor_weight(color, target_luminance, anchor, minimum, low, weight, attempts - 1)
+    else
+      anchor_weight(color, target_luminance, anchor, minimum, weight, high, attempts - 1)
+    end
+  end
+
+  defp contrast_candidates(color, background_luminances, minimum) do
+    oklab = rgb_to_oklab(color)
+
+    [0.0, 1.0]
+    |> Enum.map(&contrast_candidate(oklab, &1, background_luminances, minimum))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp contrast_candidate(oklab, target, bg_luminances, minimum) do
+    {lightness, _a, _b} = oklab
+
+    satisfied? =
+      oklab
+      |> put_elem(0, target)
+      |> oklab_to_rgb()
+      |> contrast_satisfied?(bg_luminances, minimum)
+
+    if satisfied? do
+      weight =
+        contrast_weight(oklab, target, bg_luminances, minimum, 0.0, 1.0, @contrast_iterations)
+
+      candidate_lightness = blend_number(lightness, target, weight)
+      distance = abs(candidate_lightness - lightness)
+
+      {distance, oklab |> put_elem(0, candidate_lightness) |> oklab_to_rgb()}
+    end
+  end
+
+  defp contrast_weight(_oklab, _target, _backgrounds, _minimum, _low, high, 0), do: high
+
+  defp contrast_weight(oklab, target, background_luminances, minimum, low, high, attempts) do
+    {lightness, _a, _b} = oklab
+    weight = (low + high) / 2
+
+    candidate =
+      oklab
+      |> put_elem(0, blend_number(lightness, target, weight))
+      |> oklab_to_rgb()
+
+    if contrast_satisfied?(candidate, background_luminances, minimum) do
+      contrast_weight(oklab, target, background_luminances, minimum, low, weight, attempts - 1)
+    else
+      contrast_weight(oklab, target, background_luminances, minimum, weight, high, attempts - 1)
+    end
+  end
+
+  defp contrast_satisfied?(color, background_luminances, minimum) do
+    color_luminance = relative_luminance(color)
+    Enum.all?(background_luminances, &(ratio_luminances(color_luminance, &1) >= minimum))
+  end
+
+  defp ratio_rgb(left, right) do
+    ratio_luminances(relative_luminance(left), relative_luminance(right))
+  end
+
+  defp ratio_with_luminance(color, other_luminance) do
+    ratio_luminances(relative_luminance(color), other_luminance)
+  end
+
+  defp ratio_luminances(left, right) do
+    lighter = max(left, right)
+    darker = min(left, right)
+    (lighter + 0.05) / (darker + 0.05)
+  end
+
+  defp relative_luminance({red, green, blue}) do
+    0.2126 * linear_channel(red) +
+      0.7152 * linear_channel(green) +
+      0.0722 * linear_channel(blue)
+  end
+
+  defp linear_channel(channel), do: elem(@linear_channels, channel)
+
+  defp rgb_to_oklab({red, green, blue}) do
+    red = linear_channel(red)
+    green = linear_channel(green)
+    blue = linear_channel(blue)
+
+    light = cube_root(0.4122214708 * red + 0.5363325363 * green + 0.0514459929 * blue)
+    medium = cube_root(0.2119034982 * red + 0.6806995451 * green + 0.1073969566 * blue)
+    short = cube_root(0.0883024619 * red + 0.2817188376 * green + 0.6299787005 * blue)
+
+    {
+      0.2104542553 * light + 0.793617785 * medium - 0.0040720468 * short,
+      1.9779984951 * light - 2.428592205 * medium + 0.4505937099 * short,
+      0.0259040371 * light + 0.7827717662 * medium - 0.808675766 * short
+    }
+  end
+
+  defp oklab_to_rgb(oklab) do
+    channels = oklab_to_rgb_channels(oklab)
+
+    if rgb_channels_in_gamut?(channels) do
+      normalize_rgb_channels(channels)
+    else
+      fit_oklab_chroma(oklab, 0.0, 1.0, @gamut_search_iterations)
+    end
+  end
+
+  defp fit_oklab_chroma({lightness, a, b}, low, _high, 0) do
+    {lightness, a * low, b * low}
+    |> oklab_to_rgb_channels()
+    |> normalize_rgb_channels()
+  end
+
+  defp fit_oklab_chroma({lightness, a, b} = oklab, low, high, attempts) do
+    scale = (low + high) / 2
+    channels = oklab_to_rgb_channels({lightness, a * scale, b * scale})
+
+    if rgb_channels_in_gamut?(channels) do
+      fit_oklab_chroma(oklab, scale, high, attempts - 1)
+    else
+      fit_oklab_chroma(oklab, low, scale, attempts - 1)
+    end
+  end
+
+  defp oklab_to_rgb_channels({lightness, a, b}) do
+    light = lightness + 0.3963377774 * a + 0.2158037573 * b
+    medium = lightness - 0.1055613458 * a - 0.0638541728 * b
+    short = lightness - 0.0894841775 * a - 1.291485548 * b
+
+    light = light * light * light
+    medium = medium * medium * medium
+    short = short * short * short
+
+    {
+      encode_linear_channel(4.0767416621 * light - 3.3077115913 * medium + 0.2309699292 * short) *
+        255,
+      encode_linear_channel(-1.2684380046 * light + 2.6097574011 * medium - 0.3413193965 * short) *
+        255,
+      encode_linear_channel(-0.0041960863 * light - 0.7034186147 * medium + 1.707614701 * short) *
+        255
+    }
+  end
+
+  defp encode_linear_channel(channel) when abs(channel) <= 0.0031308,
+    do: 12.92 * channel
+
+  defp encode_linear_channel(channel) do
+    sign = if channel < 0, do: -1, else: 1
+    sign * (1.055 * :math.pow(abs(channel), 1 / 2.4) - 0.055)
+  end
+
+  defp rgb_channels_in_gamut?({red, green, blue}) do
+    Enum.all?([red, green, blue], &(&1 >= -0.001 and &1 <= 255.001))
+  end
+
+  defp normalize_rgb_channels({red, green, blue}) do
+    {normalize_rgb_channel(red), normalize_rgb_channel(green), normalize_rgb_channel(blue)}
+  end
+
+  defp normalize_rgb_channel(channel), do: channel |> max(0.0) |> min(255.0) |> round()
+
+  defp mix({left_red, left_green, left_blue}, {right_red, right_green, right_blue}, weight) do
+    {
+      blend_channel(left_red, right_red, weight),
+      blend_channel(left_green, right_green, weight),
+      blend_channel(left_blue, right_blue, weight)
+    }
+  end
+
+  defp blend_channel(left, right, weight), do: round(blend_number(left, right, weight))
+  defp blend_number(left, right, weight), do: left * (1.0 - weight) + right * weight
+  defp cube_root(value), do: :math.pow(value, 1 / 3)
+
+  defp to_rgb_colors(colors) do
+    Enum.reduce_while(colors, {:ok, []}, fn color, {:ok, acc} ->
+      case to_rgb(color) do
+        {:ok, rgb} -> {:cont, {:ok, [rgb | acc]}}
+        :error -> {:halt, :error}
+      end
+    end)
+  end
+
+  defp to_rgb({red, green, blue}) when red in 0..255 and green in 0..255 and blue in 0..255,
+    do: {:ok, {red, green, blue}}
+
+  defp to_rgb("#" <> hex), do: parse_hex(hex)
+  defp to_rgb(_color), do: :error
+
+  defp parse_hex(<<red, green, blue>>), do: parse_hex(<<red, red, green, green, blue, blue>>)
+
+  defp parse_hex(<<red::binary-size(2), green::binary-size(2), blue::binary-size(2)>>) do
+    with {:ok, red} <- parse_hex_channel(red),
+         {:ok, green} <- parse_hex_channel(green),
+         {:ok, blue} <- parse_hex_channel(blue) do
+      {:ok, {red, green, blue}}
+    end
+  end
+
+  defp parse_hex(_hex), do: :error
+
+  defp parse_hex_channel(channel) do
+    case Integer.parse(channel, 16) do
+      {value, ""} when value in 0..255 -> {:ok, value}
+      _other -> :error
+    end
+  end
+end

--- a/lib/breeze/theme/probe.ex
+++ b/lib/breeze/theme/probe.ex
@@ -6,7 +6,7 @@ defmodule Breeze.Theme.Probe do
   @palette_cache_table __MODULE__.PaletteCache
   @palette_waiters_table __MODULE__.PaletteWaiters
   @palette_probe_timeout_ms 120
-  @required_palette_indexes [1, 2, 3, 4, 5, 6, 9, 10, 11, 12, 13, 14]
+  @semantic_palette_indexes [1, 2, 3, 4, 5, 6]
 
   @spec cached_terminal_palette(%Termite.Terminal{} | nil) :: map() | nil
   def cached_terminal_palette(%Termite.Terminal{} = terminal) do
@@ -170,7 +170,7 @@ defmodule Breeze.Theme.Probe do
     foreground_background = ["\e]10;?\e\\", "\e]11;?\e\\"]
 
     indexed =
-      Enum.map(@required_palette_indexes, fn index ->
+      Enum.map(@semantic_palette_indexes, fn index ->
         ["\e]4;", Integer.to_string(index), ";?\e\\"]
       end)
 
@@ -294,7 +294,7 @@ defmodule Breeze.Theme.Probe do
 
   defp palette_probe_complete?(palette) when is_map(palette) do
     Enum.all?([:background, :foreground], &match?({_, _, _}, Map.get(palette, &1))) and
-      Enum.all?(@required_palette_indexes, &match?({_, _, _}, Map.get(palette, &1)))
+      Enum.all?(@semantic_palette_indexes, &match?({_, _, _}, Map.get(palette, &1)))
   end
 end
 

--- a/test/breeze/input_router_test.exs
+++ b/test/breeze/input_router_test.exs
@@ -57,12 +57,6 @@ defmodule Breeze.InputRouterTest do
         send(owner, {ref, {:data, "\e]4;4;rgb:3333/5555/aaaa\a"}})
         send(owner, {ref, {:data, "\e]4;5;rgb:9999/3333/aaaa\a"}})
         send(owner, {ref, {:data, "\e]4;6;rgb:3333/aaaa/aaaa\a"}})
-        send(owner, {ref, {:data, "\e]4;9;rgb:dddd/6666/4444\a"}})
-        send(owner, {ref, {:data, "\e]4;10;rgb:4444/cccc/5555\a"}})
-        send(owner, {ref, {:data, "\e]4;11;rgb:e6e6/d1d1/5a5a\a"}})
-        send(owner, {ref, {:data, "\e]4;12;rgb:5f5f/7b7b/e0e0\a"}})
-        send(owner, {ref, {:data, "\e]4;13;rgb:b3b3/6b6b/d4d4\a"}})
-        send(owner, {ref, {:data, "\e]4;14;rgb:5a5a/d6d6/d6d6\a"}})
       end
 
       {:ok, term}
@@ -91,14 +85,8 @@ defmodule Breeze.InputRouterTest do
         send(owner, {ref, {:data, "\e]4;3;rgb:cccc/bbbb/3333\a"}})
         send(owner, {ref, {:data, "\e]4;4;rgb:3333/5555/aaaa\a"}})
         send(owner, {ref, {:data, "\e]4;5;rgb:9999/3333/aaaa\a"}})
-        send(owner, {ref, {:data, "\e]4;6;rgb:3333/aaaa/aaaa\a"}})
-        send(owner, {ref, {:data, "\e]4;9;rgb:dddd/6666/4444\a"}})
-        send(owner, {ref, {:data, "\e]4;10;rgb:4444/cccc/5555\a"}})
-        send(owner, {ref, {:data, "\e]4;11;rgb:e6e6/d1d1/5a5a\a"}})
-        send(owner, {ref, {:data, "\e]4;12;rgb:5f5f/7b7b/e0e0\a"}})
-        send(owner, {ref, {:data, "\e]4;13;rgb:b3b3/6b6b/d4d4\a"}})
         send(owner, {ref, {:data, "\e]"}})
-        send(owner, {ref, {:data, "4;14;rgb:5a5a/d6d6/d6d6\a"}})
+        send(owner, {ref, {:data, "4;6;rgb:3333/aaaa/aaaa\a"}})
       end
 
       {:ok, term}
@@ -109,13 +97,7 @@ defmodule Breeze.InputRouterTest do
     @behaviour Termite.Terminal.Adapter
 
     @late_palette_reply "\e]4;5;rgb:9999/3333/aaaa\a" <>
-                          "\e]4;6;rgb:3333/aaaa/aaaa\a" <>
-                          "\e]4;9;rgb:dddd/6666/4444\a" <>
-                          "\e]4;10;rgb:4444/cccc/5555\a" <>
-                          "\e]4;11;rgb:e6e6/d1d1/5a5a\a" <>
-                          "\e]4;12;rgb:5f5f/7b7b/e0e0\a" <>
-                          "\e]4;13;rgb:b3b3/6b6b/d4d4\a" <>
-                          "\e]4;14;rgb:5a5a/d6d6/d6d6\a"
+                          "\e]4;6;rgb:3333/aaaa/aaaa\a"
 
     def start(opts) do
       {:ok,

--- a/test/breeze/style_test.exs
+++ b/test/breeze/style_test.exs
@@ -1037,9 +1037,9 @@ defmodule Breeze.StyleTest do
       )
       |> Style.to_element(theme: theme, focus: true)
 
-    assert unfocused.style.foreground_color == {106, 128, 131}
-    assert focused.style.foreground_color == {147, 161, 161}
-    assert unfocused.style.background_color == {44, 78, 86}
-    assert focused.style.background_color == {63, 94, 100}
+    assert unfocused.style.foreground_color == {107, 129, 132}
+    assert focused.style.foreground_color == {148, 162, 162}
+    assert unfocused.style.background_color == {44, 79, 86}
+    assert focused.style.background_color == {64, 94, 100}
   end
 end

--- a/test/breeze/theme_contrast_test.exs
+++ b/test/breeze/theme_contrast_test.exs
@@ -1,0 +1,34 @@
+defmodule Breeze.Theme.ContrastTest do
+  use ExUnit.Case, async: true
+
+  alias Breeze.Theme.Contrast
+
+  test "calculates WCAG contrast for RGB and hexadecimal colors" do
+    assert_in_delta Contrast.ratio("#000000", "#ffffff"), 21.0, 0.001
+    assert_in_delta Contrast.ratio({119, 119, 119}, {255, 255, 255}), 4.478, 0.001
+    assert Contrast.ratio(0, 7) == nil
+    assert Contrast.ratio("#invalid", "#ffffff") == nil
+  end
+
+  test "adjusts lightness in either direction while retaining color character" do
+    cases = [
+      {{220, 50, 47}, [{0, 43, 54}, {18, 58, 67}]},
+      {{221, 221, 221}, [{240, 240, 240}, {225, 225, 225}]}
+    ]
+
+    for {source, backgrounds} <- cases do
+      adjusted = Contrast.adjust(source, backgrounds, 4.5)
+
+      for background <- backgrounds do
+        assert Contrast.ratio(adjusted, background) >= 4.5
+      end
+
+      assert color_spread(adjusted) >= color_spread(source) * 0.85
+    end
+  end
+
+  defp color_spread(color) do
+    channels = Tuple.to_list(color)
+    Enum.max(channels) - Enum.min(channels)
+  end
+end

--- a/test/breeze/theme_test.exs
+++ b/test/breeze/theme_test.exs
@@ -8,6 +8,9 @@ defmodule Breeze.ThemeTest do
   alias Breeze.Theme.Probe, as: ThemeProbe
   alias Breeze.Theme.Probe.TableOwner
 
+  @text_colors [:text, :primary, :secondary, :warning, :error, :success, :accent]
+  @surfaces [:background, :surface, :panel]
+
   defmodule PaletteAdapter do
     @behaviour Termite.Terminal.Adapter
 
@@ -27,12 +30,6 @@ defmodule Breeze.ThemeTest do
       send(owner, {ref, {:data, "\e]4;4;rgb:f5f5/c2c2/e7e7\a"}})
       send(owner, {ref, {:data, "\e]4;5;rgb:fafa/b3b3/8787\a"}})
       send(owner, {ref, {:data, "\e]4;6;rgb:cba6/f7f7/f7f7\a"}})
-      send(owner, {ref, {:data, "\e]4;9;rgb:f28f/adad/adad\a"}})
-      send(owner, {ref, {:data, "\e]4;10;rgb:abe9/b3b3/b3b3\a"}})
-      send(owner, {ref, {:data, "\e]4;11;rgb:fae3/b0b0/b0b0\a"}})
-      send(owner, {ref, {:data, "\e]4;12;rgb:f5f5/c2c2/e7e7\a"}})
-      send(owner, {ref, {:data, "\e]4;13;rgb:fafa/b3b3/8787\a"}})
-      send(owner, {ref, {:data, "\e]4;14;rgb:cba6/f7f7/f7f7\a"}})
       {:ok, term}
     end
   end
@@ -93,6 +90,12 @@ defmodule Breeze.ThemeTest do
            ]
   end
 
+  test "calculates WCAG contrast ratios for RGB and hexadecimal colors" do
+    assert_in_delta Theme.contrast_ratio("#000000", "#ffffff"), 21.0, 0.001
+    assert_in_delta Theme.contrast_ratio({119, 119, 119}, {255, 255, 255}), 4.478, 0.001
+    assert Theme.contrast_ratio(0, 7) == nil
+  end
+
   test "next_theme advances through a theme cycle" do
     assert {:commander, %Theme{name: "commander-blue"}} = Theme.next_theme(:dracula)
     assert {:nord, %Theme{name: "nord"}} = Theme.next_theme(:gruvbox)
@@ -119,12 +122,21 @@ defmodule Breeze.ThemeTest do
       )
 
     assert Theme.color(theme, :background) == {16, 17, 18}
-    assert Theme.color(theme, :primary) == {51, 85, 170}
+    assert Theme.color(theme, :primary) == {109, 149, 239}
     assert Theme.color(theme, :surface) == {34, 35, 36}
     assert Theme.color(theme, :panel) == {47, 48, 49}
   end
 
   test "system prefers base ANSI hues over bright grayscale slots for solarized-like palettes" do
+    semantic_colors = %{
+      primary: {38, 139, 210},
+      secondary: {42, 161, 152},
+      warning: {181, 137, 0},
+      error: {220, 50, 47},
+      success: {133, 153, 0},
+      accent: {211, 54, 130}
+    }
+
     theme =
       Theme.system(
         palette: %{
@@ -145,12 +157,83 @@ defmodule Breeze.ThemeTest do
         }
       )
 
-    assert Theme.color(theme, :primary) == {38, 139, 210}
-    assert Theme.color(theme, :secondary) == {42, 161, 152}
-    assert Theme.color(theme, :warning) == {181, 137, 0}
-    assert Theme.color(theme, :error) == {220, 50, 47}
-    assert Theme.color(theme, :success) == {133, 153, 0}
-    assert Theme.color(theme, :accent) == {211, 54, 130}
+    assert elem(Theme.color(theme, :primary), 2) > elem(Theme.color(theme, :primary), 0)
+    assert elem(Theme.color(theme, :secondary), 1) > elem(Theme.color(theme, :secondary), 0)
+    assert elem(Theme.color(theme, :warning), 0) > elem(Theme.color(theme, :warning), 2)
+    assert elem(Theme.color(theme, :error), 0) > elem(Theme.color(theme, :error), 1)
+    assert elem(Theme.color(theme, :success), 1) > elem(Theme.color(theme, :success), 2)
+    assert elem(Theme.color(theme, :accent), 0) > elem(Theme.color(theme, :accent), 1)
+
+    refute Theme.color(theme, :primary) == {131, 148, 150}
+    refute Theme.color(theme, :secondary) == {147, 161, 161}
+
+    for {role, source} <- semantic_colors do
+      corrected = Theme.color(theme, role)
+
+      assert color_spread(corrected) >= color_spread(source) * 0.85,
+             "system #{role} lost too much of the probed color's saturation"
+
+      for background <- @surfaces do
+        assert Theme.contrast_ratio(corrected, Theme.color(theme, background)) >= 4.5
+      end
+    end
+  end
+
+  test "system corrects low-contrast probed palettes for semantic use" do
+    palettes = [
+      %{background: "#202020", foreground: "#454545", ansi: "#303030"},
+      %{background: "#f0f0f0", foreground: "#cccccc", ansi: "#dddddd"},
+      %{background: "#3479e1", foreground: "#91303d", ansi: "#6778a0"}
+    ]
+
+    for palette <- palettes do
+      terminal_palette =
+        1..14
+        |> Map.new(&{&1, palette.ansi})
+        |> Map.merge(%{background: palette.background, foreground: palette.foreground})
+
+      theme = Theme.system(palette: terminal_palette)
+
+      for foreground <- @text_colors, background <- @surfaces do
+        assert Theme.contrast_ratio(
+                 Theme.color(theme, foreground),
+                 Theme.color(theme, background)
+               ) >= 4.5,
+               "system #{foreground}/#{background} failed for #{inspect(palette)}"
+      end
+
+      for background <- @surfaces do
+        assert Theme.contrast_ratio(
+                 Theme.color(theme, :muted),
+                 Theme.color(theme, background)
+               ) >= 3.0
+      end
+
+      for background <- @surfaces do
+        assert Theme.contrast_ratio(
+                 Theme.color(theme, :border),
+                 Theme.color(theme, background)
+               ) >= 3.0
+      end
+    end
+  end
+
+  test "materialized system themes are reused until the terminal palette changes" do
+    palette = %{
+      1 => "#aa2233",
+      2 => "#22aa33",
+      3 => "#ccbb33",
+      4 => "#3355aa",
+      5 => "#9933aa",
+      6 => "#33aaaa",
+      background: "#101112",
+      foreground: "#f0f0f0"
+    }
+
+    theme = Theme.system(palette: palette)
+
+    refreshed = Theme.new(theme, palette: Map.put(palette, 4, "#4477dd"))
+    refute Theme.color(theme, :primary) == Theme.color(refreshed, :primary)
   end
 
   test "system falls back to system16 when no runtime palette is available" do
@@ -173,7 +256,8 @@ defmodule Breeze.ThemeTest do
     assert {:start, {:reader, ^ref}, query} = ThemeProbe.start_runtime_palette_probe(terminal)
     refute query =~ "\a"
     assert query =~ "\e]10;?\e\\"
-    assert query =~ "\e]4;14;?\e\\"
+    assert query =~ "\e]4;6;?\e\\"
+    refute query =~ "\e]4;9;?\e\\"
   end
 
   test "runtime palette tables have a stable owner" do
@@ -285,7 +369,7 @@ defmodule Breeze.ThemeTest do
     end
   end
 
-  test "system keeps derived RGB neutral tones where system16 falls back on solarized-like palettes" do
+  test "system keeps accessible RGB neutral tones where system16 uses ANSI fallbacks" do
     palette = %{
       1 => "#dc322f",
       2 => "#859900",
@@ -311,7 +395,16 @@ defmodule Breeze.ThemeTest do
     assert Theme.color(system16, :surface) == 8
     assert Theme.color(system, :panel) == {18, 58, 67}
     assert Theme.color(system, :surface) == {10, 51, 62}
-    assert Theme.color(system16, :muted) == Theme.color(system, :muted)
+    refute Theme.color(system16, :muted) == Theme.color(system, :muted)
+
+    muted_contrast =
+      Theme.contrast_ratio(Theme.color(system, :muted), Theme.color(system, :panel))
+
+    text_contrast =
+      Theme.contrast_ratio(Theme.color(system, :text), Theme.color(system, :panel))
+
+    assert muted_contrast >= 3.0
+    assert muted_contrast < text_contrast
   end
 
   test "custom themes preserve explicit colors" do
@@ -444,5 +537,10 @@ defmodule Breeze.ThemeTest do
     assert Breeze.ChildServer.metadata(pid).theme.mode == :system16
     assert {:noreply, _focused, true} = Breeze.ChildServer.dispatch_input(pid, "t")
     assert Breeze.ChildServer.metadata(pid).theme.mode == :custom
+  end
+
+  defp color_spread(color) do
+    channels = Tuple.to_list(color)
+    Enum.max(channels) - Enum.min(channels)
   end
 end


### PR DESCRIPTION
The colors returned by the system theme probe are now adjusted so that the specific colors have enough contract between them. This prevents having (for example) the muted color be too close to the background color.

The implementation is fairly technical, so it exists in its own module.

We also have fewer system probe queries, as we only use 8 of the 14 values (bright variants are ignored).