### PR TITLE
fix: Stabilize clipboard timeout tests

### DIFF
--- a/test/breeze/error_view/clipboard_test.exs
+++ b/test/breeze/error_view/clipboard_test.exs
@@ -6,6 +6,7 @@ defmodule Breeze.ErrorView.ClipboardTest do
   test "returns timeout when clipboard command does not finish" do
     assert {:error, :timeout} =
              Clipboard.copy("details",
+               os_type: {:unix, :linux},
                timeout: 10,
                run_fun: fn _name, _path, _text ->
                  Process.sleep(1_000)

--- a/test/breeze/live_view_crash_test.exs
+++ b/test/breeze/live_view_crash_test.exs
@@ -519,6 +519,7 @@ defmodule Breeze.LiveView.CrashTest do
           terminal: terminal,
           internal: [
             clipboard: [
+              os_type: {:unix, :linux},
               timeout: 10,
               find_executable: fn "wl-copy" -> "/usr/bin/wl-copy" end,
               run_fun: fn _name, _path, _text ->
@@ -542,19 +543,13 @@ defmodule Breeze.LiveView.CrashTest do
       drain_terminal_writes()
       send(pid, {reader, {:data, "y"}})
 
-      writes =
-        wait_until(fn ->
-          writes = drain_terminal_writes()
-          output = IO.iodata_to_binary(writes)
+      wait_until(fn -> :sys.get_state(pid).crash_scrollback? end)
 
-          if output =~ "Crash Details" and output =~ "Clipboard copy failed: :timeout" and
-               output =~ "Press q to quit, r to resume, R to hard restart." do
-            output
-          else
-            false
-          end
-        end)
+      writes = IO.iodata_to_binary(drain_terminal_writes())
 
+      assert writes =~ "Crash Details"
+      assert writes =~ "Clipboard copy failed: :timeout"
+      assert writes =~ "Press q to quit, r to resume, R to hard restart."
       assert writes =~ "\e[?1049l"
       assert writes =~ "Breeze Error"
       assert writes =~ "CrashingView"


### PR DESCRIPTION
Both clipboard timeout tests mock `wl-copy` but use the host OS to pick the command. On macOS that picks `pbcopy`, which crashes the mock. The 10 ms timeout races with the crash, so the tests can pass or fail depending on scheduling. Set the OS to Linux in both tests to match the mock.

The scrollback test also drained terminal writes on every polling attempt and threw them away if the expected text hadn't arrived yet. That could lose the escape sequence sent before the crash details. Wait for `crash_scrollback?`, which is set after all writes, then collect the output once. The same three text checks are still there as assertions.

Reproduced both reported failures before the fix. All 787 tests pass with seeds `223480`, `830777`, and `462225` after it. Formatting checks pass too.
